### PR TITLE
DriveCoastToApoapsis() tweaking

### DIFF
--- a/MechJeb2/MechJebModuleDockingAutopilot.cs
+++ b/MechJeb2/MechJebModuleDockingAutopilot.cs
@@ -132,7 +132,7 @@ namespace MuMech
             Vector3d targetVel = core.target.TargetOrbit.GetVel();
 
             double zApproachSpeed = MaxSpeedForDistance(Math.Max(zSep - acquireRange, 0), -zAxis);
-            double latApproachSpeed = MaxSpeedForDistance(lateralSep.magnitude, -lateralSep); // TODO check if it should be +lateralSep
+			double latApproachSpeed = MaxSpeedForDistance(lateralSep.magnitude > 1.0 ? Math.Pow(lateralSep.magnitude, 2.0) : lateralSep.magnitude, -lateralSep); // TODO check if it should be +lateralSep
 
             bool align = true;
 


### PR DESCRIPTION
- Ascent Autopilot recomputes desiredFlightPathAngle as needed (instead
of recording lastDesiredFlightPathAngle ) in DriveCoastToApoapsis()
- Ascent Autopilot freezes all steering in DriveCoastToApoapsis() when
performing an apoapsis boost (ThrottleToRaiseApoapsis())
- Docking Autopilot gives increased priority to closing lateral distance
to docking port when further away than 1 meter from docking axis.

