### PR TITLE
 let attitude control settle before autowarp

### DIFF
--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -134,7 +134,7 @@ namespace MuMech
             //autowarp, but only if we're already aligned with the node
             if (autowarp && !burnTriggered)
             {
-                if (core.attitude.attitudeAngleFromTarget() < 1 || (core.attitude.attitudeAngleFromTarget() < 10 && !MuUtils.PhysicsRunning()))
+                if ((core.attitude.attitudeAngleFromTarget() < 1 && core.vessel.angularVelocity.magnitude < 0.001d) || (core.attitude.attitudeAngleFromTarget() < 10 && !MuUtils.PhysicsRunning()))
                 {
                     core.warp.WarpToUT(node.UT - halfBurnTime - leadTime);
                 }


### PR DESCRIPTION
This way MJ no longer relies on the 'stop rotation by warping' cheat and also improves Persistent Rotation compatibility.