### PR TITLE
Fix for Circularize function

### DIFF
--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -333,7 +333,7 @@ namespace MuMech
                     break;
 
                 case TimeReference.ALTITUDE:
-                    if (circularizeAltitude > o.PeA && circularizeAltitude < o.ApA)
+                    if (circularizeAltitude > o.PeA && (circularizeAltitude < o.ApA || o.eccentricity >= 1))
                     {
                         UT = o.NextTimeOfRadius(UT, o.referenceBody.Radius + circularizeAltitude);
                     }


### PR DESCRIPTION
Fix for Circularize function, if you want to change your hyperbolic orbit to circular orbit at some altitude.

In old version it says you can't circularize, because of this statement: "circularizeAltitude < o.ApA". o.ApA is negative.
I have just added the same test as in NextTimeOfRadius() function. It should never throw ArgumentException.
