### PR TITLE
titlebar dragging and other smaller UI improvements

### DIFF
--- a/MechJeb2/DisplayModule.cs
+++ b/MechJeb2/DisplayModule.cs
@@ -9,6 +9,7 @@ namespace MuMech
     public class DisplayModule : ComputerModule
     {
         public bool hidden = false;
+        public bool locked = false;
 
         public Rect windowPos
         {
@@ -81,7 +82,19 @@ namespace MuMech
                 enabled = false;
             }
 
-            if (draggable)
+//            if (GUI.Button(new Rect(windowPos.width - 40, 2, 20, 16), (locked ? "X" : "O"))) // lock button needs an icon, letters look crap
+//            {
+//                locked = !locked;
+//            }
+            
+            bool allowDrag = true;
+            if (core.GetComputerModule<MechJebModuleSettings>().useTitlebarDragging)
+            {
+            	allowDrag = Mouse.screenPos.x >= windowPos.xMin + 3 && Mouse.screenPos.x <= windowPos.xMin + windowPos.width - 3 &&
+							Mouse.screenPos.y >= windowPos.yMin + 3 && Mouse.screenPos.y <= windowPos.yMin + 17;
+            }
+            
+            if (draggable && allowDrag)
                 GUI.DragWindow();
         }
 
@@ -125,6 +138,7 @@ namespace MuMech
             base.OnSave(local, type, global);
 
             if (global != null) global.AddValue("enabled", enabled);
+//            if (global != null) global.AddValue("locked", locked);
         }
 
         public override void OnLoad(ConfigNode local, ConfigNode type, ConfigNode global)
@@ -136,6 +150,12 @@ namespace MuMech
                 bool loadedEnabled;
                 if (bool.TryParse(global.GetValue("enabled"), out loadedEnabled)) enabled = loadedEnabled;
             }
+
+//            if (global != null && global.HasValue("locked"))
+//            {
+//                bool loadedLocked;
+//                if (bool.TryParse(global.GetValue("locked"), out loadedLocked)) locked = loadedLocked;
+//            }
         }
 
         public virtual bool isActive()

--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -262,7 +262,7 @@ namespace MuMech
                 }
             }
 
-            if (forceRoll && Vector3.Angle(vesselState.up, vesselState.forward) > 7 && core.attitude.attitudeError < 5)
+            if (forceRoll && Vector3.Angle(vesselState.up, vesselState.forward) > 7)
             {
                 var pitch = 90 - Vector3.Angle(vesselState.up, desiredThrustVector);
                 var hdg = core.rover.HeadingToPos(vessel.CoM, vessel.CoM + desiredThrustVector);

--- a/MechJeb2/MechJebModuleSettings.cs
+++ b/MechJeb2/MechJebModuleSettings.cs
@@ -26,6 +26,9 @@ namespace MuMech
         [ToggleInfoItem("Hide 'Brake on Eject' in Rover Controller", InfoItem.Category.Misc), Persistent(pass = (int)Pass.Global)]
         public bool hideBrakeOnEject = false;
 
+        [ToggleInfoItem("Use only the titlebar for window dragging", InfoItem.Category.Misc), Persistent(pass = (int)Pass.Global)]
+        public bool useTitlebarDragging = false;
+
         public override void OnLoad(ConfigNode local, ConfigNode type, ConfigNode global)
         {
             base.OnLoad(local, type, global);
@@ -89,6 +92,8 @@ namespace MuMech
 
             MechJebModuleCustomWindowEditor ed = core.GetComputerModule<MechJebModuleCustomWindowEditor>();
             ed.registry.Find(i => i.id == "Toggle:Settings.hideBrakeOnEject").DrawItem();
+
+            ed.registry.Find(i => i.id == "Toggle:Settings.useTitlebarDragging").DrawItem();
             
             ed.registry.Find(i => i.id == "Toggle:Menu.useAppLauncher").DrawItem();
             if (ToolbarManager.ToolbarAvailable || core.GetComputerModule<MechJebModuleMenu>().useAppLauncher)

--- a/MechJeb2/MechJebModuleSmartASS.cs
+++ b/MechJeb2/MechJebModuleSmartASS.cs
@@ -191,6 +191,7 @@ namespace MuMech
 
                         break;
                     case Mode.SURFACE:
+                    	double val = (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); // change by 5 if the mod_key is held down, else by 1
                         GUILayout.BeginHorizontal();
                         TargetButton(Target.SURFACE_PROGRADE);
                         TargetButton(Target.SURFACE_RETROGRADE);
@@ -202,21 +203,75 @@ namespace MuMech
                         TargetButton(Target.VERTICAL_PLUS);
                         GUILayout.EndHorizontal();
                         if (target == Target.SURFACE) {
-                            GuiUtils.SimpleTextBox("HDG:", srfHdg);
-                            GuiUtils.SimpleTextBox("PIT:", srfPit);
-                            GuiUtils.SimpleTextBox("ROL:", srfRol);
+                        	GUILayout.BeginHorizontal();
+                            GuiUtils.SimpleTextBox("HDG", srfHdg, "°", 37);
+                            if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
+                            	srfHdg -= val;
+                                Engage();
+                            }
+                            if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
+                                srfHdg += val;
+                                Engage();
+                            }
+                            if (GUILayout.Button("0", GUILayout.ExpandWidth(false))) {
+                                srfHdg = 0;
+                                Engage();
+                            }
+                            if (GUILayout.Button("90", GUILayout.Width(35))) {
+                                srfHdg = 90;
+                                Engage();
+                            }
+                            GUILayout.EndHorizontal();
+                        	GUILayout.BeginHorizontal();
+                            GuiUtils.SimpleTextBox("PIT", srfPit, "°", 37);
+                            if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
+                                srfPit -= val;
+                                Engage();
+                            }
+                            if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
+                                srfPit += val;
+                                Engage();
+                            }
+                            if (GUILayout.Button("0", GUILayout.ExpandWidth(false))) {
+                                srfPit = 0;
+                                Engage();
+                            }
+                            if (GUILayout.Button("90", GUILayout.Width(35))) {
+                                srfPit = 90;
+                                Engage();
+                            }
+                            GUILayout.EndHorizontal();
+                        	GUILayout.BeginHorizontal();
+                            GuiUtils.SimpleTextBox("ROL", srfRol, "°", 37);
+                            if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
+                                srfRol -= val;
+                                Engage();
+                            }
+                            if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
+                                srfRol += val;
+                                Engage();
+                            }
+                            if (GUILayout.Button("0", GUILayout.ExpandWidth(false))) {
+                                srfRol = 0;
+                                Engage();
+                            }
+                            if (GUILayout.Button("180", GUILayout.Width(35))) {
+                                srfRol = 180;
+                                Engage();
+                            }
+                            GUILayout.EndHorizontal();
                             if (GUILayout.Button("EXECUTE")) {
                                 Engage();
                             }
                         } else if (target == Target.SURFACE_PROGRADE || target == Target.SURFACE_RETROGRADE) {
                             GUILayout.BeginHorizontal();
-                            GuiUtils.SimpleTextBox("ROL", srfVelRol, "°", 60);
+                            GuiUtils.SimpleTextBox("ROL", srfVelRol, "°", 37);
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
-                                srfVelRol -= 1;
+                                srfVelRol -= val;
                                 Engage();
                             }
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
-                                srfVelRol += 1;
+                                srfVelRol += val;
                                 Engage();
                             }
                             if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false))) {
@@ -229,13 +284,13 @@ namespace MuMech
                             }
                             GUILayout.EndHorizontal();
                             GUILayout.BeginHorizontal();
-                            GuiUtils.SimpleTextBox("PIT", srfVelPit, "°", 60);
+                            GuiUtils.SimpleTextBox("PIT", srfVelPit, "°", 37);
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
-                                srfVelPit -= 1;
+                                srfVelPit -= val;
                                 Engage();
                             }
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
-                                srfVelPit += 1;
+                                srfVelPit += val;
                                 Engage();
                             }
                             if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false))) {
@@ -248,13 +303,13 @@ namespace MuMech
                             }
                             GUILayout.EndHorizontal();
                             GUILayout.BeginHorizontal();
-                            GuiUtils.SimpleTextBox("YAW", srfVelYaw, "°", 60);
+                            GuiUtils.SimpleTextBox("YAW", srfVelYaw, "°", 37);
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
-                                srfVelYaw -= 1;
+                                srfVelYaw -= val;
                                 Engage();
                             }
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
-                                srfVelYaw += 1;
+                                srfVelYaw += val;
                                 Engage();
                             }
                             if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false))) {

--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -586,7 +586,7 @@ namespace MuMech
 						}
 					}
 					
-					if(Event.current.type == EventType.Repaint)
+					if (Event.current.type == EventType.Repaint)
 					{
 						waypointRects[i] = GUILayoutUtility.GetLastRect();
 						//if (i == ap.WaypointIndex) { Debug.Log(Event.current.type.ToString() + " - " + waypointRects[i].ToString() + " - " + scroll.ToString()); }


### PR DESCRIPTION
added a setting to limit window dragability to the titlebar, default off
changed the error playing a role whenever Force Roll in the ascent ap is using PYR or not because switching seemed often worse than sticking to either
shrunk the width of the SASS' surface input fields and also added the Heading Pitch Roll control also have +-0 and an additional one too, also made +/- do a change of 5 instead of 1 when the mod_key is held down when clicking
