### PR TITLE
Fix some exceptions in advanced window transfer

### DIFF
--- a/MechJeb2/Maneuver/TransferCalculator.cs
+++ b/MechJeb2/Maneuver/TransferCalculator.cs
@@ -394,10 +394,13 @@ namespace MuMech
 					fi[2] = err.z;
 					return;
 				}
-				else
+
+				// As of 0.25 CalculatePatch fails if the orbit does not change SoI
+				if (next_orbit.referenceBody == null)
 				{
-					orbit = next_orbit;
+					next_orbit.UpdateFromOrbitAtUT(orbit, orbit.StartUT + orbit.period, orbit.referenceBody);
 				}
+				orbit = next_orbit;
 			}
 		}
 


### PR DESCRIPTION
When the orbit does not change SoI, PatchedConics.CalculatePatch returns
a broken orbit and crashes the optimizer.
Now those orbits are recognized and we just iterate one more orbit.
