### PR TITLE
MechJebModuleThrustController: Add electric throttle limiter

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -109,6 +109,7 @@ namespace MuMech
             core.thrust.LimitAccelerationInfoItem();
             core.thrust.LimitThrottleInfoItem();
             core.thrust.LimiterMinThrottleInfoItem();
+            core.thrust.LimitElectricInfoItem();
             GUILayout.BeginHorizontal();
             autopilot.forceRoll = GUILayout.Toggle(autopilot.forceRoll, "Force Roll");
             if (autopilot.forceRoll)

--- a/MechJeb2/MechJebModuleThrustWindow.cs
+++ b/MechJeb2/MechJebModuleThrustWindow.cs
@@ -59,6 +59,7 @@ namespace MuMech
             core.thrust.LimitAccelerationInfoItem();
             core.thrust.LimitThrottleInfoItem();
             core.thrust.LimiterMinThrottleInfoItem();
+            core.thrust.LimitElectricInfoItem();
             core.thrust.LimitToPreventFlameoutInfoItem();
             core.thrust.smoothThrottle = GUILayout.Toggle(core.thrust.smoothThrottle, "Smooth throttle");
             core.thrust.manageIntakes = GUILayout.Toggle(core.thrust.manageIntakes, "Manage air intakes");

--- a/MechJeb2/VesselExtensions.cs
+++ b/MechJeb2/VesselExtensions.cs
@@ -98,6 +98,34 @@ namespace MuMech
             return vessel.TotalResourceAmount(definition) * definition.density;
         }
 
+        public static double MaxResourceAmount(this Vessel vessel, PartResourceDefinition definition)
+        {
+            if (definition == null) return 0;
+            List<Part> parts = (HighLogic.LoadedSceneIsEditor ? EditorLogic.fetch.ship.parts : vessel.parts);
+
+            double amount = 0;
+            for (int i = 0; i < parts.Count; i++)
+            {
+                Part p = parts[i];
+                for (int j = 0; j < p.Resources.Count; j++)
+                {
+                    PartResource r = p.Resources[j];
+
+                    if (r.info.id == definition.id)
+                    {
+                        amount += r.maxAmount;
+                    }
+                }
+            }
+
+            return amount;
+        }
+
+        public static double MaxResourceAmount(this Vessel vessel, string resourceName)
+        {
+            return vessel.MaxResourceAmount(PartResourceLibrary.Instance.GetDefinition(resourceName));
+        }
+
         public static bool HasElectricCharge(this Vessel vessel)
         {
             if (vessel == null)


### PR DESCRIPTION
Craft powered by electric engines can become uncontrollable when their
probe core is starved of power.  When in this state, all available
power is immediately consumed by the engines and there is no way to
adjust the throttle.  This can result in much longer burns than
desired.

This change adds an optional proportional throttle limiter which will
scale back the throttle when the vessel is low on ElectricCharge.  It
can safely be left enabled at all times, as it is only active when an
active engine uses ElectricCharge as a propellant.

There are two parameters: ElectricLimitLo and ElectricLimitHi,
expressed in the UI as percentages of total ElectricCharge capacity.

While in operation, the limiter can be in one of three states,
indicated by the color of the limiter's label:

 - Red: If the vessel's ElectricCharge level is below ElectricLimitLo
   (default 5%), the throttle is limited to zero.

 - Yellow: If ElectricCharge is between the two limits, set the
   throttle in proportion to where it sits within that range.

 - Green: If the vessel's ElectricCharge level is above ElectricLimitHi
   (default 15%), the throttle is unlimited; naturally, other limiters
   may still reduce thrust below 100%

While operating in the yellow state, the limiter finds a throttle
setting which consumes only as much power as the vessel can generate.

Tuning:

You need to set the threshholds high enough that a sudden increase in
electrical demand won't consume all power before the throttle goes to zero.

The low limit is most critical; for solar-powered craft, you should
set it high enough that batteries won't run down to zero during the
longest expected orbital eclipse period.

Setting the "Hi" limit is more a matter of taste; lower levels mean
you can make longer sprints at full power before the limiter kicks in,
but also increase the risk of running out of power entirely.