### PR TITLE
fix makefile issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@ else
 		MANAGED := ${KSPDIR}/KSP_Data/Managed/
 	endif
 	ifeq ($(UNAME_S),Darwin)
+		GMCS ?= mcs
 		ifndef KSPDIR
 			KSPDIR  := ${HOME}/Library/Application Support/Steam/SteamApps/common/Kerbal Space Program
 		endif
-		MANAGED := ${KSPDIR}/KSP.app/Contents/Data/Managed/
+		MANAGED := ${KSPDIR}/KSP.app/Contents/Resources/Data/Managed/
 	endif
 endif
 
@@ -49,7 +50,7 @@ build/%.dll: ${MECHJEBFILES}
 	mkdir -p build
 	${RESGEN2} -usesourcepath MechJeb2/Properties/Resources.resx build/Resources.resources
 	${GMCS} -t:library -lib:"${MANAGED}" \
-		-r:Assembly-CSharp,Assembly-CSharp-firstpass,UnityEngine,UnityEngine.UI,KSPUtil \
+		-r:Assembly-CSharp,Assembly-CSharp-firstpass,UnityEngine,UnityEngine.UI \
 		-out:$@ \
 		${MECHJEBFILES} \
 		-resource:build/Resources.resources,MuMech.Properties.Resources.resources


### PR DESCRIPTION
KSPUtil.dll is gone.  Also, on Darwin at least the dlls have been moved,
and the `gmcs` command has been removed for awhile now.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>