### PR TITLE
rework of node executor ullage patch

### DIFF
--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -36,10 +36,6 @@ namespace MuMech
             double dV = node.GetBurnVector(orbit).magnitude;
             double halfBurnTIme;
             double burnTIme = BurnTime(dV, out halfBurnTIme);
-            if (double.IsInfinity(halfBurnTIme))
-            {
-                halfBurnTIme = 0.0;
-            }
             return GuiUtils.TimeToDHMS(node.UT - halfBurnTIme - vesselState.time);
         }
 
@@ -227,27 +223,7 @@ namespace MuMech
                 // TODO: Be smarter about throttle limits on future stages.
                 if (i == stats.vacStats.Length - 1)
                 {
-                    if (this.core.thrust.limiter != MechJebModuleThrustController.LimitMode.UnstableIgnition)
-                    {
-                        stageAvgAccel *= (double)this.vesselState.throttleLimit;
-                    }
-                    else
-                    {
-                        double fLimitTemp = 1.0;
-                        if (this.core.thrust.limitThrottle)
-                        {
-                            fLimitTemp = this.core.thrust.maxThrottle;
-                        }
-                        if (this.core.thrust.limitAcceleration)
-                        {
-                            fLimitTemp = Math.Min(fLimitTemp, this.core.thrust.maxAccelerationLimit);
-                        }
-                        if (this.core.thrust.limiterMinThrottle)
-                        {
-                            fLimitTemp = Math.Max(this.core.thrust.minThrottle, fLimitTemp);
-                        }
-                        stageAvgAccel *= fLimitTemp;
-                    }
+                        stageAvgAccel *= (double)this.vesselState.throttleFixedLimit;
                 }
 
                 halfBurnTime += Math.Min(halfDvLeft, stageBurnDv) / stageAvgAccel;
@@ -255,6 +231,17 @@ namespace MuMech
 
                 burnTime += stageBurnDv / stageAvgAccel;
 
+            }
+
+            /* infinity means acceleration is zero for some reason, which is dangerous nonsense, so use zero instead */
+            if (double.IsInfinity(halfBurnTime))
+            {
+                halfBurnTime = 0.0;
+            }
+
+            if (double.IsInfinity(burnTime))
+            {
+                burnTime = 0.0;
             }
 
             return burnTime;

--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -296,15 +296,23 @@ namespace MuMech
         /* the fixed throttle limit (i.e. user limited in the GUI), does not include transient conditions as limiting to zero due to unstable propellants in RF */
         public float throttleFixedLimit { get; private set; }
 
+        /* This is an API for limits which are "temporary" or "conditional" (things like ullage status which will change very soon).
+           This will often be temporarily zero, which means the computed accelleration of the ship will be zero, which would cause
+           consumers (like the NodeExecutor) to compute infinite burntime, so this value should not be used by those consumers */
         private void setTempLimit(float limit, LimitMode mode)
         {
             throttleLimit = limit;
             limiter = mode;
         }
 
+        /* This is an API for limits which are not temporary (like the throttle limit set in the GUI)
+           The throttleFixedLimit is what consumers like the NodeExecutor should use to compute acceleration and burntime.
+           This deliberately sets both values.  The actually applied throttle limit may be lower than thottleFixedLimit
+           (i.e. there may be a more limiting temp limit) */
         private void setFixedLimit(float limit, LimitMode mode)
         {
-            throttleLimit = limit;
+            if (throttleLimit > limit)
+                throttleLimit = limit;
             throttleFixedLimit = limit;
             limiter = mode;
         }

--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -498,12 +498,12 @@ namespace MuMech
                 }
             }
 
-            if (double.IsNaN(throttleLimit)) throttleLimit = 0;
+            if (double.IsNaN(throttleLimit)) throttleLimit = 1.0;
             throttleLimit = Mathf.Clamp01(throttleLimit);
 
             /* we do not _apply_ the "fixed" limit, the actual throttleLimit should always be the more limited and lower one */
             /* the purpose of the "fixed" limit is for external consumers like the node executor to consume */
-            if (double.IsNaN(throttleFixedLimit)) throttleFixedLimit = 0;
+            if (double.IsNaN(throttleFixedLimit)) throttleFixedLimit = 1.0;
             throttleFixedLimit = Mathf.Clamp01(throttleFixedLimit);
 
             vesselState.throttleLimit = throttleLimit;

--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using KSP.UI.Screens;
@@ -112,8 +112,6 @@ namespace MuMech
 
         [Persistent(pass = (int)Pass.Global)]
         public EditableDouble maxAcceleration = 40;
-
-        public double maxAccelerationLimit = 1;
 
         [GeneralInfoItem("Limit acceleration", InfoItem.Category.Thrust)]
         public void LimitAccelerationInfoItem()
@@ -293,6 +291,24 @@ namespace MuMech
             targetThrottle = Mathf.Clamp01((float)(desiredAcceleration / vesselState.maxThrustAccel));
         }
 
+        /* the current throttle limit, this may include transient condition such as limiting to zero due to unstable propellants in RF */
+        public float throttleLimit { get; private set; }
+        /* the fixed throttle limit (i.e. user limited in the GUI), does not include transient conditions as limiting to zero due to unstable propellants in RF */
+        public float throttleFixedLimit { get; private set; }
+
+        private void setTempLimit(float limit, LimitMode mode)
+        {
+            throttleLimit = limit;
+            limiter = mode;
+        }
+
+        private void setFixedLimit(float limit, LimitMode mode)
+        {
+            throttleLimit = limit;
+            throttleFixedLimit = limit;
+            limiter = mode;
+        }
+
         public override void Drive(FlightCtrlState s)
         {
             float threshold = 0.1F;
@@ -397,51 +413,59 @@ namespace MuMech
             if (users.Count > 1)
                 s.mainThrottle = targetThrottle;
 
-            float throttleLimit = 1;
+            throttleLimit = 1;
+            throttleFixedLimit = 1;
 
             limiter = LimitMode.None;
 
             if (limitThrottle)
             {
-                if (maxThrottle < throttleLimit) limiter = LimitMode.Throttle;
-                throttleLimit = Mathf.Min(throttleLimit, (float)maxThrottle);
+                if (maxThrottle < throttleLimit)
+                {
+                    setFixedLimit((float)maxThrottle, LimitMode.Throttle);
+                }
             }
 
             if (limitToTerminalVelocity)
             {
                 float limit = TerminalVelocityThrottle();
-                if (limit < throttleLimit) limiter = LimitMode.TerminalVelocity;
-                throttleLimit = Mathf.Min(throttleLimit, limit);
+                if (limit < throttleLimit)
+                {
+                    setFixedLimit(limit, LimitMode.TerminalVelocity);
+                }
             }
 
             if (limitDynamicPressure)
             {
                 float limit = MaximumDynamicPressureThrottle();
-                if (limit < throttleLimit) limiter = LimitMode.DynamicPressure;
-                throttleLimit = Mathf.Min(throttleLimit, limit);
+                if (limit < throttleLimit)
+                {
+                    setFixedLimit(limit, LimitMode.DynamicPressure);
+                }
             }
 
             if (limitToPreventOverheats)
             {
                 float limit = (float)TemperatureSafetyThrottle();
-                if(limit < throttleLimit) limiter = LimitMode.Temperature;
-                throttleLimit = Mathf.Min(throttleLimit, limit);
+                if (limit < throttleLimit) {
+                    setFixedLimit(limit, LimitMode.Temperature);
+                }
             }
 
             if (limitAcceleration)
             {
                 float limit = AccelerationLimitedThrottle();
-                if(limit < throttleLimit) limiter = LimitMode.Acceleration;
-                throttleLimit = Mathf.Min(throttleLimit, limit);
-                // to provide an externally facing value. (used when ignition is unstable so we can approximate throttle limit when ignition stablizes)
-                maxAccelerationLimit = throttleLimit;
+                if (limit < throttleLimit) {
+                    setFixedLimit(limit, LimitMode.Acceleration);
+                }
             }
 
             if (electricThrottle && ElectricEngineRunning())
             {
                 float limit = ElectricThrottle();
-                if (limit < throttleLimit) limiter = LimitMode.Electric;
-                throttleLimit = Mathf.Min(throttleLimit, limit);
+                if (limit < throttleLimit) {
+                    setFixedLimit(limit, LimitMode.Electric);
+                }
             }
 
             if (limitToPreventFlameout)
@@ -449,14 +473,14 @@ namespace MuMech
                 // This clause benefits being last: if we don't need much air
                 // due to prior limits, we can close some intakes.
                 float limit = FlameoutSafetyThrottle();
-                if (limit < throttleLimit) limiter = LimitMode.Flameout;
-                throttleLimit = Mathf.Min(throttleLimit, limit);
+                if (limit < throttleLimit) {
+                    setFixedLimit(limit, LimitMode.Flameout);
+                }
             }
 
-            if (limiterMinThrottle  && limiter != LimitMode.None && throttleLimit < minThrottle)
+            if (limiterMinThrottle && limiter != LimitMode.None && throttleLimit < minThrottle)
             {
-                limiter = LimitMode.MinThrottle;
-                throttleLimit = (float) minThrottle;
+                setFixedLimit((float) minThrottle, LimitMode.MinThrottle);
             }
 
             // RealFuels ullage integration.  Stock always has stableUllage.
@@ -465,8 +489,7 @@ namespace MuMech
                 if (s.mainThrottle > 0.0F && throttleLimit > 0.0F )
                 {
                     // We want to fire the throttle, and nothing else is limiting us, but we have unstable ullage
-                    limiter = LimitMode.UnstableIgnition;
-                    throttleLimit = 0.0F;
+                    setTempLimit(0.0F, LimitMode.UnstableIgnition);
                     if (vessel.ActionGroups[KSPActionGroup.RCS] && s.Z == 0)
                     {
                         // RCS is on, so use it to ullage
@@ -478,7 +501,13 @@ namespace MuMech
             if (double.IsNaN(throttleLimit)) throttleLimit = 0;
             throttleLimit = Mathf.Clamp01(throttleLimit);
 
+            /* we do not _apply_ the "fixed" limit, the actual throttleLimit should always be the more limited and lower one */
+            /* the purpose of the "fixed" limit is for external consumers like the node executor to consume */
+            if (double.IsNaN(throttleFixedLimit)) throttleFixedLimit = 0;
+            throttleFixedLimit = Mathf.Clamp01(throttleFixedLimit);
+
             vesselState.throttleLimit = throttleLimit;
+            vesselState.throttleFixedLimit = throttleFixedLimit;
 
             if (s.mainThrottle < throttleLimit) limiter = LimitMode.None;
 

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -139,7 +139,10 @@ namespace MuMech
         public double maxEngineResponseTime = 0;
 
         public bool rcsThrust = false;
+        /* the current throttle limit, this may include transient condition such as limiting to zero due to unstable propellants in RF */
         public float throttleLimit = 1;
+        /* the fixed throttle limit (i.e. user limited in the GUI), does not include transient conditions as limiting to zero due to unstable propellants in RF */
+        public float throttleFixedLimit = 1;
         public double limitedMaxThrustAccel { get { return maxThrustAccel * throttleLimit + minThrustAccel * (1 - throttleLimit); } }
 
         public Vector3d CoT;


### PR DESCRIPTION
🚧 DO NOT MERGE YET 🚧 

Looking for @Starwaster 's feedback

Basically what this does is add another API that the ThrottleController exposes which is the "fixed" throttle limit.  Basically all the throttle limiting code other than ullaging sets this.  Then there is the throttleLimit which is still the actually applied throttle limit.  When ignitions are being prevented, typically the fixedThrottleLimit would be 1.0 while the throttleLimit would be 0.0.

The Node Executor now doesn't need to know as much about throttling and ullaging, and just trusts the fixedThrottleLimit from the throttle controller.

I also moved the infinity check around so that its a bit more aggressive about not presenting infinite burntime calculations through any API.  If there's a reason why some consumers need that patched and not others its definitely not obvious, and it reads more correct to be more aggressive about preventing infinite burntimes.