### PR TITLE
Changed "Node burn time" to display one decimal place

### DIFF
--- a/MechJeb2/MechJebModuleInfoItems.cs
+++ b/MechJeb2/MechJebModuleInfoItems.cs
@@ -30,7 +30,7 @@ namespace MuMech
 
             ManeuverNode node = vessel.patchedConicSolver.maneuverNodes.First();
             double burnTime = node.GetBurnVector(node.patch).magnitude / vesselState.limitedMaxThrustAccel;
-            return GuiUtils.TimeToDHMS(burnTime);
+            return GuiUtils.TimeToDHMS(burnTime, 1);
         }
 
         [ValueInfoItem("Time to node", InfoItem.Category.Misc)]


### PR DESCRIPTION
When entering burn times into RemoteTech, I sometimes need more precision for the node burn time so I changed it to display one decimal place.
