### PR TITLE
launch inclination fixes for Kerbin

### DIFF
--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -245,29 +245,30 @@ namespace MuMech
             // fall back to tracking desiredHorizontalVelocity
             if ( Vector3d.Dot(desiredHorizontalVelocity.normalized, deltaHorizontalVelocity.normalized) < 0.90 )
             {
+                // it is important that we do NOT do the fracReserveDV math here, we want to ignore the deltaHV entirely at ths point
                 return MuUtils.ClampDegrees360(180 / Math.PI * Math.Atan2(Vector3d.Dot(desiredHorizontalVelocity, east), Vector3d.Dot(desiredHorizontalVelocity, north)));
-            } else {
-              // when doing two-burn ascents we should really integrate the first burn up to the target altitude, and then
-              // we should target hitting the desired inclination angle at that point and work backwards.  Instead we have
-              // this somewhat janky algorithm that I dreamed up.  We lop off a good chunk of the desired horizontal velocity
-              // so that the angular change caused by the deltaHV correction makes the angle larger.  The 8400 magic number
-              // here shuts down this correction for launches from Earth (and from Eve?).  The 0.85 number clamps the fraction
-              // to 85% (over that should get real weird, fairly quickly).  The 1.2's just give me a straight line with
-              // roughly 0.85 when launching from Kerbin and 0 when launching from Earth.  One (useful?) feature of this
-              // algorithm is that it is very aggressive at the launch site (which should reduce the dV from steering
-              // corrections for polar orbits?)
-              double fracReserveDV = Math.Max(Math.Min(-1.2 / 8400.0 * desiredHorizontalVelocity.magnitude + 1.2, 0.85), 0.0);
-
-              // Deliberately use the *delta* horizontal velocity magnitude times the fracReserve so that we fade-out as we launch.
-              // (deltaHV trends towards zero so the fracReserve of that dV trends towards zero -- and as the deltaHV whips around
-              // then we hit the other side of the conditional above and no longer hit this code).
-              desiredHorizontalVelocity = ( desiredHorizontalVelocity.magnitude - fracReserveDV * deltaHorizontalVelocity.magnitude ) * desiredHorizontalVelocity.normalized;
-
-              // recompute the new delta
-              deltaHorizontalVelocity = desiredHorizontalVelocity - actualHorizontalVelocity;
-
-              return MuUtils.ClampDegrees360(180 / Math.PI * Math.Atan2(Vector3d.Dot(deltaHorizontalVelocity, east), Vector3d.Dot(deltaHorizontalVelocity, north)));
             }
+
+            // when doing two-burn ascents we should really integrate the first burn up to the target altitude, and then
+            // we should target hitting the desired inclination angle at that point and work backwards.  Instead we have
+            // this somewhat janky algorithm that I dreamed up.  We lop off a good chunk of the desired horizontal velocity
+            // so that the angular change caused by the deltaHV correction makes the angle larger.  The 8400 magic number
+            // here shuts down this correction for launches from Earth (and from Eve?).  The 0.85 number clamps the fraction
+            // to 85% (over that should get real weird, fairly quickly).  The 1.2's just give me a straight line with
+            // roughly 0.85 when launching from Kerbin and 0 when launching from Earth.  One (useful?) feature of this
+            // algorithm is that it is very aggressive at the launch site (which should reduce the dV from steering
+            // corrections for polar orbits?)
+            double fracReserveDV = Math.Max(Math.Min(-1.2 / 8400.0 * desiredHorizontalVelocity.magnitude + 1.2, 0.85), 0.0);
+
+            // Deliberately use the *delta* horizontal velocity magnitude times the fracReserve so that we fade-out as we launch.
+            // (deltaHV trends towards zero so the fracReserve of that dV trends towards zero -- and as the deltaHV whips around
+            // then we hit the other side of the conditional above and no longer hit this code).
+            desiredHorizontalVelocity = ( desiredHorizontalVelocity.magnitude - fracReserveDV * deltaHorizontalVelocity.magnitude ) * desiredHorizontalVelocity.normalized;
+
+            // recompute the new delta
+            deltaHorizontalVelocity = desiredHorizontalVelocity - actualHorizontalVelocity;
+
+            return MuUtils.ClampDegrees360(180 / Math.PI * Math.Atan2(Vector3d.Dot(deltaHorizontalVelocity, east), Vector3d.Dot(deltaHorizontalVelocity, north)));
         }
 
         //Computes the delta-V of the burn required to change an orbit's inclination to a given value

--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -243,11 +243,30 @@ namespace MuMech
 
             // if you circularize in one burn, towards the end deltaHorizontalVelocity will whip around, but we want to
             // fall back to tracking desiredHorizontalVelocity
-            if ( Vector3d.Dot(desiredHorizontalVelocity.normalized, deltaHorizontalVelocity.normalized) > 0.90 )
+            if ( Vector3d.Dot(desiredHorizontalVelocity.normalized, deltaHorizontalVelocity.normalized) < 0.90 )
             {
-                return MuUtils.ClampDegrees360(180 / Math.PI * Math.Atan2(Vector3d.Dot(deltaHorizontalVelocity, east), Vector3d.Dot(deltaHorizontalVelocity, north)));
-            } else {
                 return MuUtils.ClampDegrees360(180 / Math.PI * Math.Atan2(Vector3d.Dot(desiredHorizontalVelocity, east), Vector3d.Dot(desiredHorizontalVelocity, north)));
+            } else {
+              // when doing two-burn ascents we should really integrate the first burn up to the target altitude, and then
+              // we should target hitting the desired inclination angle at that point and work backwards.  Instead we have
+              // this somewhat janky algorithm that I dreamed up.  We lop off a good chunk of the desired horizontal velocity
+              // so that the angular change caused by the deltaHV correction makes the angle larger.  The 8400 magic number
+              // here shuts down this correction for launches from Earth (and from Eve?).  The 0.85 number clamps the fraction
+              // to 85% (over that should get real weird, fairly quickly).  The 1.2's just give me a straight line with
+              // roughly 0.85 when launching from Kerbin and 0 when launching from Earth.  One (useful?) feature of this
+              // algorithm is that it is very aggressive at the launch site (which should reduce the dV from steering
+              // corrections for polar orbits?)
+              double fracReserveDV = Math.Max(Math.Min(-1.2 / 8400.0 * desiredHorizontalVelocity.magnitude + 1.2, 0.85), 0.0);
+
+              // Deliberately use the *delta* horizontal velocity magnitude times the fracReserve so that we fade-out as we launch.
+              // (deltaHV trends towards zero so the fracReserve of that dV trends towards zero -- and as the deltaHV whips around
+              // then we hit the other side of the conditional above and no longer hit this code).
+              desiredHorizontalVelocity = ( desiredHorizontalVelocity.magnitude - fracReserveDV * deltaHorizontalVelocity.magnitude ) * desiredHorizontalVelocity.normalized;
+
+              // recompute the new delta
+              deltaHorizontalVelocity = desiredHorizontalVelocity - actualHorizontalVelocity;
+
+              return MuUtils.ClampDegrees360(180 / Math.PI * Math.Atan2(Vector3d.Dot(deltaHorizontalVelocity, east), Vector3d.Dot(deltaHorizontalVelocity, north)));
             }
         }
 


### PR DESCRIPTION
this patch is a bit of hackery to make two-stage burns work correctly
on Kerbin, also tested on Mun and even Gilly.

on Earth we don't need this so much because we tend to do single burns
and the Earth is really big.

the fracDV calculation essentially selects .85 as the frac to apply
to Kerbin while fading out to a correction of .00 on Earth.

the correction factor also fades out as we launch and the deltaHV
value trends down.  that means we correct stronger sooner which
should(?) reduce the steering losses from high inclination launches.

as the deltaHV value whips around we stop doing this calculation as
well (which is fairly important because deltaHV can get large again but
point in the wrong direction under some conditions).

the 0.85 value is frighteningly large, but i had to do that to get
rockets to launch correctly on Kerbin.  i can't really explain it with
numberical arguments but the rockets launch well.  on Kerbin with 175m/s
of coriolis velocity at KSC it only costed that plus an extra 16m/s of
steering losses to hit a 90.01 inclination orbit compared to a 0 degree
one.

tested with 90 degrees and 135 degrees inclination on Kerbin with SLTs
ranging from 1.1 to over 2.5.  on Gilly with a 2000 launch TWR it didn't
work because that's just insane -- one puff and you launch whichever
direction you were pointed on the surface -- but after clamping the
throttle to 1% it worked fine.

since we track continuously as we launch now any inaccuracy in the
initial guess will get corrected over time.

rockets with truly insanely high TWRs and super-short takeoff burns to
raise the apoapsis will still not work well.  the two possible
strategies there will be to simply throttle down -- or else i think we
could fade this algorithm out as the TWR gets stupidly big.  not sure
how much it matters though since at extreme TWR attitude control doesn't
help you any and you launch like a gun based on whatever your attitude
was due to the surface contour.