### PR TITLE
Use ship altitude instead of final alt for ascent heading

### DIFF
--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -205,7 +205,7 @@ namespace MuMech
             //during the vertical ascent we just thrust straight up at max throttle
             if (forceRoll)
             { // pre-align roll unless correctiveSteering is active as it would just interfere with that
-                double desiredHeading = OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination, desiredOrbitAltitude);
+                double desiredHeading = OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination);
                 core.attitude.attitudeTo(desiredHeading, 90, verticalRoll, this);
             }
             else 
@@ -303,7 +303,7 @@ namespace MuMech
             Vector3d actualVelocityUnit = ((1 - referenceFrameBlend) * vesselState.surfaceVelocity.normalized
                                                + referenceFrameBlend * vesselState.orbitalVelocity.normalized).normalized;
 
-            double desiredHeading = MathExtensions.Deg2Rad * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination, desiredOrbitAltitude);
+            double desiredHeading = MathExtensions.Deg2Rad * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination);
             Vector3d desiredHeadingVector = Math.Sin(desiredHeading) * vesselState.east + Math.Cos(desiredHeading) * vesselState.north;
             double desiredFlightPathAngle = ascentPath.FlightPathAngle(vesselState.altitudeASL, vesselState.speedSurface);
 
@@ -404,7 +404,7 @@ namespace MuMech
             // - Starwaster
             core.thrust.targetThrottle = 0;
 
-            double desiredHeading = MathExtensions.Deg2Rad * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination, desiredOrbitAltitude);
+            double desiredHeading = MathExtensions.Deg2Rad * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination);
             Vector3d desiredHeadingVector = Math.Sin(desiredHeading) * vesselState.east + Math.Cos(desiredHeading) * vesselState.north;
             double desiredFlightPathAngle = ascentPath.FlightPathAngle(vesselState.altitudeASL, vesselState.speedSurface);
 

--- a/MechJeb2/MechJebModuleAscentNavBall.cs
+++ b/MechJeb2/MechJebModuleAscentNavBall.cs
@@ -45,7 +45,7 @@ namespace MuMech
             if (NavBallGuidance && autopilot != null && autopilot.ascentPath != null)
             {
                 double angle = Math.PI / 180 * autopilot.ascentPath.FlightPathAngle(vesselState.altitudeASL, vesselState.speedSurface);
-                double heading = Math.PI / 180 * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, autopilot.desiredInclination, autopilot.desiredOrbitAltitude);
+                double heading = Math.PI / 180 * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, autopilot.desiredInclination);
                 Vector3d horizontalDir = Math.Cos(heading) * vesselState.north + Math.Sin(heading) * vesselState.east;
                 Vector3d dir = Math.Cos(angle) * horizontalDir + Math.Sin(angle) * vesselState.up;
                 core.target.UpdateDirectionTarget(dir);

--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -198,11 +198,11 @@ namespace MuMech
         //Returned heading is in degrees and in the range 0 to 360.
         //If the given latitude is too large, so that an orbit with a given inclination never attains the 
         //given latitude, then this function returns either 90 (if -90 < inclination < 90) or 270.
-        public static double HeadingForLaunchInclination(Vessel vessel, VesselState vesselState, double inclinationDegrees, double orbAlt)
+        public static double HeadingForLaunchInclination(Vessel vessel, VesselState vesselState, double inclinationDegrees)
         {
             CelestialBody body = vessel.mainBody;
             double latitudeDegrees = vesselState.latitude;
-            double orbVel = OrbitalManeuverCalculator.CircularOrbitSpeed(body, orbAlt + body.Radius);
+            double orbVel = OrbitalManeuverCalculator.CircularOrbitSpeed(body, vesselState.altitudeASL + body.Radius);
             double headingOne = HeadingForInclination(inclinationDegrees, latitudeDegrees) * Math.PI / 180;
             double headingTwo = HeadingForInclination(-inclinationDegrees, latitudeDegrees) * Math.PI / 180;
             double now = Planetarium.GetUniversalTime();


### PR DESCRIPTION
Now that we're continuously updating the heading based on the vessel
position, it makes more sense to use the vessel's altitude as the guess
for our direction rather than the final orbital velocity.

This trades some wildly inaccurate numbers for some slightly inaccurate
numbers.

If you want to ascend directly to a large apoapsis with a large
inclination then MJ will try to shoot for the horizontal velocity of
the apoapsis while its still on the ground.  At the absurd limit if
you punch in the SOI limit of the body you're lifting off of you'll
be asking to putter along at a few m/s and that is definitely
insufficient for a launch velocity.

This algorithm gets it a little bit wrong, but it will self correct as the
rocket ascends and it continually updates.

As a refinement we could go back to injecting the target altitude again
and then calculating the velocity at the periapsis of an orbit with the
periapsis at the surface and the apoapsis at the desired height, but i'm
not sure we need to and i haven't quite convinced myself that would be
any more correct.