### PR TITLE
Prevent Unstable Ignition Menu Button

### DIFF
--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -441,6 +441,13 @@ namespace MuMech
             // RealFuels ullage integration.  Stock always has stableUllage.
             if (!vesselState.stableUllage)
             {
+                if ( targetThrottle > 0.0F && throttleLimit > 0.0F ) {
+                    // We want to fire the throttle, and nothing else is limiting us, but we have unstable ullage
+                    if (vessel.ActionGroups[KSPActionGroup.RCS] && s.Z == 0) {
+                        // RCS is on, so use it to ullage
+                        s.Z = -1.0F;
+                    }
+                }
                 throttleLimit = 0.0F;
             }
 
@@ -460,7 +467,7 @@ namespace MuMech
 
             if (double.IsNaN(s.mainThrottle)) s.mainThrottle = 0;
             s.mainThrottle = Mathf.Clamp01(s.mainThrottle);
-            
+
             if (s.Z == 0 && core.rcs.rcsThrottle && vesselState.rcsThrust) s.Z = -s.mainThrottle;
 
             lastThrottle = s.mainThrottle;

--- a/MechJeb2/MechJebModuleThrustWindow.cs
+++ b/MechJeb2/MechJebModuleThrustWindow.cs
@@ -56,6 +56,11 @@ namespace MuMech
             core.thrust.LimiterMinThrottleInfoItem();
             core.thrust.LimitElectricInfoItem();
             core.thrust.LimitToPreventFlameoutInfoItem();
+            if (VesselState.isLoadedRealFuels)
+            {
+                // does nothing in stock, so we suppress displaying it if RF is not loaded
+                core.thrust.LimitToPreventUnstableIgnitionInfoItem();
+            }
             core.thrust.smoothThrottle = GUILayout.Toggle(core.thrust.smoothThrottle, "Smooth throttle");
             core.thrust.manageIntakes = GUILayout.Toggle(core.thrust.manageIntakes, "Manage air intakes");
             GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));


### PR DESCRIPTION
Improves the user-experience for preventing unstable ignitions and doing RCS auto-ullage.

Adds a button to the Utilities menu -- by default only when RealFuels is installed so as not to confuse stock players -- that is on by default.

When MJ is suppressing the throttle due to ullage concerns it will light up green just like "Prevent jet flameout" does.

Also has a fix so that RCS auto-ullaging works with manual throttle.