### PR TITLE
Fix for NavBall target not updating when AscentGuidance window is hidden

### DIFF
--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -82,32 +82,75 @@ namespace MuMech
         AscentMode mode;
         bool placedCircularizeNode = false;
         private double lastTMinus = 999;
+        private bool engaged = false;
 
-
-        public override void OnModuleEnabled()
-        {
-            if (autodeploySolarPanels && mainBody.atmosphere)
-                mode = AscentMode.RETRACT_SOLAR_PANELS;
-            else
-                mode = AscentMode.VERTICAL_ASCENT;
-
-            placedCircularizeNode = false;
-
-            core.attitude.users.Add(this);
-            core.thrust.users.Add(this);
-            if (autostage) core.staging.users.Add(this);
-        }
 
         public override void OnModuleDisabled()
         {
-            core.attitude.attitudeDeactivate();
-            core.thrust.ThrustOff();
-            core.thrust.users.Remove(this);
-            core.staging.users.Remove(this);
+            Engaged = false;
+            NavBallGuidance = false;
+        }
 
-            if (placedCircularizeNode) core.node.Abort();
+        public bool Engaged
+        {
+            get
+            {
+                return engaged;
+            }
+            set
+            {
+                if (value)
+                {
+                    engaged = true;
 
-            status = "Off";
+                    if (autodeploySolarPanels && mainBody.atmosphere)
+                        mode = AscentMode.RETRACT_SOLAR_PANELS;
+                    else
+                        mode = AscentMode.VERTICAL_ASCENT;
+
+                    placedCircularizeNode = false;
+
+                    core.attitude.users.Add(this);
+                    core.thrust.users.Add(this);
+                    if (autostage) core.staging.users.Add(this);
+                }
+                else
+                {
+                    engaged = false;
+
+                    core.attitude.attitudeDeactivate();
+                    core.thrust.ThrustOff();
+                    core.thrust.users.Remove(this);
+                    core.staging.users.Remove(this);
+
+                    if (placedCircularizeNode) core.node.Abort();
+
+                    status = "Off";
+
+                }
+            }
+        }
+
+        protected const string TARGET_NAME = "Ascent Path Guidance";
+
+        public bool NavBallGuidance
+        {
+            get
+            {
+                return core.target.Target != null && core.target.Name == TARGET_NAME;
+            }
+            set
+            {
+                if (value)
+                {
+                    core.target.SetDirectionTarget(TARGET_NAME);
+                }
+                else
+                {
+                    core.target.Unset();
+                }
+
+            }
         }
 
         public void StartCountdown(double time)
@@ -119,47 +162,63 @@ namespace MuMech
 
         public override void OnFixedUpdate()
         {
-            if (timedLaunch)
+            if (NavBallGuidance)
             {
-                if (tMinus < 3 * vesselState.deltaT || (tMinus > 10.0 && lastTMinus < 1.0))
+                double angle = Math.PI / 180 * ascentPath.FlightPathAngle(vesselState.altitudeASL, vesselState.speedSurface);
+                double heading = Math.PI / 180 * OrbitalManeuverCalculator.HeadingForInclination(desiredInclination, vesselState.latitude);
+                Vector3d horizontalDir = Math.Cos(heading) * vesselState.north + Math.Sin(heading) * vesselState.east;
+                Vector3d dir = Math.Cos(angle) * horizontalDir + Math.Sin(angle) * vesselState.up;
+                core.target.UpdateDirectionTarget(dir);
+            }
+
+            if (Engaged)
+            {
+                if (timedLaunch)
                 {
-                    if (enabled && vesselState.thrustAvailable < 10E-4) // only stage if we have no engines active
-                        Staging.ActivateNextStage();
-                    timedLaunch = false;
+                    if (tMinus < 3 * vesselState.deltaT || (tMinus > 10.0 && lastTMinus < 1.0))
+                    {
+                        if (enabled && vesselState.thrustAvailable < 10E-4) // only stage if we have no engines active
+                            Staging.ActivateNextStage();
+                        timedLaunch = false;
+                    }
+                    else
+                    {
+                        if (core.node.autowarp)
+                            core.warp.WarpToUT(launchTime - warpCountDown);
+                    }
+                    lastTMinus = tMinus;
                 }
-                else
-                {
-                    if (core.node.autowarp)
-                        core.warp.WarpToUT(launchTime - warpCountDown);
-                }
-                lastTMinus = tMinus;
             }
         }
 
         public override void Drive(FlightCtrlState s)
         {
-            limitingAoA = false;
-            switch (mode)
+            if (Engaged)
             {
-                case AscentMode.RETRACT_SOLAR_PANELS:
-                    DriveRetractSolarPanels(s);
-                    break;
 
-                case AscentMode.VERTICAL_ASCENT:
-                    DriveVerticalAscent(s);
-                    break;
+                limitingAoA = false;
+                switch (mode)
+                {
+                    case AscentMode.RETRACT_SOLAR_PANELS:
+                        DriveRetractSolarPanels(s);
+                        break;
 
-                case AscentMode.GRAVITY_TURN:
-                    DriveGravityTurn(s);
-                    break;
+                    case AscentMode.VERTICAL_ASCENT:
+                        DriveVerticalAscent(s);
+                        break;
 
-                case AscentMode.COAST_TO_APOAPSIS:
-                    DriveCoastToApoapsis(s);
-                    break;
+                    case AscentMode.GRAVITY_TURN:
+                        DriveGravityTurn(s);
+                        break;
 
-                case AscentMode.CIRCULARIZE:
-                    DriveCircularizationBurn(s);
-                    break;
+                    case AscentMode.COAST_TO_APOAPSIS:
+                        DriveCoastToApoapsis(s);
+                        break;
+
+                    case AscentMode.CIRCULARIZE:
+                        DriveCircularizationBurn(s);
+                        break;
+                }
             }
         }
 

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -13,11 +13,6 @@ namespace MuMech
     {
         public MechJebModuleAscentGuidance(MechJebCore core) : base(core) { }
 
-        protected const string TARGET_NAME = "Ascent Path Guidance";
-        protected bool showingGuidance { get { return core.target.Target != null && core.target.Name == TARGET_NAME; } }
-
-        public IAscentPath ascentPath = null;
-
         public EditableDouble desiredInclination = 0;
 
         public bool launchingToPlane = false;
@@ -30,17 +25,24 @@ namespace MuMech
         public override void OnStart(PartModule.StartState state)
         {
             autopilot = core.GetComputerModule<MechJebModuleAscentAutopilot>();
-            if (autopilot != null) desiredInclination = autopilot.desiredInclination;
+            if (autopilot != null)
+            {
+                autopilot.users.Add(this);
+                desiredInclination = autopilot.desiredInclination;
+            }
         }
 
-        public override void OnModuleEnabled()
+        public virtual void OnDestroy()
         {
+            // REVIEW: Ideally this would be called when the MechJeb module is switched off, but it doesn't seem to be
+            if (autopilot != null)
+            {
+              autopilot.users.Remove(this);
+            }
         }
 
         public override void OnModuleDisabled()
         {
-            if (core.target.NormalTargetExists && (core.target.Name == TARGET_NAME))
-                core.target.Unset();
             launchingToInterplanetary = false;
             launchingToPlane = false;
             launchingToRendezvous = false;
@@ -48,32 +50,25 @@ namespace MuMech
             if (editor != null) editor.enabled = false;
         }
 
-        public override void OnFixedUpdate()
-        {
-            if (ascentPath == null) return;
-
-            if (showingGuidance)
-            {
-                double angle = Math.PI / 180 * ascentPath.FlightPathAngle(vesselState.altitudeASL, vesselState.speedSurface);
-                double heading = Math.PI / 180 * OrbitalManeuverCalculator.HeadingForInclination(desiredInclination, vesselState.latitude);
-                Vector3d horizontalDir = Math.Cos(heading) * vesselState.north + Math.Sin(heading) * vesselState.east;
-                Vector3d dir = Math.Cos(angle) * horizontalDir + Math.Sin(angle) * vesselState.up;
-                core.target.UpdateDirectionTarget(dir);
-            }
-        }
-
         [GeneralInfoItem("Toggle Ascent Navball Guidance", InfoItem.Category.Misc, showInEditor = false)]
         public void ToggleAscentNavballGuidanceInfoItem()
         {
-            if (showingGuidance)
+            if (autopilot != null)
             {
-                if (GUILayout.Button("Hide ascent navball guidance"))
-                    core.target.Unset();
-            }
-            else
-            {
-                if (GUILayout.Button("Show ascent navball guidance"))
-                    core.target.SetDirectionTarget(TARGET_NAME);
+                GUILayout.Label("AP Enabled" + autopilot.enabled.ToString());
+                GUILayout.Label("AP Engaged" + autopilot.Engaged.ToString());
+                GUILayout.Label("AP Navball" + autopilot.NavBallGuidance.ToString());
+
+                if (autopilot.NavBallGuidance)
+                {
+                    if (GUILayout.Button("Hide ascent navball guidance"))
+                        autopilot.NavBallGuidance = false;
+                }
+                else
+                {
+                    if (GUILayout.Button("Show ascent navball guidance"))
+                        autopilot.NavBallGuidance = true;
+                }
             }
         }
 
@@ -87,19 +82,20 @@ namespace MuMech
 
             if (autopilot != null)
             {
-                if (autopilot.enabled)
+                if (autopilot.Engaged)
                 {
-                    if (GUILayout.Button("Disengage autopilot")) autopilot.users.Remove(this);
+                    if (GUILayout.Button("Disengage autopilot"))
+                    {
+                        autopilot.Engaged = false;
+                    }
                 }
                 else
                 {
                     if (GUILayout.Button("Engage autopilot"))
                     {
-                        autopilot.users.Add(this);
+                        autopilot.Engaged = true;
                     }
                 }
-
-                ascentPath = autopilot.ascentPath;
 
                 GuiUtils.SimpleTextBox("Orbit altitude", autopilot.desiredOrbitAltitude, "km");
                 autopilot.desiredInclination = desiredInclination;
@@ -131,7 +127,8 @@ namespace MuMech
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(25);
-            if (autopilot.limitAoA) {
+            if (autopilot.limitAoA)
+            {
                 GUIStyle sl = new GUIStyle(GUI.skin.label);
                 if (autopilot.limitingAoA && vesselState.dynamicPressure < autopilot.aoALimitFadeoutPressure)
                     sl.normal.textColor = sl.hover.textColor = Color.green;
@@ -175,7 +172,7 @@ namespace MuMech
                         if (GUILayout.Button("Launch into plane of target"))
                         {
                             launchingToPlane = true;
-                            autopilot.StartCountdown( vesselState.time +
+                            autopilot.StartCountdown(vesselState.time +
                                 LaunchTiming.TimeToPlane(mainBody, vesselState.latitude, vesselState.longitude, core.target.TargetOrbit));
                         }
                         if (core.target.TargetOrbit.referenceBody == orbit.referenceBody.referenceBody)


### PR DESCRIPTION
Moved the NavBall logic into the AscentAutoPilot so that it can be updated regardless of whether the UI is present. Also means that the AutoPilot can be 'Enabled' but not 'Engaged':

Enabling just means it will update (e.g. the nav ball, pluss optionally the vessel control)
Engaged means it will actually control the vessel

One minor issue is that if you have the ascent path shown on the navball and then right-click disable the MechJeb module on the vessel, the ascent target remains on the navball (though is no longer updated). I haven't been able to figure out the correct hook for when than happens (i.e to remove the autopilot user that I add in AscentGuidance.OnStart())