### PR TITLE
Improving the HeadingForLaunchInclination function.

### DIFF
--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -248,26 +248,7 @@ namespace MuMech
                 // it is important that we do NOT do the fracReserveDV math here, we want to ignore the deltaHV entirely at ths point
                 return MuUtils.ClampDegrees360(UtilMath.Rad2Deg * Math.Atan2(Vector3d.Dot(desiredHorizontalVelocity, east), Vector3d.Dot(desiredHorizontalVelocity, north)));
             }
-
-            // when doing two-burn ascents we should really integrate the first burn up to the target altitude, and then
-            // we should target hitting the desired inclination angle at that point and work backwards.  Instead we have
-            // this somewhat janky algorithm that I dreamed up.  We lop off a good chunk of the desired horizontal velocity
-            // so that the angular change caused by the deltaHV correction makes the angle larger.  The 8400 magic number
-            // here shuts down this correction for launches from Earth (and from Eve?).  The 0.85 number clamps the fraction
-            // to 85% (over that should get real weird, fairly quickly).  The 1.2's just give me a straight line with
-            // roughly 0.85 when launching from Kerbin and 0 when launching from Earth.  One (useful?) feature of this
-            // algorithm is that it is very aggressive at the launch site (which should reduce the dV from steering
-            // corrections for polar orbits?)
-            double fracReserveDV = Math.Max(Math.Min(-1.2 / 8400.0 * desiredHorizontalVelocity.magnitude + 1.2, 0.85), 0.0);
-
-            // Deliberately use the *delta* horizontal velocity magnitude times the fracReserve so that we fade-out as we launch.
-            // (deltaHV trends towards zero so the fracReserve of that dV trends towards zero -- and as the deltaHV whips around
-            // then we hit the other side of the conditional above and no longer hit this code).
-            desiredHorizontalVelocity = ( desiredHorizontalVelocity.magnitude - fracReserveDV * deltaHorizontalVelocity.magnitude ) * desiredHorizontalVelocity.normalized;
-
-            // recompute the new delta
-            deltaHorizontalVelocity = desiredHorizontalVelocity - actualHorizontalVelocity;
-
+            
             return MuUtils.ClampDegrees360(UtilMath.Rad2Deg * Math.Atan2(Vector3d.Dot(deltaHorizontalVelocity, east), Vector3d.Dot(deltaHorizontalVelocity, north)));
         }
 


### PR DESCRIPTION
The original version of this code had to transition between the ground frame of reference and the inflight frame of reference, so it had a complex reserve system to figure out the transition.
Later, the code was modified to use the vessel's frame of reference, so the transition is no longer needed.  The current code now calculates the difference between your target velocity vector, and your current velocity vector,
and returns the heading for that.  That's the exact heading we want to take (if we were to do an impulse)

I did a bit of testing on this.  Here's the raw results.  It is better at hitting polar orbits (and saved ~50 dv in the process)  The numbers on the left are with the original code, the numbers on the right are the patched code.

test craft leaving KSP / Target inclination 45 deg  100k
inclination before circularization   46.935         / 40.612
final inclination 45.000            / 44.999
vac dv remaining: 101 m/s           / 135 m/s

test craft leaving KSP / Target inclination 90 deg 100k
inclination before circularization   93.207         / 83.473
final inclination    90.026         / 89.999
vac dv remaining:   -33 m/s  (didn't achieve orbit) / 21 m/s

Test mun launch @ 45 latitude     target 60 deg   30k  Engine 100%
inclination before circularization   52.208        / 51.418
final inclination    60.000        / 60.000
vac dv remaining:    68 m/s        / 68 m/s

Mun lander   mun @ 45 inclination     target 60 deg   30k  Engine 20%
inclination before circularization   58.866        / 57.876
final inclination    60.000        / 60.000
vac dv remaining:    85 m/s        / 85 m/s

Mun lander   mun @ 45 inclination     target 0 deg   30k  Engine 20%
inclination before circularization   ??  ~45 deg   /  
final inclination    45.056        / 45.052
vac dv remaining:    87 m/s        / 87 m/s
