### PR TITLE
Added 'toggle ascent guidance' window item button and made 'Extend all solar panels' a toggle button

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -61,6 +61,26 @@ namespace MuMech
             }
         }
 
+        [GeneralInfoItem("Toggle Ascent Navball Guidance", InfoItem.Category.Misc, showInEditor = false)]
+        public void ToggleAscentNavballGuidanceInfoItem()
+        {
+            if (showingGuidance)
+            {
+                if (GUILayout.Button("Hide ascent navball guidance"))
+                {
+                    core.target.Unset();
+                }
+            }
+            else
+            {
+                if (GUILayout.Button("Show ascent navball guidance"))
+                {
+                    core.target.SetDirectionTarget(TARGET_NAME);
+                }
+            }
+        }
+
+
         protected override void WindowGUI(int windowID)
         {
             GUILayout.BeginVertical();

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -14,6 +14,7 @@ namespace MuMech
         public MechJebModuleAscentGuidance(MechJebCore core) : base(core) { }
 
         protected const string TARGET_NAME = "Ascent Path Guidance";
+        protected bool showingGuidance { get { return core.target.Target != null && core.target.Name == TARGET_NAME; } }
 
         public IAscentPath ascentPath = null;
 
@@ -50,7 +51,7 @@ namespace MuMech
         {
             if (ascentPath == null) return;
 
-            if (core.target.Target != null && core.target.Name == TARGET_NAME)
+            if (showingGuidance)
             {
                 double angle = Math.PI / 180 * ascentPath.FlightPathAngle(vesselState.altitudeASL, vesselState.speedSurface);
                 double heading = Math.PI / 180 * OrbitalManeuverCalculator.HeadingForInclination(desiredInclination, vesselState.latitude);
@@ -63,8 +64,6 @@ namespace MuMech
         protected override void WindowGUI(int windowID)
         {
             GUILayout.BeginVertical();
-
-            bool showingGuidance = (core.target.Target != null && core.target.Name == TARGET_NAME);
 
             if (showingGuidance)
             {

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -82,15 +82,8 @@ namespace MuMech
         {
             GUILayout.BeginVertical();
 
-            if (showingGuidance)
-            {
-                GUILayout.Label("The purple circle on the navball points along the ascent path.");
-                if (GUILayout.Button("Stop showing navball guidance")) core.target.Unset();
-            }
-            else if (GUILayout.Button("Show navball ascent path guidance"))
-            {
-                core.target.SetDirectionTarget(TARGET_NAME);
-            }
+            GUILayout.Label("When guidance is enabled, the purple circle on the navball points along the ascent path.");
+            ToggleAscentNavballGuidanceInfoItem();
 
             if (autopilot != null)
             {

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -39,7 +39,8 @@ namespace MuMech
 
         public override void OnModuleDisabled()
         {
-            if (core.target.NormalTargetExists && (core.target.Name == TARGET_NAME)) core.target.Unset();
+            if (core.target.NormalTargetExists && (core.target.Name == TARGET_NAME))
+                core.target.Unset();
             launchingToInterplanetary = false;
             launchingToPlane = false;
             launchingToRendezvous = false;

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -68,16 +68,12 @@ namespace MuMech
             if (showingGuidance)
             {
                 if (GUILayout.Button("Hide ascent navball guidance"))
-                {
                     core.target.Unset();
-                }
             }
             else
             {
                 if (GUILayout.Button("Show ascent navball guidance"))
-                {
                     core.target.SetDirectionTarget(TARGET_NAME);
-                }
             }
         }
 

--- a/MechJeb2/MechJebModuleSolarPanelController.cs
+++ b/MechJeb2/MechJebModuleSolarPanelController.cs
@@ -34,12 +34,22 @@ namespace MuMech
             return sa.Events["Extend"].active || sa.Events["Retract"].active;
         }
 
-        [GeneralInfoItem("Extend all solar panels", InfoItem.Category.Misc, showInEditor = false)]
-        public void ExtendAllSolarPanelsInfoItem()
+        [GeneralInfoItem("Toggle all solar panels", InfoItem.Category.Misc, showInEditor = false)]
+        public void ToggleAllSolarPanelsInfoItem()
         {
-            if (GUILayout.Button("Extend all solar panels"))
+            if (AllRetracted())
             {
-                ExtendAll();
+                if (GUILayout.Button("Extend all solar panels"))
+                {
+                    ExtendAll();
+                }
+            }
+            else
+            {
+                if (GUILayout.Button("Retract all solar panels"))
+                {
+                    RetractAll();
+                }
             }
         }
 
@@ -58,15 +68,6 @@ namespace MuMech
                         sa.Extend();
                     }
                 }
-            }
-        }
-
-        [GeneralInfoItem("Retract all solar panels", InfoItem.Category.Misc, showInEditor = false)]
-        public void RetractAllSolarPanelsInfoItem()
-        {
-            if (GUILayout.Button("Retract all solar panels"))
-            {
-                RetractAll();
             }
         }
 


### PR DESCRIPTION
To make it easier to have a custom window with some of the functionality of the Ascent Guidance, I've expose the toggle ascent guidance as a button that can be exposed on custom windows.

Note that to simplify and reduce duplicated code, the information label has been modified, though this has the bonus side effect of keeping the positioning of the UI within in the ascent guidance window stable:

![image](https://cloud.githubusercontent.com/assets/1076923/9746979/e2c6687a-5672-11e5-97e6-235a7f59fb4e.png)

On this fork there is also a change that makes merges the 'Extend/Retract all solar panels' button a single toggle button rather two seperate buttons.