### PR TITLE
Improvements

### DIFF
--- a/MechJeb2/GuiUtils.cs
+++ b/MechJeb2/GuiUtils.cs
@@ -450,12 +450,16 @@ namespace MuMech
             return parsedSomething;
         }
         
-        public static double FromToETA(Vector3 From, Vector3 To, double Speed = 0) {
+        public static double ArcDistance(Vector3 From, Vector3 To) {
         	double a = (FlightGlobals.ActiveVessel.mainBody.transform.position - From).magnitude;
         	double b = (FlightGlobals.ActiveVessel.mainBody.transform.position - To).magnitude;
         	double c = Vector3d.Distance(From, To);
         	double ang = Math.Acos(((a * a + b * b) - c * c) / (double)(2f * a * b));
-        	return ang * FlightGlobals.ActiveVessel.mainBody.Radius / (Speed > 0 ? Speed : FlightGlobals.ActiveVessel.horizontalSrfSpeed);
+        	return ang * FlightGlobals.ActiveVessel.mainBody.Radius;
+        }
+        
+        public static double FromToETA(Vector3 From, Vector3 To, double Speed = 0) {
+        	return ArcDistance(From, To) / (Speed > 0 ? Speed : FlightGlobals.ActiveVessel.horizontalSrfSpeed);
         }
 
         public static bool MouseIsOverWindow(MechJebCore core)

--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -180,7 +180,7 @@ namespace MuMech
             if (autoThrottle && orbit.ApA > desiredOrbitAltitude) mode = AscentMode.COAST_TO_APOAPSIS;
 
             //during the vertical ascent we just thrust straight up at max throttle
-            if (forceRoll && !correctiveSteering && vesselState.altitudeTrue > 25)
+            if (forceRoll && vesselState.altitudeTrue > 50)
             { // pre-align roll unless correctiveSteering is active as it would just interfere with that
                 core.attitude.attitudeTo(90 - desiredInclination, 90, verticalRoll, this);
             }

--- a/MechJeb2/MechJebModuleAscentPathEditor.cs
+++ b/MechJeb2/MechJebModuleAscentPathEditor.cs
@@ -44,7 +44,8 @@ namespace MuMech
 
             GUILayout.BeginHorizontal();
             path.autoPath = GUILayout.Toggle(path.autoPath, "Automatic Altitude Turn", GUILayout.ExpandWidth(false));
-            if (path.autoPath) path.autoTurnPerc = Mathf.Floor(GUILayout.HorizontalSlider(path.autoTurnPerc, 0.01f, 1.05f) * 200f + 0.5f) / 200f;
+            if (path.autoPath) path.autoTurnPerc = Mathf.Floor(GUILayout.HorizontalSlider(path.autoTurnPerc * 200f, 1f, 210.5f)) / 200f;
+            // 1 to 200 / 200 = 0.5% to 105%, without this mess would the slider cause lots of garbage floats like 0.9999864
             GUILayout.EndHorizontal();
 
             if (path.autoPath)

--- a/MechJeb2/MechJebModuleRoverController.cs
+++ b/MechJeb2/MechJebModuleRoverController.cs
@@ -237,7 +237,7 @@ namespace MuMech
 					var brakeFactor = Math.Max((curSpeed - minSpeed) * 1, 3);
 					var newSpeed = Math.Min(maxSpeed, Math.Max((distance - wp.Radius) / brakeFactor, minSpeed)); // brake when getting closer
 					newSpeed = (newSpeed > turnSpeed ? TurningSpeed(newSpeed, headingErr) : newSpeed); // reduce speed when turning a lot
-					if (LimitAcceleration) { newSpeed = curSpeed + Mathf.Clamp((float)(newSpeed - curSpeed), -1.5f, 0.5f); }
+//					if (LimitAcceleration) { newSpeed = curSpeed + Mathf.Clamp((float)(newSpeed - curSpeed), -1.5f, 0.5f); }
 //					newSpeed = tgtSpeed + Mathf.Clamp((float)(newSpeed - tgtSpeed), -Time.deltaTime * 8f, Time.deltaTime * 2f);
 					var radius = Math.Max(wp.Radius, 10);
 					if (distance < radius)
@@ -336,8 +336,10 @@ namespace MuMech
 				if (s.wheelThrottle == s.wheelThrottleTrim || FlightGlobals.ActiveVessel != vessel)
 				{
 					float act = (float)speedPID.Compute(speedErr);
-					s.wheelThrottle = !LimitAcceleration ? Mathf.Clamp((float)act, -1, 1) : // I think I'm using these ( ? : ) a bit too much
-						(traction == 0 ? 0 : (act < 0 ? Mathf.Clamp(act, -1f, 1f) : (lastThrottle + Mathf.Clamp(act - lastThrottle, -0.005f, 0.005f)) * (traction < tractionLimit ? -1 : 1)));
+					s.wheelThrottle = (!LimitAcceleration ? Mathf.Clamp(act, -1, 1) : // I think I'm using these ( ? : ) a bit too much
+						(traction == 0 ? 0 : (act < 0 ? Mathf.Clamp(act, -1f, 1f) : (lastThrottle + Mathf.Clamp(act - lastThrottle, -0.01f, 0.01f)) * (traction < tractionLimit ? -1 : 1))));
+//						(lastThrottle + Mathf.Clamp(act, -0.01f, 0.01f)));
+//					Debug.Log(s.wheelThrottle + Mathf.Clamp(act, -0.01f, 0.01f));
 					if (curSpeed < 0 & s.wheelThrottle < 0) { s.wheelThrottle = 0; } // don't go backwards
 //					if (Mathf.Sign(act) + Mathf.Sign(s.wheelThrottle) == 0) { s.wheelThrottle = Mathf.Clamp(act, -1f, 1f); }
 					if (speedErr < -1 && StabilityControl && Mathf.Sign(s.wheelThrottle) + Mathf.Sign((float)curSpeed) == 0) { // StabilityControl && traction > 50 && 
@@ -347,7 +349,7 @@ namespace MuMech
 //					else if (!stabilityControl || traction <= 50 || speedErr > -0.2 || Mathf.Sign(s.wheelThrottle) + Mathf.Sign((float)curSpeed) != 0) {
 //						vessel.ActionGroups.SetGroup(KSPActionGroup.Brakes, (GameSettings.BRAKES.GetKey() && vessel.isActiveVessel));
 //					}
-					lastThrottle = s.wheelThrottle;
+					lastThrottle = Mathf.Clamp(s.wheelThrottle, -1, 1);
 				}
 			}
 			

--- a/MechJeb2/MechJebModuleRoverController.cs
+++ b/MechJeb2/MechJebModuleRoverController.cs
@@ -32,7 +32,7 @@ namespace MuMech
 //			}
 //		}
 
-		[EditableInfoItem("Heading", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]
+		[EditableInfoItem("Heading", InfoItem.Category.Rover, width = 40), Persistent(pass = (int)Pass.Local)]
 		public EditableDouble heading = 0;
 
 //		protected bool controlSpeed = false;
@@ -54,7 +54,7 @@ namespace MuMech
 //			}
 //		}
 
-		[EditableInfoItem("Speed", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]
+		[EditableInfoItem("Speed", InfoItem.Category.Rover, width = 40), Persistent(pass = (int)Pass.Local)]
 		public EditableDouble speed = 10;
 
         [ToggleInfoItem("Brake on Pilot Eject", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]

--- a/MechJeb2/MechJebModuleRoverWindow.cs
+++ b/MechJeb2/MechJebModuleRoverWindow.cs
@@ -109,22 +109,16 @@ namespace MuMech
 			GUILayout.EndHorizontal();
 			
 			GUILayout.BeginHorizontal();
-			if (autopilot.WaypointIndex == -1) {
-				if (autopilot.Waypoints.Count > 0) {
+			if (autopilot.Waypoints.Count > 0) {
+				if (!autopilot.ControlHeading || !autopilot.ControlSpeed) {
 					if (GUILayout.Button("Follow")) {
 						autopilot.WaypointIndex = 0;
 						autopilot.ControlHeading = autopilot.ControlSpeed = true;
 						autopilot.LoopWaypoints = alt;
 					}
 				}
-				else {
-//					if (GUILayout.Button("No Waypoints")) {
-//					}
-				}
-			}
-			else {
-				if (GUILayout.Button("Stop")) {
-					autopilot.WaypointIndex = -1;
+				else if (GUILayout.Button("Stop")) {
+					// autopilot.WaypointIndex = -1; // more annoying than helpful
 					autopilot.ControlHeading = autopilot.ControlSpeed = autopilot.LoopWaypoints = false;
 				}
 			}

--- a/MechJeb2/MechJebModuleRoverWindow.cs
+++ b/MechJeb2/MechJebModuleRoverWindow.cs
@@ -42,10 +42,18 @@ namespace MuMech
 			}
 			
 			ed.registry.Find(i => i.id == "Toggle:RoverController.ControlHeading").DrawItem();
+			GUILayout.BeginHorizontal();
 			ed.registry.Find(i => i.id == "Editable:RoverController.heading").DrawItem();
+			if (GUILayout.Button("-", GUILayout.Width(18))) { autopilot.heading.val -= (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); }
+			if (GUILayout.Button("+", GUILayout.Width(18))) { autopilot.heading.val += (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); }
+			GUILayout.EndHorizontal();
 			ed.registry.Find(i => i.id == "Value:RoverController.headingErr").DrawItem();
 			ed.registry.Find(i => i.id == "Toggle:RoverController.ControlSpeed").DrawItem();
+			GUILayout.BeginHorizontal();
 			ed.registry.Find(i => i.id == "Editable:RoverController.speed").DrawItem();
+			if (GUILayout.Button("-", GUILayout.Width(18))) { autopilot.speed.val -= (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); }
+			if (GUILayout.Button("+", GUILayout.Width(18))) { autopilot.speed.val += (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); }
+			GUILayout.EndHorizontal();
 			ed.registry.Find(i => i.id == "Value:RoverController.speedErr").DrawItem();
             ed.registry.Find(i => i.id == "Toggle:RoverController.StabilityControl").DrawItem();
             

--- a/MechJeb2/MechJebModuleSmartASS.cs
+++ b/MechJeb2/MechJebModuleSmartASS.cs
@@ -214,57 +214,57 @@ namespace MuMech
                             GuiUtils.SimpleTextBox("HDG", srfHdg, "°", 37);
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
                             	srfHdg -= val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
                                 srfHdg += val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false))) {
                                 srfHdg = 0;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("90", GUILayout.Width(35))) {
                                 srfHdg = 90;
-                                Engage();
+                                Engage(false);
                             }
                             GUILayout.EndHorizontal();
                         	GUILayout.BeginHorizontal();
                             GuiUtils.SimpleTextBox("PIT", srfPit, "°", 37);
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
                                 srfPit -= val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
                                 srfPit += val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false))) {
                                 srfPit = 0;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("90", GUILayout.Width(35))) {
                                 srfPit = 90;
-                                Engage();
+                                Engage(false);
                             }
                             GUILayout.EndHorizontal();
                         	GUILayout.BeginHorizontal();
                             GuiUtils.SimpleTextBox("ROL", srfRol, "°", 37);
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
                                 srfRol -= val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
                                 srfRol += val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false))) {
                                 srfRol = 0;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("180", GUILayout.Width(35))) {
                                 srfRol = 180;
-                                Engage();
+                                Engage(false);
                             }
                             GUILayout.EndHorizontal();
                             if (GUILayout.Button("EXECUTE")) {
@@ -275,57 +275,57 @@ namespace MuMech
                             GuiUtils.SimpleTextBox("ROL", srfVelRol, "°", 37);
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
                                 srfVelRol -= val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
                                 srfVelRol += val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false))) {
                                 srfVelRol = -vesselState.vesselRoll.value;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false))) {
                                 srfVelRol = 0;
-                                Engage();
+                                Engage(false);
                             }
                             GUILayout.EndHorizontal();
                             GUILayout.BeginHorizontal();
                             GuiUtils.SimpleTextBox("PIT", srfVelPit, "°", 37);
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
                                 srfVelPit -= val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
                                 srfVelPit += val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false))) {
                                 srfVelPit = vesselState.AoA.value;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false))) {
                                 srfVelPit = 0;
-                                Engage();
+                                Engage(false);
                             }
                             GUILayout.EndHorizontal();
                             GUILayout.BeginHorizontal();
                             GuiUtils.SimpleTextBox("YAW", srfVelYaw, "°", 37);
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false))) {
                                 srfVelYaw -= val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false))) {
                                 srfVelYaw += val;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false))) {
                                 srfVelYaw = -vesselState.AoS.value;
-                                Engage();
+                                Engage(false);
                             }
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false))) {
                                 srfVelYaw = 0;
-                                Engage();
+                                Engage(false);
                             }
                             GUILayout.EndHorizontal();
                         }
@@ -376,7 +376,7 @@ namespace MuMech
             base.WindowGUI(windowID);
         }
 
-        public void Engage()
+        public void Engage(bool resetPID = true)
         {
             Quaternion attitude = new Quaternion();
             Vector3d direction = Vector3d.zero;
@@ -492,7 +492,7 @@ namespace MuMech
             else
                 core.attitude.attitudeTo(attitude, reference, this);
 
-            core.attitude.pid.Reset();
+            if (resetPID) { core.attitude.pid.Reset(); }
         }
 
         public override GUILayoutOption[] WindowOptions()

--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -528,6 +528,15 @@ namespace MuMech
 			}
 		}
 
+		public MechJebWaypoint SelectedWaypoint() {
+			return (selIndex > -1 ? ap.Waypoints[selIndex] : null);
+		}
+		
+		public int SelectedWaypointIndex {
+			get { return selIndex; }
+			set { selIndex = value; }
+		}
+		
 		public override GUILayoutOption[] WindowOptions()
 		{
 			return new GUILayoutOption[] { GUILayout.Width(500), GUILayout.Height(400) };
@@ -545,20 +554,20 @@ namespace MuMech
 				for (int i = 0; i < ap.Waypoints.Count; i++)
 				{
 					var wp = ap.Waypoints[i];
+					var maxSpeed = (wp.MaxSpeed > 0 ? wp.MaxSpeed : ap.speed.val);
+					var minSpeed = (wp.MinSpeed > 0 ? wp.MinSpeed : 0);
 					if (MapView.MapIsEnabled && i == selIndex)
 					{
-						MuMech.GLUtils.DrawMapViewGroundMarker(mainBody, wp.Latitude, wp.Longitude, Color.red, (DateTime.Now.Second + DateTime.Now.Millisecond / 1000f) * 6, mainBody.Radius / 250);
+						MuMech.GLUtils.DrawMapViewGroundMarker(mainBody, wp.Latitude, wp.Longitude, Color.red, (DateTime.Now.Second + DateTime.Now.Millisecond / 1000f) * 6, mainBody.Radius / 100);
 					}
 					if (i >= ap.WaypointIndex)
 					{
 						if (ap.WaypointIndex > -1)
 						{
-							eta += GuiUtils.FromToETA((i == ap.WaypointIndex ? vessel.CoM : (Vector3)ap.Waypoints[i - 1].Position), (Vector3)wp.Position, (i == ap.WaypointIndex ? (float)Math.Round(ap.etaSpeed, 1) : wp.MaxSpeed));
+							eta += GuiUtils.FromToETA((i == ap.WaypointIndex ? vessel.CoM : (Vector3)ap.Waypoints[i - 1].Position), (Vector3)wp.Position, (ap.etaSpeed > 0.1 && ap.etaSpeed < maxSpeed ? (float)Math.Round(ap.etaSpeed, 1) : maxSpeed));
 						}
 						dist += Vector3.Distance((i == ap.WaypointIndex || (ap.WaypointIndex == -1 && i == 0) ? vessel.CoM : (Vector3)ap.Waypoints[i - 1].Position), (Vector3)wp.Position);
 					}
-					var maxSpeed = (wp.MaxSpeed > 0 ? wp.MaxSpeed : ap.speed.val);
-					var minSpeed = (wp.MinSpeed > 0 ? wp.MinSpeed : 0);
 					string str = string.Format("[{0}] - {1} - R: {2:F1} m\n       S: {3:F0} ~ {4:F0} - D: {5}m - ETA: {6}", i + 1, wp.GetNameWithCoords(), wp.Radius,
 					                           minSpeed, maxSpeed, MuUtils.ToSI(dist, -1), GuiUtils.TimeToDHMS(eta));
 					GUI.backgroundColor = (i == ap.WaypointIndex ? new Color(0.5f, 1f, 0.5f) : Color.white);
@@ -600,24 +609,24 @@ namespace MuMech
 						GUILayout.Label("  Radius: ", GUILayout.ExpandWidth(false));
 						tmpRadius = GUILayout.TextField(tmpRadius, GUILayout.Width(50));
 						float.TryParse(tmpRadius, out wp.Radius);
-						if (GUILayout.Button("A", GUILayout.ExpandWidth(false))) { ap.Waypoints.ForEach(fewp => fewp.Radius = wp.Radius); }
+						if (GUILayout.Button("A", GUILayout.ExpandWidth(false))) { ap.Waypoints.GetRange(i, ap.Waypoints.Count).ForEach(fewp => fewp.Radius = wp.Radius); }
 						
 						GUILayout.Label("- Speed: ", GUILayout.ExpandWidth(false));
 						tmpMinSpeed = GUILayout.TextField(tmpMinSpeed, GUILayout.Width(40));
 						float.TryParse(tmpMinSpeed, out wp.MinSpeed);
-						if (GUILayout.Button("A", GUILayout.ExpandWidth(false))) { ap.Waypoints.ForEach(fewp => fewp.MinSpeed = wp.MinSpeed); }
+						if (GUILayout.Button("A", GUILayout.ExpandWidth(false))) { ap.Waypoints.GetRange(i, ap.Waypoints.Count).ForEach(fewp => fewp.MinSpeed = wp.MinSpeed); }
 						
 						GUILayout.Label(" - ", GUILayout.ExpandWidth(false));
 						tmpMaxSpeed = GUILayout.TextField(tmpMaxSpeed, GUILayout.Width(40));
 						float.TryParse(tmpMaxSpeed, out wp.MaxSpeed);
-						if (GUILayout.Button("A", GUILayout.ExpandWidth(false))) { ap.Waypoints.ForEach(fewp => fewp.MaxSpeed = wp.MaxSpeed); }
+						if (GUILayout.Button("A", GUILayout.ExpandWidth(false))) { ap.Waypoints.GetRange(i, ap.Waypoints.Count).ForEach(fewp => fewp.MaxSpeed = wp.MaxSpeed); }
 						
 						GUILayout.FlexibleSpace();
 						if (GUILayout.Button("QS", (wp.Quicksave ? styleQuicksave : styleInactive), GUILayout.ExpandWidth(false)))
 						{
 							if (alt)
 							{
-								ap.Waypoints.ForEach(fewp => fewp.Quicksave = !fewp.Quicksave);
+								ap.Waypoints.GetRange(i, ap.Waypoints.Count).ForEach(fewp => fewp.Quicksave = !fewp.Quicksave);
 							}
 							else
 							{


### PR DESCRIPTION
+- buttons for rover speed and heading
changed ascent path gravity turn starting auto altitude range to 0.5 ~ 105 %
enabled rolling at straight ascent for ascent ap when using force roll
small change to how the rover's limitAcceleration works
small changes to the waypoint system to allow easier external manipulation for pathfinders and such
made the rover AP waypoint Follow/Stop button not reset waypoint index anymore and instead just toggle controlHeading/Speed
made SASS no longer reset the PID when the +- adjustment buttons for Surface mode are used to prevent reset attitude drops, Execute still resets for when the PID needs a kick
added function ArcDistance to GuiUtils which returns the distance between two vectors on the same planet as estimated surface distance instead of straight line distance