### PR TITLE
MechJebModuleStagingController: improve autostaging when there is uneven resource consumption

### DIFF
--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -130,9 +130,11 @@ namespace MuMech
             return false;
         }
 
+	// Find resources burned by engines that will remain after staging (so we wait until tanks are empty before releasing drop tanks)
         public List<int> FindBurnedResources()
         {
-            var activeEngines = vessel.parts.Where(p => p.inverseStage >= Staging.CurrentStage && p.IsEngine() && !p.IsSepratron());
+            var activeEngines = vessel.parts.Where(p => p.inverseStage >= Staging.CurrentStage && p.IsEngine() && !p.IsSepratron() &&
+                !p.IsDecoupledInStage(Staging.CurrentStage - 1));
             var engineModules = activeEngines.Select(p => p.Modules.OfType<ModuleEngines>().First(e => e.isEnabled));
             var burnedPropellants = engineModules.SelectMany(eng => eng.propellants);
             List<int> propellantIDs = burnedPropellants.Select(prop => prop.id).ToList();


### PR DESCRIPTION
This module looks at both engine state and resource presence to determine
whether to inhibit staging.  In the absence of crossfeed, engine state
should be sufficient, but for engineless drop tanks (and hybrid configurations
like the never-flown Saturn V 4/260 where there's a crossfed drop tank
on top of a solid-fuel booster) we should be able to drain those tanks, too.

However, looking at the resources required by all engines means that
if there's a slight propellant imbalance we won't stage if we're just
out of oxidizer; to fix this, exclude engines which would be dropped
in the next staging from the resource evaluation.