### PR TITLE
README.md points to re-created KSP forum thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 MechJeb2
 
 MechJeb2 - KSP mod
-Visit http://mechjeb.com for more info
+Visit http://forum.kerbalspaceprogram.com/index.php?/topic/154834-122-anatid-robotics-mumech-mechjeb-autopilot-260-12-dec-2016/ for more info


### PR DESCRIPTION
It seems that http://mechjeb.com/ is redirecting to the old forum thread that was lost. It might be better to drop this PR and make the change on mechjeb.com