### PR TITLE
Allow overriding of MANAGED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ else
 		ifndef KSPDIR
 			KSPDIR  := ${HOME}/Library/Application Support/Steam/SteamApps/common/Kerbal Space Program
 		endif
-		MANAGED := ${KSPDIR}/KSP.app/Contents/Data/Managed/
+		ifndef MANAGED
+			MANAGED := ${KSPDIR}/KSP.app/Contents/Data/Managed/
+		endif
 	endif
 endif
 


### PR DESCRIPTION
The 1.1.3 release of KSP on Mac OS X (as of when this PR was created) does not include any DLLs other than `Assembly-CSharp.dll`. I have sent a support request to Squad to find out if that was an oversight or if they're really _not_ supposed to be installed in the app package. In the meantime, I have downloaded the Linux release (which has the DLLs), but of course that's not nested under `KSP.app`.

Which is a long-winded explanation of why I need to be able to override `MANAGED` when compiling MechJeb2. 😄 