### PR TITLE
Updated Makefile to check if XDG_DATA_HOME and/or KSPDIR are defined.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,18 @@ ifeq ($(OS),Windows_NT)
 else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Linux)
-		XDG_DATA_HOME := ${HOME}/.local/share
-		KSPDIR := ${XDG_DATA_HOME}/Steam/SteamApps/common/Kerbal Space Program
+		ifndef XDG_DATA_HOME
+			XDG_DATA_HOME := ${HOME}/.local/share
+		endif
+		ifndef KSPDIR
+			KSPDIR := ${XDG_DATA_HOME}/Steam/SteamApps/common/Kerbal Space Program
+		endif
 		MANAGED := ${KSPDIR}/KSP_Data/Managed/
 	endif
 	ifeq ($(UNAME_S),Darwin)
-		KSPDIR  := ${HOME}/Library/Application Support/Steam/SteamApps/common/Kerbal Space Program
+		ifndef KSPDIR
+			KSPDIR  := ${HOME}/Library/Application Support/Steam/SteamApps/common/Kerbal Space Program
+		endif
 		MANAGED := ${KSPDIR}/KSP.app/Contents/Data/Managed/
 	endif
 endif


### PR DESCRIPTION
I ran into problems compiling MechJeb2 from the makefile because my Steam library is not in the standard location (it is on a separate partition from my home directory). I've added a few lines to the makefile to check if the user has set the variables XDG_DATA_HOME and/or KSPDIR already. If so, Make will use those values instead of guessing.

Users in a similar can set the variable KSPDIR in their shell and the makefile will work normally, even without XDG_DATA_HOME set.  If they have XDG_DATA_HOME set to something other than what the makefile expects, and the KSP directory is in the usual place with respect to XDG_DATA_HOME, the makefile will also run normally.