### PR TITLE
Add a conic patch draw mode selector in the Node Editor

### DIFF
--- a/MechJeb2/MechJebModuleNodeEditor.cs
+++ b/MechJeb2/MechJebModuleNodeEditor.cs
@@ -40,6 +40,7 @@ namespace MuMech
             if (vessel.patchedConicSolver.maneuverNodes.Count == 0)
             {
                 GUILayout.Label("No maneuver nodes to edit.");
+                conicModeSelectUI();
                 GUI.DragWindow();
                 return;
             }
@@ -165,9 +166,28 @@ namespace MuMech
 
             GUILayout.EndHorizontal();
 
+            conicModeSelectUI();
+
             GUILayout.EndVertical();
 
             GUI.DragWindow();
+        }
+
+        private void conicModeSelectUI()
+        {
+            string[] conicModes = new string[] { "0", "1", "2", "3", "4" };
+            
+            GUILayout.BeginHorizontal();
+
+            GUILayout.Label("Conics Mode:", GUILayout.ExpandWidth(false));
+            int conicMode = GUILayout.SelectionGrid((int)FlightGlobals.ActiveVessel.patchedConicRenderer.relativityMode, conicModes, 5);
+            PatchRendering.RelativityMode cmode = (PatchRendering.RelativityMode)Enum.ToObject(typeof(PatchRendering.RelativityMode), conicMode);
+            if (cmode != FlightGlobals.ActiveVessel.patchedConicRenderer.relativityMode)
+            {
+                FlightGlobals.ActiveVessel.patchedConicRenderer.relativityMode = cmode;
+            }
+
+            GUILayout.EndHorizontal();
         }
 
         public override GUILayoutOption[] WindowOptions()


### PR DESCRIPTION
I often wish to switch between conic draw mode 0 and 3 on the fly.
This patch add buttons to select the conic patch draw mode on the fly in the node editor window. All mode are avaible for those who likes the others.
