### PR TITLE
Lcg/low altitude landing safety

### DIFF
--- a/MechJeb2/LandingAutopilot/CourseCorrection.cs
+++ b/MechJeb2/LandingAutopilot/CourseCorrection.cs
@@ -36,6 +36,13 @@ namespace MuMech
                     return new CoastToDeceleration(core);
                 }
 
+                // If we're off course, but already too low, skip the course correction
+                if (vesselState.altitudeASL < core.landing.DecelerationEndAltitude() + 5)
+                {
+                    return new DecelerationBurn(core);
+                }
+
+
                 // If a parachute has already been deployed then we will not be able to control attitude anyway, so move back to the coast to deceleration step.
                 if (vesselState.parachuteDeployed)
                 {


### PR DESCRIPTION
if we press one of the landing buttons when we're below the deceleration
burn altitude bad things can happen.

* if we're off course by > 150m then we get stuck in CourseCorrection and
  will reliably lithobrake
* i've seen craft get stuck in "coasting towards deceleration burn" and
  lithobrake but replication is unreliable

to address both cases, add shortcuts so that we wind up in the logic
in DecelerationBurn that selects KillHorizontalVelocity or FinalDescent
correctly.

also I've had two craft lithobrake at 50x warp, which is not reliably
reproducable and happens too fast to see what mode its in.  it may be
due to the 10-seconds-to-impact extrapolation not taking into account
gravitational acceleration on very low initial velocities and low
heights.