### PR TITLE
add OnFixedUpdate() hook to WarpToUT() API

### DIFF
--- a/MechJeb2/MechJebModuleWarpController.cs
+++ b/MechJeb2/MechJebModuleWarpController.cs
@@ -69,7 +69,7 @@ namespace MuMech
             SetTimeWarpRate(lastAskedIndex, false);
         }
 
-        // Turn SAS on during regular warp for compatibility with PersistentRotation 
+        // Turn SAS on during regular warp for compatibility with PersistentRotation
         private void SetTimeWarpRate(int rateIndex, bool instant)
         {
             if (rateIndex != TimeWarp.CurrentRateIndex)
@@ -92,8 +92,11 @@ namespace MuMech
             }
         }
 
-        public void WarpToUT(double UT, double maxRate = 100000)
+        public void WarpToUT(double UT, double maxRate = -1)
         {
+            if (maxRate < 0)
+                maxRate = TimeWarp.fetch.warpRates[TimeWarp.fetch.warpRates.Length - 1];
+
             double desiredRate = 1.0 * (UT - (vesselState.time + Time.fixedDeltaTime * (float)TimeWarp.CurrentRateIndex));
             desiredRate = MuUtils.Clamp(desiredRate, 1, maxRate);
 

--- a/MechJeb2/MechJebModuleWarpController.cs
+++ b/MechJeb2/MechJebModuleWarpController.cs
@@ -18,6 +18,7 @@ namespace MuMech
 
         private int lastAskedIndex = 0;
 
+        public double warpToUT { get; private set; }
         public bool WarpPaused { get; private set; }
 
         [Persistent(pass = (int)Pass.Global)]
@@ -50,6 +51,11 @@ namespace MuMech
 
                 //ScreenMessages.PostScreenMessage("MJ : Warp canceled by user or an other mod");
             }
+        }
+
+        public override void OnFixedUpdate() {
+            if (warpToUT > 0)
+                WarpToUT(warpToUT);
         }
 
         private void PauseWarp()
@@ -94,6 +100,11 @@ namespace MuMech
 
         public void WarpToUT(double UT, double maxRate = -1)
         {
+            if (UT <= vesselState.time) {
+                warpToUT = 0.0;
+                return;
+            }
+
             if (maxRate < 0)
                 maxRate = TimeWarp.fetch.warpRates[TimeWarp.fetch.warpRates.Length - 1];
 
@@ -110,6 +121,7 @@ namespace MuMech
             {
                 WarpRegularAtRate((float)desiredRate);
             }
+            warpToUT = UT;
         }
 
         //warp at the highest regular warp rate that is <= maxRate
@@ -228,6 +240,7 @@ namespace MuMech
 
         public bool MinimumWarp(bool instant = false)
         {
+            warpToUT = 0.0;
             if (TimeWarp.CurrentRateIndex == 0) return false; //Somehow setting TimeWarp.SetRate to 0 when already at 0 causes unexpected rapid separation (Kraken)
             SetTimeWarpRate(0, instant);
             return true;


### PR DESCRIPTION
add OnFixedUpdate() hook to WarpToUT() API

previously the WarpToUT() API required the caller to constantly
beat on WarpToUT() every FixedUpdate().

this places a bit of an undue burden on the caller which can lead
to the existing bug in the node executor:

https://github.com/MuMech/MechJeb2/blob/02efd919a5c805ff7c01f92d34c81de7546c37bd/MechJeb2/MechJebModuleNodeExecutor.cs#L135-L146

when core.attitude.attitudeAngleFromTarget() >= 1 then the first block
is not executed.  but when timeToNode < 600 the second block is also
not executed.

this happens when MJ is at maxwarp allowing the navball to spin prior to
hitting the realign check.  throughout this period it is only
occasionally calling WarpToUT when thant AngleFromTarget() < 1 check
passes.

for relatively short/slow warps timeToNode gets called and drops it out
warp, but for long/fast warps you can skip so far that 10 minutes isn't
enough lead time to start slowing down.

so...

this patch doesn't fix the NodeExecutor but instead fixes the
WarpController so that callers don't have to beat on WarpToUT()
constantly (although they still can) and WarpToUT remembers its
last setting and manages warping to the UT without needing to
be called again.