### PR TITLE
fix low inclination ascent wiggles

### DIFF
--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -207,7 +207,7 @@ namespace MuMech
             //during the vertical ascent we just thrust straight up at max throttle
             if (forceRoll)
             { // pre-align roll unless correctiveSteering is active as it would just interfere with that
-                double desiredHeading = OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination);
+                double desiredHeading = OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination, launchLatitude);
                 core.attitude.attitudeTo(desiredHeading, 90, verticalRoll, this);
             }
             else
@@ -305,7 +305,7 @@ namespace MuMech
             Vector3d actualVelocityUnit = ((1 - referenceFrameBlend) * vesselState.surfaceVelocity.normalized
                                                + referenceFrameBlend * vesselState.orbitalVelocity.normalized).normalized;
 
-            double desiredHeading = UtilMath.Deg2Rad * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination);
+            double desiredHeading = UtilMath.Deg2Rad * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination, launchLatitude);
             Vector3d desiredHeadingVector = Math.Sin(desiredHeading) * vesselState.east + Math.Cos(desiredHeading) * vesselState.north;
             double desiredFlightPathAngle = ascentPath.FlightPathAngle(vesselState.altitudeASL, vesselState.speedSurface);
 
@@ -401,7 +401,7 @@ namespace MuMech
             // - Starwaster
             core.thrust.targetThrottle = 0;
 
-            double desiredHeading = UtilMath.Deg2Rad * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination);
+            double desiredHeading = UtilMath.Deg2Rad * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, desiredInclination, launchLatitude);
             Vector3d desiredHeadingVector = Math.Sin(desiredHeading) * vesselState.east + Math.Cos(desiredHeading) * vesselState.north;
             double desiredFlightPathAngle = ascentPath.FlightPathAngle(vesselState.altitudeASL, vesselState.speedSurface);
 

--- a/MechJeb2/MechJebModuleAscentNavBall.cs
+++ b/MechJeb2/MechJebModuleAscentNavBall.cs
@@ -8,7 +8,7 @@ namespace MuMech
         {
             enabled = true;
         }
-        
+
         public bool NavBallGuidance
         {
             get
@@ -45,7 +45,7 @@ namespace MuMech
             if (NavBallGuidance && autopilot != null && autopilot.ascentPath != null)
             {
                 double angle = UtilMath.Deg2Rad * autopilot.ascentPath.FlightPathAngle(vesselState.altitudeASL, vesselState.speedSurface);
-                double heading = UtilMath.Deg2Rad * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, autopilot.desiredInclination);
+                double heading = UtilMath.Deg2Rad * OrbitalManeuverCalculator.HeadingForLaunchInclination(vessel, vesselState, autopilot.desiredInclination, autopilot.launchLatitude);
                 Vector3d horizontalDir = Math.Cos(heading) * vesselState.north + Math.Sin(heading) * vesselState.east;
                 Vector3d dir = Math.Cos(angle) * horizontalDir + Math.Sin(angle) * vesselState.up;
                 core.target.UpdateDirectionTarget(dir);

--- a/MechJeb2/MuUtils.cs
+++ b/MechJeb2/MuUtils.cs
@@ -23,7 +23,7 @@ namespace MuMech
             if (d == 0 || double.IsInfinity(d) || double.IsNaN(d)) return d.ToString() + " ";
 
             int exponent = (int)Math.Floor(Math.Log10(Math.Abs(d))); //exponent of d if it were expressed in scientific notation
-            
+
             const int unitIndexOffset = 8; //index of "" in the units array
             int unitIndex = (int)Math.Floor(exponent / 3.0) + unitIndexOffset;
             if (unitIndex < 0) unitIndex = 0;
@@ -143,7 +143,7 @@ namespace MuMech
         }
 
         //Some black magic to access the system clipboard from within Unity, found somewhere on the Web.
-        //Unfortunately it doesn't seem we have access to the System.Windows.Forms.Clipboard class, which would 
+        //Unfortunately it doesn't seem we have access to the System.Windows.Forms.Clipboard class, which would
         //make this easier.
         private static PropertyInfo m_systemCopyBufferProperty = null;
         private static PropertyInfo GetSystemCopyBufferProperty()
@@ -170,7 +170,7 @@ namespace MuMech
                 P.SetValue(null, value, null);
             }
         }
- 
+
 		public static IList<T> Swap<T>(this IList<T> list, int indexA, int indexB)
 		{
 			T tmp = list[indexA];
@@ -239,15 +239,15 @@ namespace MuMech
 
             if (hi == 0)
                 return new Color(v, t, p, alpha);
-            if (hi == 1)           
+            if (hi == 1)
                 return new Color(q, v, p, alpha);
-            if (hi == 2)           
+            if (hi == 2)
                 return new Color(p, v, t, alpha);
-            if (hi == 3)           
+            if (hi == 3)
                 return new Color(p, q, v, alpha);
-            if (hi == 4)           
+            if (hi == 4)
                 return new Color(t, p, v, alpha);
-                                    
+
             return new Color(v, p, q, alpha);
         }
     }
@@ -350,7 +350,7 @@ namespace MuMech
         {
             return v.value;
         }
-        
+
         public override string ToString()
         {
             return value.ToString();
@@ -369,7 +369,7 @@ namespace MuMech
         protected Dictionary<TKey, TValue> d = new Dictionary<TKey, TValue>();
         // Also store the keys in a list so we can iterate them without allocating an IEnumerator
         protected List<TKey> k = new List<TKey>();
-        
+
         public virtual TValue this[TKey key]
         {
             get
@@ -457,7 +457,7 @@ namespace MuMech
             }
         }
     }
-    
+
     //Represents a 2x2 matrix
     public class Matrix2x2
     {
@@ -492,14 +492,14 @@ namespace MuMech
     }
 
     //Is it silly to have a Matrix2x2 and a Matrix3x3, and not a generic Matrix? Yes.
-    //However I don't feel like implementing inverse() for matrices larger than 
+    //However I don't feel like implementing inverse() for matrices larger than
     //2x2, and I want Matrix3x3f to interact nicely with Vector3.
     public class Matrix3x3f
     {
         //row index, then column index
         private float[,] e = new float[3, 3];
 
-        public float this[int i, int j] 
+        public float this[int i, int j]
         {
             get { return e[i, j]; }
             set { e[i, j] = value; }
@@ -529,7 +529,7 @@ namespace MuMech
 			return ret;
 		}
 
-        public static Vector3d operator *(Matrix3x3f M, Vector3 v) 
+        public static Vector3d operator *(Matrix3x3f M, Vector3 v)
         {
             Vector3 ret = Vector3.zero;
             for(int i = 0; i < 3; i++) {


### PR DESCRIPTION
when launching from Kennedy (28.608) to the moon (28.363) the
ascent guidance would start (correctly) by burning due East (can't
launch to lower than your launch latitude).

as the craft followed a great circle track, the latitude of the craft
would fall allowing smaller latitudes.  however this resulted in the
craft attempting an inclination change at the end of the burn by
turning north (the opposite of a southwards jog at the start of the
burn) which was both expensive and totally screwed up plane targeting.

this fixes this by just not allowing inclinations which are below the
launch latitude (also allowing inclinations which are below the current
orbital inclination which would be fine if someone winds up in that
situation through some kind of button mashing).

this makes south-jogs very hard to do, but it results in very precise 0.25
degree errors when launching to the moon from KSC in RSS.  scanning
through NK's videos from 1.1.3-era he seems to have done no better than
this and often as bad as 0.40+ when launch to the moon with a south
jog.  i think mostly his south-jogs were fighting with the old MJ ascent
guidance which did no great-circle tracking.

adding south jogs would be hard since you need to 'know' the south jog
happened and allow the permissible launch inclination to lower.  it
might be necessary at that point to allow unclamped launch inclinations
and let people jog south and then correct, but i had a hard time getting
any better results than just with the clamped inclination.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>