### PR TITLE
New interplanetary transfer with porkchop plots

### DIFF
--- a/MechJeb2/DisplayModule.cs
+++ b/MechJeb2/DisplayModule.cs
@@ -74,14 +74,20 @@ namespace MuMech
             return new GUILayoutOption[0];
         }
 
-        protected virtual void WindowGUI(int windowID)
+        protected void WindowGUI(int windowID, bool draggable)
         {
             if (GUI.Button(new Rect(windowPos.width - 18, 2, 16, 16), ""))
             {
                 enabled = false;
             }
 
-            GUI.DragWindow();
+            if (draggable)
+                GUI.DragWindow();
+        }
+
+        protected virtual void WindowGUI(int windowID)
+        {
+            WindowGUI(windowID, true);
         }
 
         public virtual void DrawGUI(bool inEditor)

--- a/MechJeb2/GuiUtils.cs
+++ b/MechJeb2/GuiUtils.cs
@@ -21,7 +21,16 @@ namespace MuMech
     public class EditableDoubleMult : IEditable
     {
         [Persistent]
-        public double val;
+        public double _val;
+		public virtual double val
+		{
+			get { return _val; }
+			set
+			{
+				_val = value;
+				_text = (_val / multiplier).ToString();
+			}
+		}
         public readonly double multiplier;
 
         public bool parsed;
@@ -77,6 +86,16 @@ namespace MuMech
         {
             _text = GuiUtils.TimeToDHMS(seconds);
         }
+
+		public override double val
+		{
+			get { return _val; }
+			set
+			{
+				_val = value;
+				_text = GuiUtils.TimeToDHMS(_val);
+			}
+		}
 
         public override string text
         {
@@ -539,6 +558,7 @@ namespace MuMech
 
                 style = new GUIStyle(GUI.skin.window);
                 style.normal.background = background;
+                style.onNormal.background = background;
                 style.border.top = style.border.bottom;
                 style.padding.top = style.padding.bottom;
             }
@@ -580,10 +600,14 @@ namespace MuMech
                 {
                     popupOwner = null;
                     selectedItem = ComboBox.selectedItem;
+                    GUI.changed = true;
                 }
 
+                bool guiChanged = GUI.changed;
                 if (GUILayout.Button(entries[selectedItem]))
                 {
+                    // We will set the changed status when we return from the menu instead
+                    GUI.changed = guiChanged;
                     // Update the global state with the new items
                     popupOwner = caller;
                     popupActive = true;

--- a/MechJeb2/Maneuver/Operation.cs
+++ b/MechJeb2/Maneuver/Operation.cs
@@ -87,6 +87,8 @@ namespace MuMech
             res.Sort((x,y) => x.getName().CompareTo(y.getName()));
             return res.ToArray();
         }
+
+		public virtual bool draggable { get { return true;}}
     }
 }
 

--- a/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
+++ b/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
@@ -1,0 +1,238 @@
+using System;
+using UnityEngine;
+
+namespace MuMech
+{
+	public class OperationAdvancedTransfer : Operation
+	{
+		enum Mode
+		{
+			LimitedTime,
+			Porkchop
+		}
+		static string[] modeNames = {"Limited time", "Porkchop selection"};
+		public override string getName() { return "advanced transfer to another planet";}
+
+		double minDepartureTime;
+		double minTransferTime;
+		double maxDepartureTime;
+		double maxTransferTime;
+
+		public EditableTime maxArrivalTime = new EditableTime();
+
+		const double minSamplingStep = 12 * 3600;
+
+		private Mode selectionMode = Mode.Porkchop;
+		int windowWidth;
+
+		TransferCalculator worker;
+		private PlotArea plot;
+
+		bool _draggable = true;
+		public override bool draggable { get { return _draggable;}}
+
+		const int porkchop_Height = 200;
+		GUIStyle progressStyle;
+
+		public OperationAdvancedTransfer()
+		{
+			progressStyle = new GUIStyle();
+			progressStyle.font = GuiUtils.skin.font;
+			progressStyle.fontSize = GuiUtils.skin.label.fontSize;
+			progressStyle.fontStyle = GuiUtils.skin.label.fontStyle;
+			progressStyle.normal.textColor = GuiUtils.skin.label.normal.textColor;
+		}
+
+		public void CheckPreconditions(Orbit o, MechJebModuleTargetController target)
+		{
+			if (o.eccentricity >= 1 || o.ApR >= o.referenceBody.sphereOfInfluence)
+				throw new Exception("initial orbit must not be hyperbolic");
+
+			if (!target.NormalTargetExists)
+				throw new Exception("must select a target for the interplanetary transfer.");
+
+			if (o.referenceBody.referenceBody == null)
+				throw new Exception("doesn't make sense to plot an interplanetary transfer from an orbit around " + o.referenceBody.theName + ".");
+
+			if (o.referenceBody.referenceBody != target.TargetOrbit.referenceBody)
+			{
+				if (o.referenceBody == target.TargetOrbit.referenceBody)
+					throw new Exception("use regular Hohmann transfer function to intercept another body orbiting " + o.referenceBody.theName + ".");
+				throw new Exception("an interplanetary transfer from within " + o.referenceBody.theName + "'s sphere of influence must target a body that orbits " + o.referenceBody.theName + "'s parent, " + o.referenceBody.referenceBody.theName + ".");
+			}
+		}
+
+		static double SafeDepartureTime (Orbit o, double universalTime)
+		{
+			return universalTime + 600 + o.period;
+		}
+
+		void ComputeStuff(Orbit o, double universalTime, MechJebModuleTargetController target)
+		{
+			errorMessage = "";
+			try
+			{
+				CheckPreconditions(o, target);
+			}
+			catch(Exception e)
+			{
+				errorMessage = e.Message;
+				return;
+			}
+
+			if (worker != null)
+				worker.stop = true;
+			plot = null;
+
+			switch (selectionMode)
+			{
+			case Mode.LimitedTime:
+				// We could end up asking for parameters in the past, take a safe 10 min margin
+				worker = new TransferCalculator (o, target.TargetOrbit, SafeDepartureTime(o, universalTime), maxArrivalTime, minSamplingStep);
+				break;
+			case Mode.Porkchop:
+				worker = new AllGraphTransferCalculator(o, target.TargetOrbit, minDepartureTime, maxDepartureTime, minTransferTime, maxTransferTime, windowWidth, porkchop_Height);
+				break;
+			}
+		}
+
+		void ComputeTimes(Orbit o, Orbit destination, double universalTime)
+		{
+			if (destination == null)
+				return;
+
+			double synodic_period = o.referenceBody.orbit.SynodicPeriod(destination);
+			double hohmann_transfer_time = OrbitUtil.GetTransferTime(o.referenceBody.orbit, destination);
+
+			minDepartureTime = SafeDepartureTime(o, universalTime);
+			minTransferTime = 3600;
+
+			maxDepartureTime = minDepartureTime + synodic_period * 1.5;
+			maxTransferTime = hohmann_transfer_time * 1.5;
+			maxArrivalTime.val = (synodic_period + hohmann_transfer_time) * 1.5;
+		}
+
+		private void DoPorkchopGui(Orbit o, double universalTime, MechJebModuleTargetController target)
+		{
+			if (worker == null)
+				return;
+			string dv = " - ";
+			string departure = " - ";
+			string duration = " - ";
+			if (worker.Finished && worker.computed.GetLength(1) == porkchop_Height)
+			{
+				if (plot == null && Event.current.type == EventType.Layout)
+				{
+					plot = new PlotArea(
+						worker.minDepartureTime,
+						worker.maxDepartureTime,
+						worker.minTransferTime,
+						worker.maxTransferTime,
+						new Porkchop(worker.computed).texture,
+						(xmin, xmax, ymin, ymax) => {
+							minDepartureTime = Math.Max(xmin, SafeDepartureTime(o, universalTime));
+							maxDepartureTime = xmax;
+							minTransferTime = Math.Max(ymin, 3600);
+							maxTransferTime = ymax;
+							GUI.changed = true;
+						});
+					plot.selectedPoint = new int[]{worker.bestDate, worker.bestDuration};
+				}
+			}
+			if (plot != null)
+			{
+				var point = plot.selectedPoint;
+				if (plot.hoveredPoint != null)
+					point = plot.hoveredPoint;
+
+				var p = worker.computed[point[0], point[1]];
+				if (p != null)
+				{
+					dv =  MuUtils.ToSI(p.dV.magnitude) + "m/s";
+					departure =  GuiUtils.TimeToDHMS(worker.DateFromIndex(point[0]) - Planetarium.GetUniversalTime());
+					duration = GuiUtils.TimeToDHMS(worker.DurationFromIndex(point[1]));
+				}
+				plot.DoGUI();
+				if (! plot.draggable) _draggable = false;
+			}
+			else
+			{
+				GUILayout.Box("Computing: " + worker.Progress + "%", progressStyle, new GUILayoutOption[] {
+					GUILayout.Width(windowWidth),
+					GUILayout.Height(porkchop_Height)});
+			}
+			GUILayout.BeginHorizontal();
+			GUILayout.Label("ΔV: " + dv);
+			GUILayout.FlexibleSpace();
+			if (GUILayout.Button("Reset", GuiUtils.yellowOnHover))
+				ComputeTimes(o, target.TargetOrbit, universalTime);
+			GUILayout.EndHorizontal();
+			GUILayout.Label("departure in " +departure);
+			GUILayout.Label("transit duration " + duration);
+		}
+
+		public override void DoParametersGUI(Orbit o, double universalTime, MechJebModuleTargetController target)
+		{
+			_draggable = true;
+			if (worker != null && !target.NormalTargetExists && Event.current.type == EventType.Layout)
+			{
+				worker.stop = true;
+				worker = null;
+				plot = null;
+			}
+
+			selectionMode = (Mode) GuiUtils.ComboBox.Box((int) selectionMode, modeNames, this);
+			if (Event.current.type == EventType.Repaint)
+				windowWidth = (int)GUILayoutUtility.GetLastRect().width;
+
+			switch (selectionMode)
+			{
+			case Mode.LimitedTime:
+				GuiUtils.SimpleTextBox("Max arrival time", maxArrivalTime);
+				if (worker != null && !worker.Finished)
+					GuiUtils.SimpleLabel("Computing: " + worker.Progress + "%");
+				break;
+			case Mode.Porkchop:
+				DoPorkchopGui(o, universalTime, target);
+				break;
+			}
+
+			if (worker == null || worker.destinationOrbit != target.TargetOrbit || worker.originOrbit != o)
+				ComputeTimes(o, target.TargetOrbit, universalTime);
+
+			if (GUI.changed || worker == null || worker.destinationOrbit != target.TargetOrbit || worker.originOrbit != o)
+				ComputeStuff(o, universalTime, target);
+		}
+
+		public override ManeuverParameters MakeNodeImpl(Orbit o, double UT, MechJebModuleTargetController target)
+		{
+			// Check preconditions
+			CheckPreconditions(o, target);
+			// Check if computation is finished
+			if (worker != null && !worker.Finished)
+				throw new Exception("Computation not finished");
+			if (worker == null)
+			{
+				ComputeStuff(o, UT, target);
+				throw new Exception("Started computation");
+			}
+
+			if (worker.result == null)
+			{
+				throw new Exception("Computation failed");
+			}
+			if (selectionMode == Mode.Porkchop)
+			{
+				if (plot == null || plot.selectedPoint == null)
+					throw new Exception("Invalid point selected.");
+				return TransferCalculator.OptimizeEjection(
+					worker.computed[plot.selectedPoint[0], plot.selectedPoint[1]],
+					o, worker.destinationOrbit,
+					worker.DateFromIndex(plot.selectedPoint[0]) + worker.DurationFromIndex(plot.selectedPoint[1]));
+			}
+
+			return worker.OptimizedResult;
+		}
+	}
+}
+

--- a/MechJeb2/Maneuver/PlotArea.cs
+++ b/MechJeb2/Maneuver/PlotArea.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using UnityEngine;
+
+namespace MuMech
+{
+	public class PlotArea
+	{
+		public delegate void AreaChanged(double minx, double maxx, double miny, double maxy);
+
+		static GUIStyle selectionStyle;
+
+		public bool draggable = true;
+
+		public int[] hoveredPoint;
+		public int[] selectedPoint;
+
+		private bool mouseDown;
+
+		private double minx;
+		private double maxx;
+		private double miny;
+		private double maxy;
+
+		private Texture2D texture;
+
+		private AreaChanged callback;
+
+		public PlotArea (double minx, double maxx, double miny, double maxy, Texture2D texture, AreaChanged callback)
+		{
+			this.minx = minx;
+			this.maxx = maxx;
+			this.miny = miny;
+			this.maxy = maxy;
+			this.texture = texture;
+			this.callback = callback;
+		}
+
+
+		static PlotArea()
+		{
+			selectionStyle = new GUIStyle();
+			Texture2D background = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+			background.SetPixel(0,0, new Color(0, 0, 1, 0.3f));
+			background.Apply();
+			selectionStyle.normal.background = background;
+		}
+		
+
+		public double x(int index)
+		{
+			return minx + index * (maxx - minx) / texture.width;
+		}
+		public double y(int index)
+		{
+			return miny + index * (maxy - miny) / texture.height;
+		}
+
+		public void DoGUI()
+		{
+			GUILayout.Box(texture, GUIStyle.none, new GUILayoutOption[] { GUILayout.Width(texture.width), GUILayout.Height(texture.height)});
+			if (Event.current.type == EventType.Repaint)
+			{
+				hoveredPoint = null;
+				var rect = GUILayoutUtility.GetLastRect(); rect.x +=1; rect.y += 2;
+				Vector2 mouse = Event.current.mousePosition;
+				if (rect.Contains(mouse))
+				{
+					var pos = (mouse - rect.position);
+					hoveredPoint = new int[]{(int) pos.x, (int)(rect.height - pos.y - 1)};
+				}
+				else
+				{
+					mouseDown = false;
+				}
+				if (mouseDown)
+				{
+					GUI.Box(new Rect(rect.x + Math.Min(selectedPoint[0], hoveredPoint[0]),
+						rect.y + rect.height - Math.Max(selectedPoint[1], hoveredPoint[1]),
+						Math.Abs(selectedPoint[0] - hoveredPoint[0]),
+						Math.Abs(selectedPoint[1] - hoveredPoint[1])), "", selectionStyle);
+				}
+			}
+
+			draggable = hoveredPoint == null;
+			if (hoveredPoint != null)
+			{
+				switch (Event.current.type)
+				{
+				case EventType.MouseDown:
+					if (Event.current.button == 0)
+					{
+						mouseDown = true;
+						selectedPoint = hoveredPoint;
+					}
+					break;
+				case EventType.MouseUp:
+					if (Event.current.button == 0 && mouseDown)
+					{
+						mouseDown = false;
+						if (Math.Abs(selectedPoint[0] - hoveredPoint[0]) > 5 &&
+							Math.Abs(selectedPoint[1] - hoveredPoint[1]) > 5)
+						{
+							callback(
+								x(Math.Min(selectedPoint[0], hoveredPoint[0])),
+								x(Math.Max(selectedPoint[0], hoveredPoint[0])),
+								y(Math.Min(selectedPoint[1], hoveredPoint[1])),
+								y(Math.Max(selectedPoint[1], hoveredPoint[1]))
+							);
+						}
+					}
+					break;
+				case EventType.ScrollWheel:
+					if (Event.current.delta.y == 0)
+						break;
+					double lambda = Event.current.delta.y < 0 ? 0.7 : 1/0.7;
+					double deltax = maxx - minx;
+					double deltay = maxy - miny;
+
+					double newminx = x(hoveredPoint[0]) - hoveredPoint[0] * lambda * deltax / texture.width;
+					double newminy = y(hoveredPoint[1]) - hoveredPoint[1] * lambda * deltay / texture.height;
+					callback(
+						newminx,
+						newminx + lambda * deltax,
+						newminy,
+						newminy + lambda * deltay
+					);
+						
+					break;
+				}
+			}
+		}
+	}
+}
+

--- a/MechJeb2/Maneuver/Porkchop.cs
+++ b/MechJeb2/Maneuver/Porkchop.cs
@@ -1,0 +1,86 @@
+// #define DEBUG
+
+using System;
+using UnityEngine;
+
+namespace MuMech
+{
+	public class Porkchop
+	{
+		public readonly Texture2D texture;
+
+		public Porkchop(ManeuverParameters[,] nodes)
+		{
+			Gradient colours = new Gradient();
+			var colourKeys = new GradientColorKey[6];
+			colourKeys[0].color = new Color(0.25f, 0.25f, 1.0f);
+			colourKeys[0].time = 0.0f;
+			colourKeys[1].color = new Color(0.5f, 0.5f, 1.0f);
+			colourKeys[1].time = 0.01f;
+			colourKeys[2].color = new Color(0.5f, 1.0f, 1.0f);
+			colourKeys[2].time = 0.25f;
+			colourKeys[3].color = new Color(0.5f, 1.0f, 0.5f);
+			colourKeys[3].time = 0.5f;
+			colourKeys[4].color = new Color(1.0f, 1.0f, 0.5f);
+			colourKeys[4].time = 0.75f;
+			colourKeys[5].color = new Color(1.0f, 0.5f, 0.5f);
+			colourKeys[5].time = 1.0f;
+
+			var alphaKeys = new GradientAlphaKey[2];
+			alphaKeys[0].alpha = 1.0f;
+			alphaKeys[0].time = 0.0f;
+			alphaKeys[1].alpha = 1.0f;
+			alphaKeys[1].time = 1.0f;
+
+			colours.SetKeys(colourKeys, alphaKeys);
+
+			double DVminsqr = double.MaxValue;
+			double DVmaxsqr = double.MinValue;
+			for (int i = 0; i < nodes.GetLength(0); i++)
+			{
+				for (int j = 0; j < nodes.GetLength(1); j++)
+				{
+					if (nodes[i, j] != null)
+					{
+						double DVsqr = nodes[i, j].dV.sqrMagnitude;
+						if (DVsqr < DVminsqr)
+						{
+							DVminsqr = DVsqr;
+						}
+
+						DVmaxsqr = Math.Max(DVmaxsqr, nodes[i, j].dV.sqrMagnitude);
+					}
+				}
+			}
+
+			texture = new Texture2D(nodes.GetLength(0), nodes.GetLength(1), TextureFormat.RGB24, false);
+			double logDVminsqr = Math.Log(DVminsqr);
+			double logDVmaxsqr = Math.Min(Math.Log(DVmaxsqr), logDVminsqr + 4);
+
+
+			for (int i = 0; i < nodes.GetLength(0); i++)
+			{
+				for (int j = 0; j < nodes.GetLength(1); j++)
+				{
+					if (nodes[i, j] == null)
+					{
+						texture.SetPixel(i, j, colours.Evaluate(1));
+					}
+					else
+					{
+						double lambda = (Math.Log(nodes[i, j].dV.sqrMagnitude) - logDVminsqr) / (logDVmaxsqr - logDVminsqr);
+						texture.SetPixel(i, j, colours.Evaluate((float)lambda));
+					}
+				}
+			}
+
+			texture.Apply();
+
+#if DEBUG
+			string dir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+			System.IO.File.WriteAllBytes(dir + "/Porkchop.png", texture.EncodeToPNG());
+#endif
+		}
+	}
+}
+

--- a/MechJeb2/Maneuver/TransferCalculator.cs
+++ b/MechJeb2/Maneuver/TransferCalculator.cs
@@ -1,0 +1,458 @@
+﻿// #define DEBUG
+
+using System;
+using System.Threading;
+using UnityEngine;
+
+namespace MuMech
+{
+	public class TransferCalculator
+	{
+		public int bestDate = 0;
+		public int bestDuration = 0;
+		public bool stop = false;
+
+		int pendingJobs;
+
+		// Original parameters, only used to check if parameters have changed
+		public readonly Orbit originOrbit;
+		public readonly Orbit destinationOrbit;
+
+		protected readonly Orbit origin;
+		protected readonly Orbit destination;
+
+		protected int nextDateIndex;
+		protected readonly int dateSamples;
+		public readonly double minDepartureTime = 3600;
+		public readonly double maxDepartureTime;
+		public readonly double minTransferTime = 3600;
+		public readonly double maxTransferTime;
+		protected readonly int maxDurationSamples;
+
+		public ManeuverParameters[,] computed;
+#if DEBUG
+		string[,] log;
+#endif
+
+		double arrivalDate;
+
+		public ManeuverParameters result;
+
+
+		public TransferCalculator(
+				Orbit o, Orbit target,
+				double min_departure_time,
+				double max_transfer_time,
+				double min_sampling_step):
+			this(o, target, min_departure_time, min_departure_time + max_transfer_time, 3600, max_transfer_time,
+			     Math.Min(1000, Math.Max(200, (int) (max_transfer_time / Math.Max(min_sampling_step, 60.0)))),
+			     Math.Min(1000, Math.Max(200, (int) (max_transfer_time / Math.Max(min_sampling_step, 60.0)))))
+		{
+			StartThreads();
+		}
+
+		protected TransferCalculator(
+			Orbit o, Orbit target,
+			double min_departure_time,
+			double max_departure_time,
+			double min_transfer_time,
+			double max_transfer_time,
+			int width,
+			int height)
+		{
+			originOrbit = o;
+			destinationOrbit = target;
+
+			origin = new Orbit();
+			origin.UpdateFromOrbitAtUT(o, min_departure_time, o.referenceBody);
+			destination = new Orbit();
+			destination.UpdateFromOrbitAtUT(target, min_departure_time, target.referenceBody);
+			maxDurationSamples = height;
+			dateSamples = width;
+			nextDateIndex = dateSamples;
+			this.minDepartureTime = min_departure_time;
+			this.maxDepartureTime = max_departure_time;
+			this.minTransferTime = min_transfer_time;
+			this.maxTransferTime = max_transfer_time;
+			computed = new ManeuverParameters[dateSamples, maxDurationSamples];
+			pendingJobs = 0;
+
+#if DEBUG
+			log = new string[dateSamples, maxDurationSamples];
+#endif
+		}
+
+		protected void StartThreads()
+		{
+
+			if (pendingJobs != 0)
+				throw new Exception("Computation threads have already been started");
+
+			pendingJobs = Math.Max(1, Environment.ProcessorCount - 1);
+			for (int job = 0; job < pendingJobs; job++)
+				ThreadPool.QueueUserWorkItem(ComputeDeltaV);
+
+//			pending_jobs = 1;
+//			ComputeDeltaV(this);
+		}
+
+		private bool IsBetter(int date_index1, int duration_index1, int date_index2, int duration_index2)
+		{
+			return computed[date_index1, duration_index1].dV.sqrMagnitude > computed[date_index2, duration_index2].dV.sqrMagnitude;
+		}
+
+		void ComputeDeltaV(object args)
+		{
+			CelestialBody origin_planet = origin.referenceBody;
+
+			for (int date_index = TakeDateIndex();
+					date_index >= 0;
+					date_index = TakeDateIndex())
+			{
+				double t0 = DateFromIndex(date_index);
+				Vector3d V1_0 = origin_planet.orbit.getOrbitalVelocityAtUT(t0);
+				Vector3d R1 = origin_planet.orbit.getRelativePositionAtUT(t0);
+
+				int duration_samples = DurationSamplesForDate(date_index);
+				for (int duration_index = 0; duration_index < duration_samples; duration_index++)
+				{
+					if (stop)
+						break;
+
+					double dt = DurationFromIndex(duration_index);
+					double t1 = t0 + dt;
+
+					Vector3d R2 = destination.getRelativePositionAtUT(t1);
+
+					bool short_way = Vector3d.Dot(Vector3d.Cross(R1, R2), origin_planet.orbit.GetOrbitNormal()) > 0;
+					try
+					{
+						Vector3d V1, V2;
+#if DEBUG
+						log[date_index, duration_index] = dt + ","
+							+ R1.x + "," + R1.y + "," + R1.z + ","
+								+ R2.x + "," + R2.y + "," + R2.z + ","
+								+ V1_0.x + "," + V1_0.y + "," + V1_0.z;
+#endif
+						LambertSolver.Solve(R1, R2, dt, origin_planet.referenceBody, short_way, out V1, out V2);
+
+#if DEBUG
+						log[date_index, duration_index] += "," + V1.x + "," + V1.y + "," + V1.z;
+#endif
+
+						Vector3d soi_exit_velocity = V1 - V1_0;
+						var maneuver = ComputeEjectionManeuver(soi_exit_velocity, origin, t0);
+						if (!double.IsNaN(maneuver.dV.sqrMagnitude) && !double.IsNaN(maneuver.UT))
+						{
+							computed[date_index, duration_index] = maneuver;
+						}
+#if DEBUG
+						log[date_index, duration_index] += "," + maneuver.dV.magnitude;
+#endif
+					}
+					catch (Exception) {}
+				}
+			}
+
+			JobFinished();
+		}
+
+		private void JobFinished()
+		{
+			int remaining = Interlocked.Decrement(ref pendingJobs);
+			if (remaining == 0)
+			{
+				for (int date_index = 0; date_index < dateSamples; date_index++)
+				{
+					int n = DurationSamplesForDate(date_index);
+					for (int duration_index = 0; duration_index < n; duration_index++)
+					{
+						if (computed[bestDate, bestDuration] == null ||
+							(computed[date_index, duration_index] != null
+								&& IsBetter(bestDate, bestDuration, date_index, duration_index)))
+						{
+							bestDate = date_index;
+							bestDuration = duration_index;
+						}
+					}
+				}
+
+				arrivalDate = DateFromIndex(bestDate) + DurationFromIndex(bestDuration);
+				result = computed[bestDate, bestDuration];
+
+				pendingJobs = -1;
+
+#if DEBUG
+				string dir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+				var f = System.IO.File.CreateText(dir + "/DeltaVWorking.csv");
+				f.WriteLine(originOrbit.referenceBody.referenceBody.gravParameter);
+				for (int date_index = 0; date_index < dateSamples; date_index++)
+				{
+					int n = DurationSamplesForDate(date_index);
+					for (int duration_index = 0; duration_index < n; duration_index++)
+					{
+						f.WriteLine(log[date_index, duration_index]);
+					}
+				}
+#endif
+			}
+		}
+
+		public bool Finished { get { return pendingJobs == -1; } }
+
+		public virtual int Progress { get
+			{ return (int)(100 * (1 - Math.Sqrt((double)Math.Max(0, nextDateIndex) / dateSamples))); } }
+
+		protected int TakeDateIndex() { return Interlocked.Decrement(ref nextDateIndex); }
+
+		public virtual int DurationSamplesForDate(int date_index)
+		{
+			return (int)(maxDurationSamples * (maxDepartureTime - DateFromIndex(date_index)) / maxTransferTime);
+		}
+		public double DurationFromIndex(int index)
+		{
+			return minTransferTime + index * (maxTransferTime - minTransferTime) / maxDurationSamples;
+		}
+		public double DateFromIndex(int index)
+		{
+			return minDepartureTime + index * (maxDepartureTime - minDepartureTime) / dateSamples;
+		}
+
+		public ManeuverParameters OptimizedResult
+		{
+			get
+			{
+				return OptimizeEjection(result, origin, destination, arrivalDate);
+			}
+		}
+
+		// Compute the two intersecting lines of a cone with a corner at (0,0,0) with a plane passing by (0,0,0)
+		// If there is no intersection, return the line on the plane closest to the cone (assumes cone_angle > pi/2)
+		static void IntersectConePlane(Vector3d cone_direction, double cone_angle, Vector3d plane_normal, out Vector3d intersect_1, out Vector3d intersect_2)
+		{
+			intersect_1 = Vector3d.zero;
+			intersect_2 = Vector3d.zero;
+
+			cone_direction.Normalize();
+			plane_normal.Normalize();
+
+			// Change the frame of reference:
+			// x = cone_direction
+			// y = plane_normal projected on the plane normal to cone_direction
+			// z = x * y
+			Vector3d x = cone_direction;
+			Vector3d z = Vector3d.Cross(x, plane_normal).normalized;
+			Vector3d y = Vector3d.Cross(z, x);
+
+			// transition matrix from the temporary frame to the global frame
+			Matrix3x3f M_i_tmp = new Matrix3x3f();
+			for (int i = 0; i < 3; i++)
+			{
+				M_i_tmp[i, 0] = (float)x[i];
+				M_i_tmp[i, 1] = (float)y[i];
+				M_i_tmp[i, 2] = (float)z[i];
+			}
+
+			Vector3d n = M_i_tmp.transpose() * plane_normal;
+			double cos_phi = -n.x / (n.y * Math.Tan(cone_angle));
+
+			if (Math.Abs(cos_phi) <= 1.0f)
+			{
+				intersect_1.x = Math.Cos(cone_angle);
+				intersect_1.y = Math.Sin(cone_angle) * cos_phi;
+				intersect_1.z = Math.Sin(cone_angle) * Math.Sqrt(1 - cos_phi * cos_phi);
+			}
+			else
+			{
+				intersect_1.x = -n.y;
+				intersect_1.y = n.x;
+				intersect_1.z = 0.0;
+			}
+
+			intersect_2.x = intersect_1.x;
+			intersect_2.y = intersect_1.y;
+			intersect_2.z = -intersect_1.z;
+
+			intersect_1 = M_i_tmp * intersect_1;
+			intersect_2 = M_i_tmp * intersect_2;
+		}
+
+		static double AngleAboutAxis(Vector3d v1, Vector3d v2, Vector3d axis)
+		{
+			axis.Normalize();
+
+			v1 = (v1 - Vector3d.Dot(axis, v1) * axis).normalized;
+			v2 = (v2 - Vector3d.Dot(axis, v2) * axis).normalized;
+
+			return Math.Atan2(Vector3d.Dot(axis, Vector3d.Cross(v1, v2)), Vector3d.Dot(v1, v2));
+		}
+
+		static ManeuverParameters ComputeEjectionManeuver(Vector3d exit_velocity, Orbit initial_orbit, double UT_0)
+		{
+			double GM = initial_orbit.referenceBody.gravParameter;
+			double C3 = exit_velocity.sqrMagnitude;
+			double sma = -GM / C3;
+			double Rpe = initial_orbit.semiMajorAxis;
+			double ecc = 1 - Rpe / sma;
+			double theta = Math.Acos(-1 / ecc);
+
+			Vector3d intersect_1;
+			Vector3d intersect_2;
+
+			// intersect_1 is the optimal position on the orbit assuming the orbit is circular and the sphere of influence is infinite
+			IntersectConePlane(exit_velocity, theta, initial_orbit.h, out intersect_1, out intersect_2);
+
+			Vector3d eccvec = initial_orbit.GetEccVector();
+
+			double true_anomaly = AngleAboutAxis(eccvec, intersect_1, initial_orbit.h);
+			// GetMeanAnomalyAtTrueAnomaly expects degrees and returns radians
+			double mean_anomaly = initial_orbit.GetMeanAnomalyAtTrueAnomaly(true_anomaly * 180 / Math.PI);
+
+			double delta_mean_anomaly = MuUtils.ClampRadiansPi(mean_anomaly - initial_orbit.MeanAnomalyAtUT(UT_0));
+
+			double UT = UT_0 + delta_mean_anomaly / initial_orbit.MeanMotion();
+
+			Vector3d V_0 = initial_orbit.getOrbitalVelocityAtUT(UT);
+			Vector3d pos = initial_orbit.getRelativePositionAtUT(UT);
+
+			double final_vel = Math.Sqrt(C3 + 2 * GM / pos.magnitude);
+
+			Vector3d x = pos.normalized;
+			Vector3d z = Vector3d.Cross(x, exit_velocity).normalized;
+			Vector3d y = Vector3d.Cross(z, x);
+
+			theta = Math.PI / 2;
+			double dtheta = 0.001;
+			Orbit sample = new Orbit();
+
+			double theta_err = Double.MaxValue;
+
+			for (int iteration = 0 ; iteration < 50 ; ++iteration)
+			{
+				Vector3d V_1 = final_vel * (Math.Cos(theta) * x + Math.Sin(theta) * y);
+				sample.UpdateFromStateVectors(pos, V_1, initial_orbit.referenceBody, UT);
+				theta_err = AngleAboutAxis(exit_velocity, sample.getOrbitalVelocityAtUT(OrbitExtensions.NextTimeOfRadius(sample, UT, sample.referenceBody.sphereOfInfluence)), z);
+				if (double.IsNaN(theta_err))
+					return null;
+				if (Math.Abs(theta_err) <= Math.PI / 1800)
+					return new ManeuverParameters((V_1 - V_0).xzy, UT);
+
+				V_1 = final_vel * (Math.Cos(theta + dtheta) * x + Math.Sin(theta + dtheta) * y);
+				sample.UpdateFromStateVectors(pos, V_1, initial_orbit.referenceBody, UT);
+				double theta_err_2 = AngleAboutAxis(exit_velocity, sample.getOrbitalVelocityAtUT(OrbitExtensions.NextTimeOfRadius(sample, UT, sample.referenceBody.sphereOfInfluence)), z);
+
+				V_1 = final_vel * (Math.Cos(theta - dtheta) * x + Math.Sin(theta - dtheta) * y);
+				sample.UpdateFromStateVectors(pos, V_1, initial_orbit.referenceBody, UT);
+				double theta_err_3 = AngleAboutAxis(exit_velocity, sample.getOrbitalVelocityAtUT(OrbitExtensions.NextTimeOfRadius(sample, UT, sample.referenceBody.sphereOfInfluence)), z);
+
+				double derr = MuUtils.ClampRadiansPi(theta_err_2 - theta_err_3) / (2 * dtheta);
+
+				theta = MuUtils.ClampRadiansTwoPi(theta - theta_err / derr);
+
+				// if theta > pi, replace with 2pi - theta, the function ejection_angle=f(theta) is symmetrc wrt theta=pi
+				if (theta > Math.PI)
+					theta = 2 * Math.PI - theta;
+			}
+
+			return null;
+		}
+
+		class OptimizerData
+		{
+			public Orbit initial_orbit;
+			public double original_UT;
+			public double UT_arrival;
+			public Vector3d pos_arrival;
+		}
+
+		static void DistanceToTarget(double[] x, double[] fi, object obj)
+		{
+			OptimizerData data = (OptimizerData)obj;
+
+			double t = data.original_UT + x[3];
+			Vector3d DV = new Vector3d(x[0], x[1], x[2]);
+
+			Orbit orbit = new Orbit();
+			orbit.UpdateFromStateVectors(data.initial_orbit.getRelativePositionAtUT(t), data.initial_orbit.getOrbitalVelocityAtUT(t) + DV.xzy, data.initial_orbit.referenceBody, t);
+			orbit.StartUT = t;
+
+			var pars = new PatchedConics.SolverParameters();
+			Vector3d pos;
+
+			while(true)
+			{
+				Orbit next_orbit = new Orbit();
+				PatchedConics.CalculatePatch(orbit, next_orbit, orbit.StartUT, pars, null);
+
+				if (orbit.EndUT > data.UT_arrival)
+				{
+					pos = orbit.getTruePositionAtUT(data.UT_arrival);
+					Vector3d err = pos - data.pos_arrival;
+
+					fi[0] = err.x;
+					fi[1] = err.y;
+					fi[2] = err.z;
+					return;
+				}
+				else
+				{
+					orbit = next_orbit;
+				}
+			}
+		}
+
+		public static ManeuverParameters OptimizeEjection(ManeuverParameters original_maneuver, Orbit initial_orbit, Orbit target, double UT_arrival)
+		{
+			alglib.minlmstate state;
+			alglib.minlmreport rep;
+
+			double[] x = new double[4];
+			double[] scale = new double[4];
+
+			x[0] = original_maneuver.dV.x;
+			x[1] = original_maneuver.dV.y;
+			x[2] = original_maneuver.dV.z;
+			x[3] = 0;
+
+			scale[0] = scale[1] = scale[2] = original_maneuver.dV.magnitude;
+			scale[3] = initial_orbit.period;
+
+			OptimizerData data = new OptimizerData();
+			data.initial_orbit = initial_orbit;
+			data.original_UT = original_maneuver.UT;
+			data.UT_arrival = UT_arrival;
+			data.pos_arrival = target.getTruePositionAtUT(UT_arrival);
+
+			alglib.minlmcreatev(3, x, 0.01, out state);
+			alglib.minlmsetcond(state, 0, 0, 0, 50);
+			alglib.minlmsetscale(state, scale);
+			alglib.minlmoptimize(state, DistanceToTarget, null, data);
+			alglib.minlmresults(state, out x, out rep);
+
+			return new ManeuverParameters(new Vector3d(x[0], x[1], x[2]), original_maneuver.UT + x[3]);
+		}
+	}
+
+	public class AllGraphTransferCalculator : TransferCalculator
+	{
+		public AllGraphTransferCalculator(
+			Orbit o, Orbit target,
+			double min_departure_time,
+			double max_departure_time,
+			double min_transfer_time,
+			double max_transfer_time,
+			int width,
+			int height) : base(o, target, min_departure_time, max_departure_time, min_transfer_time, max_transfer_time, width, height)
+		{
+			StartThreads();
+		}
+
+		public override int DurationSamplesForDate(int date_index)
+		{
+			return maxDurationSamples;
+		}
+
+		public override int Progress { get { return Math.Min(100, (int)(100 * (1 - (double)nextDateIndex / dateSamples))); } }
+	}
+}
+

--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -65,7 +65,14 @@ namespace MuMech
                 }
             }
 
-            operation[operationId].DoParametersGUI(o, UT, core.target);
+            try
+            {
+                operation[operationId].DoParametersGUI(o, UT, core.target);
+            }
+            catch(Exception e)
+            {
+                Debug.Log(e.Message + "\n" + e.StackTrace);
+            }
 
             if (anyNodeExists)
                 GUILayout.Label("after the last maneuver node.");
@@ -146,7 +153,7 @@ namespace MuMech
 
             GUILayout.EndVertical();
 
-            base.WindowGUI(windowID);
+            base.WindowGUI(windowID, operation[operationId].draggable);
         }
 
         public List<ManeuverNode> GetManeuverNodes()

--- a/MechJeb2/MechJebModuleTargetController.cs
+++ b/MechJeb2/MechJebModuleTargetController.cs
@@ -130,7 +130,11 @@ namespace MuMech
 
         public Orbit TargetOrbit
         {
-            get { return target.GetOrbit(); }
+            get {
+                if (target == null)
+                    return null;
+                return target.GetOrbit();
+            }
         }
 
         public Vector3 Position

--- a/MechJeb2/MuUtils.cs
+++ b/MechJeb2/MuUtils.cs
@@ -320,6 +320,19 @@ namespace MuMech
             set { e[i, j] = value; }
         }
 
+		public Matrix3x3f transpose()
+		{
+			Matrix3x3f ret = new Matrix3x3f();
+			for (int i = 0; i < 3; i++)
+			{
+				for (int j = 0; j < 3; j++)
+				{
+					ret.e[i, j] = e[j, i];
+				}
+			}
+			return ret;
+		}
+
         public static Vector3d operator *(Matrix3x3f M, Vector3 v) 
         {
             Vector3 ret = Vector3.zero;


### PR DESCRIPTION
This adds a new interplanetary transfer maneuver that lets the user choose the departure date and the transfer duration on a porkchop plot. The transfer with the lowest deltaV is automatically selected, and you can zoom with the mouse wheel or by selecting a rectangle on the plot.
