### PR TITLE
Rover AP changes

### DIFF
--- a/MechJeb2/MechJebModuleRoverWindow.cs
+++ b/MechJeb2/MechJebModuleRoverWindow.cs
@@ -122,7 +122,10 @@ namespace MuMech
 			ed.registry.Find(i => i.id == "Editable:RoverController.speed").DrawItem();
 			ed.registry.Find(i => i.id == "Value:RoverController.speedErr").DrawItem();
             ed.registry.Find(i => i.id == "Toggle:RoverController.stabilityControl").DrawItem();
-            ed.registry.Find(i => i.id == "Toggle:RoverController.BrakeOnEject").DrawItem();
+            if (!core.GetComputerModule<MechJebModuleSettings>().hideBrakeOnEject) {
+            	ed.registry.Find(i => i.id == "Toggle:RoverController.BrakeOnEject").DrawItem();
+            }
+            ed.registry.Find(i => i.id == "Toggle:RoverController.BrakeOnEnergyDepletion").DrawItem();
 
 			GUILayout.BeginVertical();
 			

--- a/MechJeb2/MechJebModuleSettings.cs
+++ b/MechJeb2/MechJebModuleSettings.cs
@@ -16,6 +16,9 @@ namespace MuMech
 
         [Persistent(pass = (int)Pass.Global)]
         public int skinId = 0;
+        
+        [ToggleInfoItem("Hide 'Brake on Eject' in Rover Controller", InfoItem.Category.Misc), Persistent(pass = (int)Pass.Global)]
+        public bool hideBrakeOnEject = false;
 
         public override void OnLoad(ConfigNode local, ConfigNode type, ConfigNode global)
         {
@@ -64,6 +67,9 @@ namespace MuMech
                     skinId = 2;
                 }
             }
+            
+			MechJebModuleCustomWindowEditor ed = core.GetComputerModule<MechJebModuleCustomWindowEditor>();
+			ed.registry.Find(i => i.id == "Toggle:Settings.hideBrakeOnEject").DrawItem();
 
             GUILayout.EndVertical();
 


### PR DESCRIPTION
overhauled handling of the brakes because too many spots in the Drive logic were messing with it

added "Brake on Energy Depletion" option to make solar powered rovers stop if they run out of energy at night
also folds up the solars if they're open inside an atmosphere so it can continue without breaking them

added a setting to hide "Brake on Pilot Eject" because it was annoying me and I wanted it gone but not force that onto others, so a setting for it, yay?
