### PR TITLE
Rover AP overhaul for the configurable stock wheels

### DIFF
--- a/MechJeb2/MechJebModuleRoverController.cs
+++ b/MechJeb2/MechJebModuleRoverController.cs
@@ -333,7 +333,7 @@ namespace MuMech
 				headingErr = MuUtils.ClampDegrees180(instantaneousHeading - heading);
 				if (s.wheelSteer == s.wheelSteerTrim || FlightGlobals.ActiveVessel != vessel)
 				{
-					float limit = (Math.Abs(curSpeed) > turnSpeed ? Mathf.Clamp((float)((turnSpeed + 6) / Math.Pow(curSpeed, 2)), 0.1f, 1f) : 1f);
+					float limit = (Math.Abs(curSpeed) > turnSpeed ? Mathf.Clamp((float)((turnSpeed + 6) / Square(curSpeed)), 0.1f, 1f) : 1f);
 					// turnSpeed needs to be higher than curSpeed or it will never steer as much as it could even at 0.2m/s above it
 					// double act = headingPID.Compute(headingErr * headingErr / 10 * Math.Sign(headingErr));
 					double act = headingPID.Compute(headingErr);

--- a/MechJeb2/MechJebModuleRoverWindow.cs
+++ b/MechJeb2/MechJebModuleRoverWindow.cs
@@ -106,10 +106,10 @@ namespace MuMech
 			GUILayout.BeginHorizontal();
 			if (autopilot.Waypoints.Count > 0) {
 				if (!autopilot.ControlHeading || !autopilot.ControlSpeed) {
-					if (GUILayout.Button("Follow")) {
-						autopilot.WaypointIndex = 0;
+					if (GUILayout.Button("Drive")) {
+						autopilot.WaypointIndex = (alt ? 0 : autopilot.WaypointIndex);
 						autopilot.ControlHeading = autopilot.ControlSpeed = true;
-						autopilot.LoopWaypoints = alt;
+						// autopilot.LoopWaypoints = alt;
 					}
 				}
 				else if (GUILayout.Button("Stop")) {

--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -573,7 +573,8 @@ namespace MuMech
 					{
 						if (alt)
 						{
-							ap.WaypointIndex = i;
+							ap.WaypointIndex = (ap.WaypointIndex == i ? -1 : i);
+							// set current waypoint or unset it if it's already the current one
 						}
 						else
 						{


### PR DESCRIPTION
I've noticed that the RoverAP became absolutely incapable of driving towards a target and actually stop in time, so it was time to figure out again how GitHub works, which I have to every single time I get back to this.

Anyways:
- WarpToDaylight is default off now, no idea why I made it default to on
- steering PID was adjusted to hopefully work better with the now different wheels
- averaging samples for the ETA was reduced a lot because it was just too large
- lots of changes to how it treats speed and turning at higher speeds, aka no longer jerking the steering to max while going 30m/s
- reminded it how2brake because it somehow forgot
- renamed the AP's "Follow" button to "Drive", though I should probably make it change depending on whenever or not you have selected a vessel, but it seems a little less confusing to me now
- changed the "Drive" button to no longer reset the waypoint index so it can be simply used as a Start/Stop button, instead alt+click now sets the waypoint index to the first waypoint
- alt+clicking the current waypoint in the waypoint list will now set the index to -1 meaning no active waypoint at all

While I've tested this build for a longer while now including having a rover go 120km on Minmus at 35m/s where the only issues were hill ramping with excessive landings would it probably not hurt if other people could also test vehicles to see if there might be other issues.