### PR TITLE
Minor rover waypoint fix

### DIFF
--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -1223,6 +1223,7 @@ namespace MuMech
 					case "Bop" : addHeight = window.BopMapdist; break;
 					case "Pol" : addHeight = window.PolMapdist; break;
 					case "Eeloo" : addHeight = window.EelooMapdist; break;
+					default: addHeight = window.KerbinMapdist; break;
 			}
 			
 			if (ap != null && ap.Waypoints.Count > 0 && ap.vessel.isActiveVessel && HighLogic.LoadedSceneIsFlight)


### PR DESCRIPTION
Adds a default value to the switch statement that determines how high above the map view to draw rover waypoints based on the name of the planet, in case the ro
ver is on a non-canonical planet.
