### PR TITLE
make stable ullage stable

### DIFF
--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -1274,7 +1274,7 @@ namespace MuMech
                     return;
                 }
 
-                if ((propellantStatus != "Nominal") && (propellantStatus != "Very Stable"))
+                if ((propellantStatus != "Nominal") && (propellantStatus != "Very Stable") && (propellantStatus != "Stable"))
                 {
                     stableUllage = false;
                 }


### PR DESCRIPTION
its probably obvious that this should have been fixed this way.

however, i was considering vessels which had means of ullage and when i
was considering how far MJ should ullage until it tried to light the
engine i was like "why not _very_ stable, that's better right?"

but for something like a sounding rocket where it is as ullaged as its
ever going to get, you want to allow users to throttle with 'stable' as
well.  right now if the prop status falls from 'very stable' to 'stable'
before you hit the throttle it breaks your launch.

really for sounding rockets users should turn this feature off.

should also consider autodetecting sounding rockets (if there's no
other engines or RCS on the craft, it'll never ullage, so this whole
feature is a bit breaking if its checked).

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>