### PR TITLE
Log exceptions in maneuver creation

### DIFF
--- a/MechJeb2/Maneuver/Operation.cs
+++ b/MechJeb2/Maneuver/Operation.cs
@@ -19,6 +19,11 @@ namespace MuMech
 
     }
 
+    public class OperationException : Exception
+    {
+        public OperationException(string message) : base(message) {}
+    }
+
     public abstract class Operation
     {
         protected string errorMessage = "";
@@ -33,7 +38,7 @@ namespace MuMech
         public abstract void DoParametersGUI(Orbit o, double universalTime, MechJebModuleTargetController target);
         // Function called when create node is pressed; input parameters are orbit and time parameters after the last maneuver and current target
         // ManeuverParameters contain a single time and dV describing the node that should be executed
-        // In case of error you can throw an exception, the message will be displayed and no node will be created.
+        // In case of error you can throw an OperationException, the message will be displayed and no node will be created.
         public abstract ManeuverParameters MakeNodeImpl(Orbit o, double universalTime, MechJebModuleTargetController target);
 
         public ManeuverParameters MakeNode(Orbit o, double universalTime, MechJebModuleTargetController target)
@@ -43,9 +48,15 @@ namespace MuMech
             {
                 return MakeNodeImpl(o, universalTime, target);
             }
-            catch (Exception e)
+            catch (OperationException e)
             {
                 errorMessage = e.Message;
+                return null;
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+                errorMessage = "An error occurred while creating the node.";
                 return null;
             }
         }

--- a/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
+++ b/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
@@ -36,19 +36,19 @@ namespace MuMech
 		public void CheckPreconditions(Orbit o, MechJebModuleTargetController target)
 		{
 			if (o.eccentricity >= 1 || o.ApR >= o.referenceBody.sphereOfInfluence)
-				throw new Exception("initial orbit must not be hyperbolic");
+				throw new OperationException("initial orbit must not be hyperbolic");
 
 			if (!target.NormalTargetExists)
-				throw new Exception("must select a target for the interplanetary transfer.");
+				throw new OperationException("must select a target for the interplanetary transfer.");
 
 			if (o.referenceBody.referenceBody == null)
-				throw new Exception("doesn't make sense to plot an interplanetary transfer from an orbit around " + o.referenceBody.theName + ".");
+				throw new OperationException("doesn't make sense to plot an interplanetary transfer from an orbit around " + o.referenceBody.theName + ".");
 
 			if (o.referenceBody.referenceBody != target.TargetOrbit.referenceBody)
 			{
 				if (o.referenceBody == target.TargetOrbit.referenceBody)
-					throw new Exception("use regular Hohmann transfer function to intercept another body orbiting " + o.referenceBody.theName + ".");
-				throw new Exception("an interplanetary transfer from within " + o.referenceBody.theName + "'s sphere of influence must target a body that orbits " + o.referenceBody.theName + "'s parent, " + o.referenceBody.referenceBody.theName + ".");
+					throw new OperationException("use regular Hohmann transfer function to intercept another body orbiting " + o.referenceBody.theName + ".");
+				throw new OperationException("an interplanetary transfer from within " + o.referenceBody.theName + "'s sphere of influence must target a body that orbits " + o.referenceBody.theName + "'s parent, " + o.referenceBody.referenceBody.theName + ".");
 			}
 		}
 
@@ -208,21 +208,21 @@ namespace MuMech
 			CheckPreconditions(o, target);
 			// Check if computation is finished
 			if (worker != null && !worker.Finished)
-				throw new Exception("Computation not finished");
+				throw new OperationException("Computation not finished");
 			if (worker == null)
 			{
 				ComputeStuff(o, UT, target);
-				throw new Exception("Started computation");
+				throw new OperationException("Started computation");
 			}
 
 			if (worker.result == null)
 			{
-				throw new Exception("Computation failed");
+				throw new OperationException("Computation failed");
 			}
 			if (selectionMode == Mode.Porkchop)
 			{
 				if (plot == null || plot.selectedPoint == null)
-					throw new Exception("Invalid point selected.");
+					throw new OperationException("Invalid point selected.");
 				return TransferCalculator.OptimizeEjection(
 					worker.computed[plot.selectedPoint[0], plot.selectedPoint[1]],
 					o, worker.destinationOrbit,

--- a/MechJeb2/Maneuver/OperationApoapsis.cs
+++ b/MechJeb2/Maneuver/OperationApoapsis.cs
@@ -27,7 +27,7 @@ namespace MuMech
             if (o.referenceBody.Radius + newApA < o.Radius(UT))
             {
                 string burnAltitude = MuUtils.ToSI(o.Radius(UT) - o.referenceBody.Radius) + "m";
-                throw new Exception("new apoapsis cannot be lower than the altitude of the burn (" + burnAltitude + ")");
+                throw new OperationException("new apoapsis cannot be lower than the altitude of the burn (" + burnAltitude + ")");
             }
 
             return new ManeuverParameters(OrbitalManeuverCalculator.DeltaVToChangeApoapsis(o, UT, newApA + o.referenceBody.Radius), UT);

--- a/MechJeb2/Maneuver/OperationCourseCorrection.cs
+++ b/MechJeb2/Maneuver/OperationCourseCorrection.cs
@@ -28,7 +28,7 @@ namespace MuMech
         public override ManeuverParameters MakeNodeImpl(Orbit o, double UT, MechJebModuleTargetController target)
         {
             if (!target.NormalTargetExists)
-                throw new Exception("must select a target for the course correction.");
+                throw new OperationException("must select a target for the course correction.");
 
             Orbit correctionPatch = o;
             while (correctionPatch != null)
@@ -43,7 +43,7 @@ namespace MuMech
             }
 
             if (correctionPatch == null || correctionPatch.referenceBody != target.TargetOrbit.referenceBody)
-                throw new Exception("target for course correction must be in the same sphere of influence");
+                throw new OperationException("target for course correction must be in the same sphere of influence");
 
             if (o.NextClosestApproachTime(target.TargetOrbit, UT) < UT + 1 ||
                     o.NextClosestApproachDistance(target.TargetOrbit, UT) > target.TargetOrbit.semiMajorAxis * 0.2)

--- a/MechJeb2/Maneuver/OperationEllipticize.cs
+++ b/MechJeb2/Maneuver/OperationEllipticize.cs
@@ -32,15 +32,15 @@ namespace MuMech
             string burnAltitude = MuUtils.ToSI(o.Radius(UT) - o.referenceBody.Radius) + "m";
             if (o.referenceBody.Radius + newPeA > o.Radius(UT))
             {
-                throw new Exception("new periapsis cannot be higher than the altitude of the burn (" + burnAltitude + ")");
+                throw new OperationException("new periapsis cannot be higher than the altitude of the burn (" + burnAltitude + ")");
             }
             else if (o.referenceBody.Radius + newApA < o.Radius(UT))
             {
-                throw new Exception("new apoapsis cannot be lower than the altitude of the burn (" + burnAltitude + ")");
+                throw new OperationException("new apoapsis cannot be lower than the altitude of the burn (" + burnAltitude + ")");
             }
             else if (newPeA < -o.referenceBody.Radius)
             {
-                throw new Exception("new periapsis cannot be lower than minus the radius of " + o.referenceBody.theName + "(-" + MuUtils.ToSI(o.referenceBody.Radius, 3) + "m)");
+                throw new OperationException("new periapsis cannot be lower than minus the radius of " + o.referenceBody.theName + "(-" + MuUtils.ToSI(o.referenceBody.Radius, 3) + "m)");
             }
 
             return new ManeuverParameters(OrbitalManeuverCalculator.DeltaVToEllipticize(o, UT, newPeA + o.referenceBody.Radius, newApA + o.referenceBody.Radius), UT);

--- a/MechJeb2/Maneuver/OperationInterplanetaryTransfer.cs
+++ b/MechJeb2/Maneuver/OperationInterplanetaryTransfer.cs
@@ -32,16 +32,16 @@ namespace MuMech
 
             // Check preconditions
             if (!target.NormalTargetExists)
-                throw new Exception("must select a target for the interplanetary transfer.");
+                throw new OperationException("must select a target for the interplanetary transfer.");
 
             if (o.referenceBody.referenceBody == null)
-                throw new Exception("doesn't make sense to plot an interplanetary transfer from an orbit around " + o.referenceBody.theName + ".");
+                throw new OperationException("doesn't make sense to plot an interplanetary transfer from an orbit around " + o.referenceBody.theName + ".");
 
             if (o.referenceBody.referenceBody != target.TargetOrbit.referenceBody)
             {
                 if (o.referenceBody == target.TargetOrbit.referenceBody)
-                    throw new Exception("use regular Hohmann transfer function to intercept another body orbiting " + o.referenceBody.theName + ".");
-                throw new Exception("an interplanetary transfer from within " + o.referenceBody.theName + "'s sphere of influence must target a body that orbits " + o.referenceBody.theName + "'s parent, " + o.referenceBody.referenceBody.theName + ".");
+                    throw new OperationException("use regular Hohmann transfer function to intercept another body orbiting " + o.referenceBody.theName + ".");
+                throw new OperationException("an interplanetary transfer from within " + o.referenceBody.theName + "'s sphere of influence must target a body that orbits " + o.referenceBody.theName + "'s parent, " + o.referenceBody.referenceBody.theName + ".");
             }
 
             // Simple warnings

--- a/MechJeb2/Maneuver/OperationKillRelVel.cs
+++ b/MechJeb2/Maneuver/OperationKillRelVel.cs
@@ -21,9 +21,9 @@ namespace MuMech
         public override ManeuverParameters MakeNodeImpl(Orbit o, double universalTime, MechJebModuleTargetController target)
         {
             if (!target.NormalTargetExists)
-                throw new Exception("must select a target to match velocities with.");
+                throw new OperationException("must select a target to match velocities with.");
             else if (o.referenceBody != target.TargetOrbit.referenceBody)
-                throw new Exception("target must be in the same sphere of influence.");
+                throw new OperationException("target must be in the same sphere of influence.");
 
             double UT = timeSelector.ComputeManeuverTime(o, universalTime, target);
 

--- a/MechJeb2/Maneuver/OperationLambert.cs
+++ b/MechJeb2/Maneuver/OperationLambert.cs
@@ -25,9 +25,9 @@ namespace MuMech
         public override ManeuverParameters MakeNodeImpl(Orbit o, double universalTime, MechJebModuleTargetController target)
         {
             if (!target.NormalTargetExists)
-                throw new Exception("must select a target to intercept.");
+                throw new OperationException("must select a target to intercept.");
             if (o.referenceBody != target.TargetOrbit.referenceBody)
-                throw new Exception("target must be in the same sphere of influence.");
+                throw new OperationException("target must be in the same sphere of influence.");
 
             double UT = timeSelector.ComputeManeuverTime(o, universalTime, target);
 

--- a/MechJeb2/Maneuver/OperationMoonReturn.cs
+++ b/MechJeb2/Maneuver/OperationMoonReturn.cs
@@ -29,7 +29,7 @@ namespace MuMech
 
             if (o.referenceBody.referenceBody == null)
             {
-                throw new Exception(o.referenceBody.theName + " is not orbiting another body you could return to.");
+                throw new OperationException(o.referenceBody.theName + " is not orbiting another body you could return to.");
             }
 
             double UT;

--- a/MechJeb2/Maneuver/OperationPeriapsis.cs
+++ b/MechJeb2/Maneuver/OperationPeriapsis.cs
@@ -28,11 +28,11 @@ namespace MuMech
             if (o.referenceBody.Radius + newPeA > o.Radius(UT))
             {
                 string burnAltitude = MuUtils.ToSI(o.Radius(UT) - o.referenceBody.Radius) + "m";
-                throw new Exception("new periapsis cannot be higher than the altitude of the burn (" + burnAltitude + ")");
+                throw new OperationException("new periapsis cannot be higher than the altitude of the burn (" + burnAltitude + ")");
             }
             else if (newPeA < -o.referenceBody.Radius)
             {
-                throw new Exception("new periapsis cannot be lower than minus the radius of " + o.referenceBody.theName + "(-" + MuUtils.ToSI(o.referenceBody.Radius, 3) + "m)");
+                throw new OperationException("new periapsis cannot be lower than minus the radius of " + o.referenceBody.theName + "(-" + MuUtils.ToSI(o.referenceBody.Radius, 3) + "m)");
             }
 
             return new ManeuverParameters(OrbitalManeuverCalculator.DeltaVToChangePeriapsis(o, UT, newPeA + o.referenceBody.Radius), UT);

--- a/MechJeb2/Maneuver/OperationPlane.cs
+++ b/MechJeb2/Maneuver/OperationPlane.cs
@@ -24,24 +24,24 @@ namespace MuMech
 
             if (!target.NormalTargetExists)
             {
-                throw new Exception("must select a target to match planes with.");
+                throw new OperationException("must select a target to match planes with.");
             }
             else if (o.referenceBody != target.TargetOrbit.referenceBody)
             {
-                throw new Exception("can only match planes with an object in the same sphere of influence.");
+                throw new OperationException("can only match planes with an object in the same sphere of influence.");
             }
             else if (timeSelector.timeReference == TimeReference.REL_ASCENDING)
             {
                 if (!o.AscendingNodeExists(target.TargetOrbit))
                 {
-                    throw new Exception("ascending node with target doesn't exist.");
+                    throw new OperationException("ascending node with target doesn't exist.");
                 }
             }
             else
             {
                 if (!o.DescendingNodeExists(target.TargetOrbit))
                 {
-                    throw new Exception("descending node with target doesn't exist.");
+                    throw new OperationException("descending node with target doesn't exist.");
                 }
             }
 

--- a/MechJeb2/Maneuver/OperationSemiMajor.cs
+++ b/MechJeb2/Maneuver/OperationSemiMajor.cs
@@ -33,7 +33,7 @@ namespace MuMech
 
             if(o.Radius(UT) > 2*newSMA)
             {
-                throw new Exception("cannot make Semi-Major Axis less than twice the burn altitude plus the radius of " + o.referenceBody.theName + "(" + MuUtils.ToSI(o.referenceBody.Radius, 3) + "m)");
+                throw new OperationException("cannot make Semi-Major Axis less than twice the burn altitude plus the radius of " + o.referenceBody.theName + "(" + MuUtils.ToSI(o.referenceBody.Radius, 3) + "m)");
             }
 
             return new ManeuverParameters(OrbitalManeuverCalculator.DeltaVForSemiMajorAxis (o, UT, newSMA), UT);

--- a/MechJeb2/Maneuver/OperationTransfer.cs
+++ b/MechJeb2/Maneuver/OperationTransfer.cs
@@ -22,19 +22,19 @@ namespace MuMech
         {
             if (!target.NormalTargetExists)
             {
-                throw new Exception("must select a target for the Hohmann transfer.");
+                throw new OperationException("must select a target for the Hohmann transfer.");
             }
             else if (o.referenceBody != target.TargetOrbit.referenceBody)
             {
-                throw new Exception("target for Hohmann transfer must be in the same sphere of influence.");
+                throw new OperationException("target for Hohmann transfer must be in the same sphere of influence.");
             }
             else if (o.eccentricity > 1)
             {
-                throw new Exception("starting orbit for Hohmann transfer must not be hyperbolic.");
+                throw new OperationException("starting orbit for Hohmann transfer must not be hyperbolic.");
             }
             else if (target.TargetOrbit.eccentricity > 1)
             {
-                throw new Exception("target orbit for Hohmann transfer must not be hyperbolic.");
+                throw new OperationException("target orbit for Hohmann transfer must not be hyperbolic.");
             }
             else if (o.RelativeInclination(target.TargetOrbit) > 30 && o.RelativeInclination(target.TargetOrbit) < 150)
             {

--- a/MechJeb2/Maneuver/TimeSelector.cs
+++ b/MechJeb2/Maneuver/TimeSelector.cs
@@ -95,7 +95,7 @@ namespace MuMech
                 }
                 else
                 {
-                    throw new System.Exception("Warning: orbit is hyperbolic, so apoapsis doesn't exist.");
+                    throw new OperationException("Warning: orbit is hyperbolic, so apoapsis doesn't exist.");
                 }
                 break;
 
@@ -110,7 +110,7 @@ namespace MuMech
                 }
                 else
                 {
-                    throw new System.Exception("Warning: no target selected.");
+                    throw new OperationException("Warning: no target selected.");
                 }
                 break;
 
@@ -121,7 +121,7 @@ namespace MuMech
                 }
                 else
                 {
-                    throw new System.Exception("Warning: can't circularize at this altitude, since current orbit does not reach it.");
+                    throw new OperationException("Warning: can't circularize at this altitude, since current orbit does not reach it.");
                 }
                 break;
 
@@ -132,7 +132,7 @@ namespace MuMech
                 }
                 else
                 {
-                    throw new System.Exception("Warning: equatorial ascending node doesn't exist.");
+                    throw new OperationException("Warning: equatorial ascending node doesn't exist.");
                 }
                 break;
 
@@ -143,7 +143,7 @@ namespace MuMech
                 }
                 else
                 {
-                    throw new System.Exception("Warning: equatorial descending node doesn't exist.");
+                    throw new OperationException("Warning: equatorial descending node doesn't exist.");
                 }
                 break;
 


### PR DESCRIPTION
In current maneuver planner system all exceptions are treated equally and displayed in GUI.

The change introduces a new OperationException that should be used for messages to the user.
Any other exception will now just show a generic message, but will log the full exception.
