### PR TITLE
one more ullage refactoring

### DIFF
--- a/MechJeb2/MechJebModuleThrustWindow.cs
+++ b/MechJeb2/MechJebModuleThrustWindow.cs
@@ -60,6 +60,7 @@ namespace MuMech
             {
                 // does nothing in stock, so we suppress displaying it if RF is not loaded
                 core.thrust.LimitToPreventUnstableIgnitionInfoItem();
+                core.thrust.AutoRCsUllageInfoItem();
             }
             core.thrust.smoothThrottle = GUILayout.Toggle(core.thrust.smoothThrottle, "Smooth throttle");
             core.thrust.manageIntakes = GUILayout.Toggle(core.thrust.manageIntakes, "Manage air intakes");
@@ -98,9 +99,9 @@ namespace MuMech
             core.solarpanel.AutoDeploySolarPanelsInfoItem();
 
             Autostage();
-            
+
             if (!core.staging.enabled && GUILayout.Button("Autostage once")) core.staging.AutostageOnce(this);
-            
+
             if (core.staging.enabled) core.staging.AutostageSettingsInfoItem();
 
             if (core.staging.enabled) GUILayout.Label(core.staging.AutostageStatus());

--- a/MechJeb2/VesselExtensions.cs
+++ b/MechJeb2/VesselExtensions.cs
@@ -42,7 +42,7 @@ namespace MuMech
                 for (int m = 0; m < count; m++)
                 {
                     T mod = part.Modules[m] as T;
-                    
+
                     if (mod != null)
                         list.Add(mod);
                 }
@@ -61,7 +61,7 @@ namespace MuMech
                 lastFixedTime = Time.fixedTime;
             }
             Guid vesselKey = vessel == null ? Guid.Empty : vessel.id;
-            
+
             MechJebCore mj;
             if (!masterMechJeb.TryGetValue(vesselKey, out mj))
             {
@@ -339,6 +339,26 @@ namespace MuMech
                 return;
             node.attachedGizmo.patchBefore = node.patch;
             node.attachedGizmo.patchAhead = node.nextPatch;
+        }
+
+        // The part loop in VesselState could expose this, but it gets disabled when the RCS action group is disabled.
+        // This method is also useful when the RCS AG is off.
+        public static bool hasEnabledRCSModules(this Vessel vessel)
+        {
+            var rcsModules = vessel.FindPartModulesImplementing<ModuleRCS>();
+
+            for (int m = 0; m < rcsModules.Count; m++)
+            {
+                ModuleRCS rcs = rcsModules[m];
+
+                if (rcs == null)
+                    continue;
+
+                if (rcs.rcsEnabled && rcs.isEnabled && !rcs.isJustForShow)
+                    return true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
- VesselState now exposes the lowestUllage condition rather than
stableUllage

- The "prevent unstable ignitions" box now only does what it says
it does.  If its checked, ullage must be stable.

- Introduced a new "Use RCS to ullage" checkbox, and moved the
auto-RCS ullaging to this function.  It is a bit smarter and does
nothing if there's no ModuleRCS active.  It will also enable the
RCS action group automatically (if there is ModuleRCS to activate)

The latter function should pretty much be safe to run with all the
time, since stuff like sounding rockets don't have any RCS.

Auto-RCS should also not get confused by RCS in probe modules since
the RCS module needs to be enabled, and with KSP >= 1.2.x we all
should be staging our RCS properly.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>