### PR TITLE
Improved parachute targeting; tidied and added more info to the landing screen.

### DIFF
--- a/MechJeb2/MechJebModuleLandingGuidance.cs
+++ b/MechJeb2/MechJebModuleLandingGuidance.cs
@@ -34,7 +34,7 @@ namespace MuMech
                 core.target.targetLongitude.DrawEditGUI(EditableAngle.Direction.EW);
 
                 // Display the ASL of the taget location
-                GUILayout.Label("\nASL:" + MuUtils.ToSI(core.vessel.mainBody.TerrainAltitude(core.target.targetLatitude, core.target.targetLongitude), -1, 4) + "m");
+                GUILayout.Label("Target ASL: " + MuUtils.ToSI(core.vessel.mainBody.TerrainAltitude(core.target.targetLatitude, core.target.targetLongitude), -1, 4) + "m");
             }
             else
             {
@@ -48,18 +48,19 @@ namespace MuMech
 
             if (mainBody.bodyName.ToLower().Contains("kerbin"))
             {
-                if (GUILayout.Button("Target KSC"))
+                GUILayout.BeginHorizontal();
+                if (GUILayout.Button("KSC Pad"))
                 {
                     core.target.SetPositionTarget(mainBody, -0.09694444, -74.5575);
                 }
-                if (GUILayout.Button("Target VAB"))
+                if (GUILayout.Button("VAB"))
                 {
                     core.target.SetPositionTarget(mainBody, -0.09694444, -74.617);
                 }
+                GUILayout.EndHorizontal();
             }
 
-            if (autopilot != null) core.node.autowarp = GUILayout.Toggle(core.node.autowarp, "Auto-warp");
-
+            
             bool active = GUILayout.Toggle(predictor.enabled, "Show landing predictions");
             if (predictor.enabled != active)
             {
@@ -99,6 +100,8 @@ namespace MuMech
 
                 GuiUtils.SimpleTextBox("Touchdown speed:", autopilot.touchdownSpeed, "m/s", 35);
 
+                if (autopilot != null) core.node.autowarp = GUILayout.Toggle(core.node.autowarp, "Auto-warp");
+
                 autopilot.deployGears = GUILayout.Toggle(autopilot.deployGears, "Deploy Landing Gear");
                 GuiUtils.SimpleTextBox("Stage Limit:", autopilot.limitGearsStage, "", 35);
                 autopilot.deployChutes = GUILayout.Toggle(autopilot.deployChutes, "Deploy Parachutes");
@@ -131,13 +134,14 @@ namespace MuMech
                 switch (result.outcome)
                 {
                     case ReentrySimulation.Outcome.LANDED:
-                        GUILayout.Label("Predicted landing site:");
+                        GUILayout.Label("Landing Predictions:");
                         GUILayout.Label(Coordinates.ToStringDMS(result.endPosition.latitude, result.endPosition.longitude) + "\nASL:" + MuUtils.ToSI(result.endASL,-1, 4) + "m");
                         double error = Vector3d.Distance(mainBody.GetRelSurfacePosition(result.endPosition.latitude, result.endPosition.longitude, 0),
                                                          mainBody.GetRelSurfacePosition(core.target.targetLatitude, core.target.targetLongitude, 0));
-                        GUILayout.Label("Target difference = " + MuUtils.ToSI(error, 0) + "m");
-                        GUILayout.Label("Predicted max drag: " + result.maxDragGees.ToString("F1") +"g");
-                        GUILayout.Label("Predicted dv needed: " + result.deltaVExpended.ToString("F1") + "m/s");
+                        GUILayout.Label("Target difference = " + MuUtils.ToSI(error, 0) + "m"
+                                       +"\nMax drag: " + result.maxDragGees.ToString("F1") +"g"
+                                       +"\nDelta-v needed: " + result.deltaVExpended.ToString("F1") + "m/s"
+                                       +"\nTime to land: " + GuiUtils.TimeToDHMS(result.endUT - Planetarium.GetUniversalTime(), 1));                        
                         break;
 
                     case ReentrySimulation.Outcome.AEROBRAKED:
@@ -145,11 +149,13 @@ namespace MuMech
                         Orbit o = result.EndOrbit();
                         if (o.eccentricity > 1) GUILayout.Label("Hyperbolic, eccentricity = " + o.eccentricity.ToString("F2"));
                         else GUILayout.Label(MuUtils.ToSI(o.PeA, 3) + "m x " + MuUtils.ToSI(o.ApA, 3) + "m");
+                        GUILayout.Label("Max drag: " + result.maxDragGees.ToString("F1") + "g"
+                                       +"\nExit atmosphere in: " + GuiUtils.TimeToDHMS(result.endUT - Planetarium.GetUniversalTime(), 1));                        
                         break;
 
                     case ReentrySimulation.Outcome.NO_REENTRY:
-                        GUILayout.Label("Orbit does not reenter:");
-                        GUILayout.Label(MuUtils.ToSI(orbit.PeA, 3) + "m Pe > " + MuUtils.ToSI(mainBody.RealMaxAtmosphereAltitude(), 3) + "m atmosphere height");
+                        GUILayout.Label("Orbit does not reenter:\n"
+                                      + MuUtils.ToSI(orbit.PeA, 3) + "m Pe > " + MuUtils.ToSI(mainBody.RealMaxAtmosphereAltitude(), 3) + "m atmosphere height");
                         break;
 
                     case ReentrySimulation.Outcome.TIMED_OUT:

--- a/MechJeb2/MechJebModuleLandingPredictions.cs
+++ b/MechJeb2/MechJebModuleLandingPredictions.cs
@@ -210,7 +210,7 @@ namespace MuMech
             if (addParachuteError)
             {
                 System.Random random = new System.Random();
-                parachuteMultiplierForThisSimulation *= ((double)1 + ((double)(random.Next(500000) - 250000) / (double)10000000));
+                parachuteMultiplierForThisSimulation *= ((double)1 + ((double)(random.Next(1000000) - 500000) / (double)10000000));
             }
 
             ReentrySimulation sim = new ReentrySimulation(patch, patch.StartUT, dragMassExcludingUsedParachutes, usableChutes, totalMass, descentSpeedPolicy, decelEndAltitudeASL, vesselState.limitedMaxThrustAccel, parachuteMultiplierForThisSimulation, altitudeOfPreviousPrediction, addParachuteError, dt); 


### PR DESCRIPTION
- Added time to land / exit atmosphere to the Landing screen
- Added parachute targeting information (quality and amount of data being used)
- Tidied up Landing screen
- Increase the amount of error added to error simulations to improve parachute targeting
- Increased the number of predictions used for parachute targeting to 40
- Changed landing gear to always lower at 1000m AGL regardless of the landing step
- Removed redundant code
- Changed to parachute targeting to discard non-correlating data, but always continue trying to build a good dataset
