### PR TITLE
Fix EditableTime behaviour

### DIFF
--- a/MechJeb2/GuiUtils.cs
+++ b/MechJeb2/GuiUtils.cs
@@ -107,12 +107,12 @@ namespace MuMech
 
                 double parsedValue;
                 parsed = double.TryParse(_text, out parsedValue);
-                if (parsed) val = parsedValue;
+                if (parsed) _val = parsedValue;
 
                 if (!parsed)
                 {
                     parsed = GuiUtils.TryParseDHMS(_text, out parsedValue);
-                    if (parsed) val = parsedValue;
+                    if (parsed) _val = parsedValue;
                 }
             }
         }


### PR DESCRIPTION
When the text is parsed, set the _val member instead of the val property to avoid changing the text.
