### PR TITLE
fixed the problem where the stage calculation assumed all engines of the...

### DIFF
--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -192,7 +192,8 @@ namespace MuMech
         public List<FuelNode> FindActiveEngines()
         {
             //Debug.Log("Finding active engines: excluding resource considerations, there are " + nodes.Where(n => n.isEngine && n.inverseStage >= simStage).Count());
-            return nodes.Where(n => n.isEngine && n.inverseStage >= simStage && n.CanDrawNeededResources(nodes)).ToList();
+            return nodes.Where(n => n.isEngine && n.inverseStage >= simStage && n.CanDrawNeededResources(nodes) &&
+                               (n.inverseStage == (HighLogic.LoadedSceneIsFlight ? FlightGlobals.ActiveVessel.currentStage : -1) ? n.isActive : true)).ToList();
         }
 
         //A Stats struct describes the result of the simulation over a certain interval of time (e.g., one stage)
@@ -260,6 +261,7 @@ namespace MuMech
         public int inverseStage;        //stage in which this part is activated
         public bool isSepratron;        //whether this part is a sepratron
         public bool isEngine = false;   //whether this part is an engine
+        public bool isActive = false;
 
         bool isFuelLine; //whether this part is a fuel line
 
@@ -301,6 +303,7 @@ namespace MuMech
                     if (engine.getIgnitionState && inverseStage < Staging.CurrentStage) inverseStage = Staging.CurrentStage;
 
                     isEngine = true;
+                    isActive = !engine.engineShutdown;
 
                     maxThrust = engine.maxThrust;
                     ispCurve = engine.atmosphereCurve;


### PR DESCRIPTION
... current stage to be on

while some where off until staged once to update it
this will fix the problem where the nodeexecutor burned too late because it expected more thrust based on this misinformation
