### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ package: build
 	mkdir -p package/MechJeb2/Plugins
 	cp -r Parts package/MechJeb2/
 	cp build/MechJeb2.dll package/MechJeb2/Plugins/
+	cp LICENCE.md README.md package/MechJeb2/
 
 tar.gz: package
 	${TAR} zcf MechJeb2-$(shell ${GIT} describe --tags --long --always).tar.gz package/MechJeb2


### PR DESCRIPTION
Allows users to run 'make' in the git repo and build the files. There
are currently 6 targets:

all: a catch all target that just runs build

build: Creates the .dll and Resources file

package: Requires build, creates a directory structure for use in
         GameData

tar.gz: Creates a tar.gz file from the 'package' contents

zip: Creates a zip file from the 'package' contents

clean: Removes the build and package directories

For a typical workflow, you would make changes and then run 'make
package' or 'make build' to check if everything compiles and is in the
right place.

I'll probably add more checks for the zip and tar.gz targets, and
possibly a git-clean target that uses `git clean` to remove untracked
files. Right now it works in Linux, but the KSPDIR is customizable as
are most of the moving executables (git, tar, zip, resgen2, gmcs). To
run this with gmcs at /usr/local/bin/gmcs, you would simply run

  make GMCS=/usr/loca/bin/gmcs package
