### PR TITLE
Further docking AP fixes

### DIFF
--- a/MechJeb2/MechJebModuleDockingGuidance.cs
+++ b/MechJeb2/MechJebModuleDockingGuidance.cs
@@ -126,7 +126,7 @@ namespace MuMech
                 GUILayout.Label("Error Z: " + error_z.ToString("F2") + " m/s  [H/N]");
 
                 GUILayout.Label("Distance Dock: " + autopilot.zSep.ToString("F2") + "m");
-                GUILayout.Label("Distance Axe Dock: " + autopilot.lateralSep.magnitude.ToString("F2") + "m");
+                GUILayout.Label("Distance Dock Axis: " + autopilot.lateralSep.magnitude.ToString("F2") + "m");
 
             }
 


### PR DESCRIPTION
* Better handling of lateral separation closure to address issue where MJ doesn't want to close the final half meter of distance between docking axes. This is done by slowing closure rate down the Z axis and increasing lateral axis closure rate.