### PR TITLE
VessleState: Use constants for g0

### DIFF
--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -4,6 +4,11 @@ using System.Linq;
 using System.Text;
 using UnityEngine;
 
+static class Constants
+{
+      public const double g0 = 9.82;
+}
+
 namespace MuMech
 {
     //Copied verbatim from old VesselState. Should this class be reorganized at all?
@@ -596,7 +601,7 @@ namespace MuMech
                 float Isp0 = e.atmosphereCurve.Evaluate(atmP0);
                 float Isp1 = e.atmosphereCurve.Evaluate(atmP1);
                 double Isp = Math.Min(Isp0, Isp1);
-                double udot = e.maxThrust / (Isp * 9.82 * e.mixtureDensity); // Tavert Issue #163
+                double udot = e.maxThrust / (Isp * Constants.g0 * e.mixtureDensity); // Tavert Issue #163
                 foreach (var propellant in e.propellants)
                 {
                     double maxreq = udot * propellant.ratio;
@@ -657,7 +662,7 @@ namespace MuMech
                 float Isp0 = e.atmosphereCurve.Evaluate(atmP0);
                 float Isp1 = e.atmosphereCurve.Evaluate(atmP1);
                 double Isp = Math.Min(Isp0, Isp1);
-                double udot = e.maxThrust / (Isp * 9.82 * e.mixtureDensity); // Tavert Issue #163
+                double udot = e.maxThrust / (Isp * Constants.g0 * e.mixtureDensity); // Tavert Issue #163
                 foreach (var propellant in e.propellants)
                 {
                     double maxreq = udot * propellant.ratio;


### PR DESCRIPTION
Currently it seems that g0 (or g_0, standard gravity) is 9.82 in Kerbal
physics. Due to the fickle nature of things in the Kerbal world, it
makes some sense to define constants like this only once, so they can be
changed more easily in the future.
