### PR TITLE
Check if EditorLogic.fetch != null before using it.

### DIFF
--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -914,7 +914,7 @@ namespace MuMech
 
                 // The EDITOR => FLIGHT transition is annoying to handle. OnDestroy is called when HighLogic.LoadedSceneIsEditor is already false
                 // So we don't save in that case, which is not that bad since nearly nothing use vessel settings in the editor.
-                if (vessel != null)
+                if (vessel != null || (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch != null))
                 {
                     string vesselName = (HighLogic.LoadedSceneIsEditor ? EditorLogic.fetch.shipNameField.text : vessel.vesselName);
                     vesselName = string.Join("_", vesselName.Split(Path.GetInvalidFileNameChars())); // Strip illegal char from the filename

--- a/MechJeb2/VesselExtensions.cs
+++ b/MechJeb2/VesselExtensions.cs
@@ -28,7 +28,7 @@ namespace MuMech
         public static List<T> GetModules<T>(this Vessel vessel) where T : PartModule
         {
             List<Part> parts;
-            if (HighLogic.LoadedSceneIsEditor) parts = EditorLogic.fetch.ship.parts;
+            if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch != null) parts = EditorLogic.fetch.ship.parts;
             else if (vessel == null) return new List<T>();
             else parts = vessel.Parts;
 


### PR DESCRIPTION
If you revert a flight back to the VAB, it happens that in Method
OnDestroy HighLogic.LoadedSceneIsEditor is true but EditorLogic is not
initialised.