### PR TITLE
2 Ullage limiter fixes

### DIFF
--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -463,15 +463,16 @@ namespace MuMech
             if (limitToPreventUnstableIgnition && !vesselState.stableUllage)
             {
                 if (( targetThrottle > 0.0F || s.mainThrottle > 0.0F ) && throttleLimit > 0.0F )
-				{
+                {
                     // We want to fire the throttle, and nothing else is limiting us, but we have unstable ullage
-                    if (vessel.ActionGroups[KSPActionGroup.RCS] && s.Z == 0) {
+                    limiter = LimitMode.UnstableIgnition;
+                    throttleLimit = 0.0F;
+                    if (vessel.ActionGroups[KSPActionGroup.RCS] && s.Z == 0)
+                    {
                         // RCS is on, so use it to ullage
                         s.Z = -1.0F;
                     }
                 }
-				limiter = LimitMode.UnstableIgnition;
-				throttleLimit = 0.0F;
             }
 
             if (double.IsNaN(throttleLimit)) throttleLimit = 0;

--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -462,7 +462,7 @@ namespace MuMech
             // RealFuels ullage integration.  Stock always has stableUllage.
             if (limitToPreventUnstableIgnition && !vesselState.stableUllage)
             {
-                if (( targetThrottle > 0.0F || s.mainThrottle > 0.0F ) && throttleLimit > 0.0F )
+                if (s.mainThrottle > 0.0F && throttleLimit > 0.0F )
                 {
                     // We want to fire the throttle, and nothing else is limiting us, but we have unstable ullage
                     limiter = LimitMode.UnstableIgnition;


### PR DESCRIPTION
- Fixes a cosmetic bug in the UI where we should only be setting the limit and showing green in the UI if the user or the `users` are doing something to throttle up.  Shouldn't be green if nothing is requesting throttle.  Also I think this would have overwritten the state and if something else had limited the throttle to 0 it would have showed as ullage limiting it to 0 if the ullage was unstable.

- Fixed a major breaking bug where it looks like the targetThrottle got cleaned up and refactored at some point (maybe?  either that or I was smoking something when I wrote the ullage limiter code...) and now s.mainThrottle is just set to that early, if there is an external `user` on the ThrottleController.  There's a condition where the `user` may have left the targetThrottle at 1.0 but unregistered, in which case the logic I'm replacing in the ullage limiter would fire and RCS would fire continuously, even though s.mainThrottle was 0.0.  Fairly trivially reproducible just by disengaging the Ascent Guidance after getting to orbit while the engine is still under power and killing the engine--Ascent Guidance clearly leaves targetThrotttle = 1.0 after unregistering itself as a `user` of the ThrottleController.  The check for targetThrottle isn't necessary, is never used after the ullage limiter, and that value (when its correct to use it) gets passed into s.mainThrottle way up at the top of this Drive() function.

The last one should be a fix for https://www.reddit.com/r/RealSolarSystem/comments/67dkn0/122_rssrorp0_rcs_translating_forward_when_coming/ although I found the problem with the Ascent Controller and not when coming out of warp (suspect many other controllers also leave the ThrottleController in the same state).