### PR TITLE
Add auto-ullaging with RCS

### DIFF
--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -441,6 +441,13 @@ namespace MuMech
             // RealFuels ullage integration.  Stock always has stableUllage.
             if (!vesselState.stableUllage)
             {
+                if ( targetThrottle > 0.0F && throttleLimit > 0.0F ) {
+                    // We want to fire the throttle, and nothing else is limiting us, but we have unstable ullage
+                    if (vessel.ActionGroups[KSPActionGroup.RCS] && s.Z == 0) {
+                        // RCS is on, so use it to ullage
+                        s.Z = -1.0F;
+                    }
+                }
                 throttleLimit = 0.0F;
             }
 
@@ -460,7 +467,7 @@ namespace MuMech
 
             if (double.IsNaN(s.mainThrottle)) s.mainThrottle = 0;
             s.mainThrottle = Mathf.Clamp01(s.mainThrottle);
-            
+
             if (s.Z == 0 && core.rcs.rcsThrottle && vesselState.rcsThrust) s.Z = -s.mainThrottle;
 
             lastThrottle = s.mainThrottle;


### PR DESCRIPTION
If RCS is on and we're in a condition where we're suppressing the
throttle due to ullage, fire the RCS jets in order to ullage.