### PR TITLE
Add InfoItems for periapsis in target SoI and minimum DV required for capture by target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ MECHJEBFILES := $(wildcard MechJeb2/*.cs) \
 	$(wildcard MechJeb2/FlyingSim/*.cs)
 
 RESGEN2 := resgen2
-GMCS    := gmcs
+GMCS    ?= gmcs
 GIT     := git
 TAR     := tar
 ZIP     := zip

--- a/MechJeb2/MechJebModuleInfoItems.cs
+++ b/MechJeb2/MechJebModuleInfoItems.cs
@@ -545,6 +545,39 @@ namespace MuMech
             return MuUtils.ToSI(relVel, -1) + "m/s";
         }
 
+		[ValueInfoItem("Periapsis in target SoI", InfoItem.Category.Misc)]
+		public string PeriapsisInTargetSOI()
+		{
+			if (!core.target.NormalTargetExists) return "N/A";
+
+			Orbit o = vessel.orbit;
+			while (o != null && o.referenceBody != vessel.targetObject)
+				o = o.nextPatch;
+
+			if (o == null) return "N/A";
+
+			return MuUtils.ToSI(o.PeA, -1) + "m";
+		}
+
+		[ValueInfoItem("ΔV for capture by target", InfoItem.Category.Misc)]
+		public string TargetCaptureDV()
+		{
+			if (!core.target.NormalTargetExists) return "N/A";
+
+			Orbit o = vessel.orbit;
+			while (o != null && o.referenceBody != vessel.targetObject)
+				o = o.nextPatch;
+
+			if (o == null) return "N/A";
+
+			double smaCapture = (o.PeR + o.referenceBody.sphereOfInfluence) / 2;
+			double velAtPeriapsis = Math.Sqrt(o.referenceBody.gravParameter * (2 / o.PeR - 1 / o.semiMajorAxis));
+			double velCapture = Math.Sqrt(o.referenceBody.gravParameter * (2 / o.PeR - 1 / smaCapture));
+
+			return MuUtils.ToSI(velAtPeriapsis - velCapture, -1) + "m/s";
+		}
+
+
         [ValueInfoItem("Target apoapsis", InfoItem.Category.Target)]
         public string TargetApoapsis()
         {


### PR DESCRIPTION
So we don't have to check the map view to see the periapsis when doing an interplanetary transfer.

Also ArchLinux uses mcs instead of gmcs, the compiler can be overridden by an environment variable.