### PR TITLE
Fixed a bug causing unexpected behavior with Kill HS in the Translatron module.

### DIFF
--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -480,13 +480,14 @@ namespace MuMech
         {
             if (tmode_changed)
             {
-                if (trans_kill_h && (tmode == TMode.OFF))
-                {
-                    core.attitude.attitudeDeactivate();
-                }
                 pid.Reset();
                 tmode_changed = false;
                 FlightInputHandler.SetNeutralControls();
+            }
+
+			if (!trans_kill_h && (tmode == TMode.OFF || tmode == TMode.KEEP_VERTICAL))
+            {
+            	core.attitude.attitudeDeactivate();
             }
         }
     }


### PR DESCRIPTION
The bug made it so that once turned checked on, attitude control could not be turned off without switching to
TMode.OFF _with_ Kill HS still checked off. 

This has been fixed, but the fix is a bit hack-ey because I was concerned that fixing it more generically would disrupt attitude control of other TModes, if some besides OFF and KEEP_VERTICAL have attitude requirements. If someone knows this was unnecessary, or can think of a better solution, feel free to build on this.
