### PR TITLE
Fix launch negative inclination circularization bug

### DIFF
--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -79,7 +79,7 @@ namespace MuMech
         public double currentMaxAoA = 0;
 
         public double launchLatitude = 0 ;
-   
+
 
         public double tMinus
         {
@@ -91,7 +91,7 @@ namespace MuMech
         AscentMode mode;
         bool placedCircularizeNode = false;
         private double lastTMinus = 999;
-        
+
         public override void OnModuleEnabled()
         {
             if (autodeploySolarPanels && mainBody.atmosphere)
@@ -197,7 +197,7 @@ namespace MuMech
             if (timedLaunch)
             {
                 status = "Awaiting liftoff";
-                core.attitude.AxisControl(false, false, false); 
+                core.attitude.AxisControl(false, false, false);
                 return;
             }
 
@@ -210,7 +210,7 @@ namespace MuMech
                 double desiredHeading = OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination);
                 core.attitude.attitudeTo(desiredHeading, 90, verticalRoll, this);
             }
-            else 
+            else
             {
                 core.attitude.attitudeTo(Vector3d.up, AttitudeReference.SURFACE_NORTH, this);
             }
@@ -317,11 +317,11 @@ namespace MuMech
             if (correctiveSteering)
             {
                 Vector3d velocityError = (desiredVelocityUnit - actualVelocityUnit);
-                
+
                 double difficulty = vesselState.surfaceVelocity.magnitude * 0.02 / vesselState.ThrustAccel(core.thrust.targetThrottle);
                 difficulty = MuUtils.Clamp(difficulty, 0.1, 1.0);
                 Vector3d steerOffset = correctiveSteeringGain * difficulty * velocityError;
-                
+
 
                 //limit the amount of steering to 10 degrees. Furthermore, never steer to a FPA of > 90 (that is, never lean backward)
                 double maxOffset = 10 * UtilMath.Deg2Rad;
@@ -456,7 +456,7 @@ namespace MuMech
                 //  into it, you actually only spend 1513 m/s to execute combined manuver.  Mechjeb should also do correction burns before
                 //  this if possible, and this can't correct all errors... but it's better then nothing.
                 //   (A better version of this should try to match inclination & LAN if target is specified)
-                Vector3d inclinationCorrection = OrbitalManeuverCalculator.DeltaVToChangeInclination(orbit, UT, desiredInclination);
+                Vector3d inclinationCorrection = OrbitalManeuverCalculator.DeltaVToChangeInclination(orbit, UT, Math.Abs(desiredInclination));
                 Vector3d smaCorrection = OrbitalManeuverCalculator.DeltaVForSemiMajorAxis(orbit.PerturbedOrbit(UT, inclinationCorrection), UT,
                     desiredOrbitAltitude + mainBody.Radius);
                 Vector3d dV = inclinationCorrection + smaCorrection;


### PR DESCRIPTION
negative inclinations are always the expensive way to change
inclination, positive inclinations are always the cheap way, and
that is baked into the function we are calling.

closes #857
