### PR TITLE
Add node merging to Maneuver Editor

### DIFF
--- a/MechJeb2/MechJebModuleNodeEditor.cs
+++ b/MechJeb2/MechJebModuleNodeEditor.cs
@@ -32,6 +32,16 @@ namespace MuMech
             normalPlus = dV.y;
         }
 
+        void MergeNext(int index)
+        {
+            ManeuverNode cur = vessel.patchedConicSolver.maneuverNodes[index];
+            ManeuverNode next = vessel.patchedConicSolver.maneuverNodes[index+1];
+
+            double newUT = (cur.UT + next.UT) / 2;
+            cur.UpdateNode(cur.patch.DeltaVToManeuverNodeCoordinates(newUT, cur.WorldDeltaV() + next.WorldDeltaV()), newUT);
+            next.RemoveSelf();
+        }
+
         protected override void WindowGUI(int windowID)
         {
             if (vessel.patchedConicSolver.maneuverNodes.Count == 0)
@@ -60,6 +70,7 @@ namespace MuMech
                 nodeIndex = GuiUtils.ArrowSelector(nodeIndex, numNodes, "Maneuver node #" + (nodeIndex + 1));
 
                 node = vessel.patchedConicSolver.maneuverNodes[nodeIndex];
+                if (nodeIndex < (numNodes-1) && GUILayout.Button("Merge next node")) MergeNext(nodeIndex);
             }
 
             if (node != oldNode)

--- a/MechJeb2/VesselExtensions.cs
+++ b/MechJeb2/VesselExtensions.cs
@@ -341,6 +341,11 @@ namespace MuMech
             node.attachedGizmo.patchAhead = node.nextPatch;
         }
 
+        public static Vector3d WorldDeltaV(this ManeuverNode node)
+        {
+            return node.patch.Prograde(node.UT) * node.DeltaV.z + node.patch.RadialPlus(node.UT) * node.DeltaV.x + -node.patch.NormalPlus(node.UT) * node.DeltaV.y;
+        }
+
         // The part loop in VesselState could expose this, but it gets disabled when the RCS action group is disabled.
         // This method is also useful when the RCS AG is off.
         public static bool hasEnabledRCSModules(this Vessel vessel)


### PR DESCRIPTION
*Super* useful when doing standard burns that involve both in- and out-of-plane delta-V (e.g. changing inclination and periapsis/apoapsis for transfer to geostationary).

Example easy apogee kick into GSO:
1. Create maneuver to change inclination to 0 at highest AN/DN
2. Create maneuver to raise periapsis to 35786km at a fixed time of 0s after next node
3. Merge nodes. Done!

UI could be improved, and attempting to merge nodes that are far apart in time leads to totally useless results, as expected.