### PR TITLE
Format Code & Disable roll control on the ground

### DIFF
--- a/MechJeb2/MechJebModuleAirplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleAirplaneAutopilot.cs
@@ -43,8 +43,9 @@ namespace MuMech
         public override void OnModuleDisabled ()
         {
             core.attitude.attitudeDeactivate ();
-            if (SpeedHoldEnabled)
-                DisableSpeedHold ();
+            if (SpeedHoldEnabled) {
+                core.thrust.users.Remove (this);
+            }
         }
 
         public void EnableHeadingHold ()

--- a/MechJeb2/MechJebModuleAirplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleAirplaneAutopilot.cs
@@ -172,7 +172,7 @@ namespace MuMech
                 double vertspd = vesselState.speedVertical;
                 v_err = RealVertSpeedTarget - vertspd;
                 VertSpeedPIDController.intAccum = MuUtils.Clamp (VertSpeedPIDController.intAccum, -60 / AccKi, 60 / AccKi);
-                exp_act = Mathf.Asin (Mathf.Clamp ((float)(RealVertSpeedTarget / vesselState.speedSurface), -1, 1)) * 57.2957795;
+                exp_act = Mathf.Asin (Mathf.Clamp ((float)(RealVertSpeedTarget / vesselState.speedSurface), -1, 1)) * UtilMath.Rad2Deg;
                 double p_act = exp_act + VertSpeedPIDController.Compute (v_err);
                 //Debug.Log(p_act);
                 if (!double.IsNaN (p_act)) {
@@ -184,17 +184,19 @@ namespace MuMech
             } else {
                 pitch = vesselState.vesselPitch;
             }
-
+            double curHeading = vesselState.HeadingFromDirection(vesselState.forward);
             if (HeadingHoldEnabled) {
                 //heading = HeadingTarget;
-                double toturn = MuUtils.ClampDegrees180 (HeadingTarget - vesselState.vesselHeading);
+                //double curHeading = vesselState.HeadingFromDirection(vesselState.forward);
+                double toturn = MuUtils.ClampDegrees180 (HeadingTarget - curHeading);
+                //Debug.Log(curHeading.ToString("F2")+" "+toturn.ToString ("F2"));
                 RealRollTarget = MuUtils.Clamp (toturn * 2, -RollMax, RollMax);
-                heading = MuUtils.ClampDegrees360 (vesselState.vesselHeading + RealRollTarget / 10);
+                heading = MuUtils.ClampDegrees360 (curHeading + RealRollTarget / 10);
                 if (-3 < toturn && toturn < 3)
                     heading = HeadingTarget;
             } else {
                 RealRollTarget = RollTarget;
-                heading = MuUtils.ClampDegrees360 (vesselState.vesselHeading + RealRollTarget / 10);
+                heading = MuUtils.ClampDegrees360 (curHeading + RealRollTarget / 10);
             }
             if (RollHoldEnabled) {
                 roll = RealRollTarget;

--- a/MechJeb2/MechJebModuleAirplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleAirplaneAutopilot.cs
@@ -171,7 +171,9 @@ namespace MuMech
                 double vertspd = vesselState.speedVertical;
                 v_err = RealVertSpeedTarget - vertspd;
                 VertSpeedPIDController.intAccum = MuUtils.Clamp (VertSpeedPIDController.intAccum, -60 / AccKi, 60 / AccKi);
-                exp_act = Mathf.Asin (Mathf.Clamp ((float)(RealVertSpeedTarget / vesselState.speedSurface), -1, 1)) * UtilMath.Rad2Deg;
+                //Debug.Log (vessel.graviticAcceleration.magnitude);
+                //Todo :find a better expression to update expected_act
+                exp_act = Mathf.Asin (Mathf.Clamp ((float)((RealVertSpeedTarget + (vessel.graviticAcceleration.magnitude / 2)) / vesselState.speedSurface), -1, 1)) * UtilMath.Rad2Deg;
                 double p_act = exp_act + VertSpeedPIDController.Compute (v_err);
                 if (!double.IsNaN (p_act)) {
                     pitch = MuUtils.Clamp (p_act, -60, 60);

--- a/MechJeb2/MechJebModuleAirplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleAirplaneAutopilot.cs
@@ -113,7 +113,7 @@ namespace MuMech
 
         double fixVertSpeed (double deltaAltitude)
         {
-            double reference = 4;
+            double reference = 5;
             if (reference < 2)
                 reference = 2;
             if (deltaAltitude > reference || deltaAltitude < -reference)

--- a/MechJeb2/MechJebModuleAirplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleAirplaneAutopilot.cs
@@ -7,92 +7,112 @@ namespace MuMech
     public class MechJebModuleAirplaneAutopilot : ComputerModule
     {
         //double heading,pitch,roll;
-        public bool HeadingHoldEnabled=false,AltitudeHoldEnabled=false,VertSpeedHoldEnabled=false,RollHoldEnabled=false,SpeedHoldEnabled=false;
+        public bool HeadingHoldEnabled = false, AltitudeHoldEnabled = false, VertSpeedHoldEnabled = false, RollHoldEnabled = false, SpeedHoldEnabled = false;
 
-        [Persistent(pass = (int)Pass.Global)]
-        public double AltitudeTarget = 0,HeadingTarget = 90,RollTarget = 0,SpeedTarget = 0,VertSpeedTarget = 0, VertSpeedMax = 10, RollMax = 30;
+        [Persistent (pass = (int)Pass.Global)]
+        public double AltitudeTarget = 0, HeadingTarget = 90, RollTarget = 0, SpeedTarget = 0, VertSpeedTarget = 0, VertSpeedMax = 10, RollMax = 30;
 
         private double pitch, heading, roll;
 
-        [Persistent(pass = (int)Pass.Global)]
-        public EditableDouble AccKp=1, AccKi=0.1, AccKd=0.01;
+        [Persistent (pass = (int)Pass.Global)]
+        public EditableDouble AccKp = 1, AccKi = 0.1, AccKd = 0.01;
 
-        [Persistent(pass = (int)Pass.Global)]
-        public EditableDouble VerKp=1, VerKi=0.1, VerKd=0.01;
+        [Persistent (pass = (int)Pass.Global)]
+        public EditableDouble VerKp = 1, VerKi = 0.1, VerKd = 0.01;
 
         double _spd = 0;
 
-        public PIDController AccelerationPIDController,VertSpeedPIDController;
+        public PIDController AccelerationPIDController, VertSpeedPIDController;
 
-        public MechJebModuleAirplaneAutopilot(MechJebCore core) : base(core)
+        public MechJebModuleAirplaneAutopilot (MechJebCore core) : base (core)
         {
             
         }
 
-        public override void OnModuleEnabled()
+        public override void OnModuleEnabled ()
         {
-            //Debug.Log ("Autopilot Engaged");
-
-            AccelerationPIDController = new PIDController(AccKp,AccKi,AccKd);
-            VertSpeedPIDController = new PIDController(VerKp,VerKi,VerKd);
-            core.attitude.users.Add(this);
+            AccelerationPIDController = new PIDController (AccKp, AccKi, AccKd);
+            VertSpeedPIDController = new PIDController (VerKp, VerKi, VerKd);
+            core.attitude.users.Add (this);
             if (AltitudeHoldEnabled)
                 EnableAltitudeHold ();
             if (SpeedHoldEnabled)
                 EnableSpeedHold ();
         }
 
-        public override void OnModuleDisabled()
+        public override void OnModuleDisabled ()
         {
-            core.attitude.attitudeDeactivate();
-            if(SpeedHoldEnabled)DisableSpeedHold ();
+            core.attitude.attitudeDeactivate ();
+            if (SpeedHoldEnabled)
+                DisableSpeedHold ();
         }
 
-        public void EnableHeadingHold(){
+        public void EnableHeadingHold ()
+        {
             HeadingHoldEnabled = true;
             RollHoldEnabled = true;
         }
-        public void DisableHeadingHold(){
+
+        public void DisableHeadingHold ()
+        {
             HeadingHoldEnabled = false;
             RollHoldEnabled = false;
         }
 
-        public void EnableSpeedHold(){
-            if (!enabled) return;
+        public void EnableSpeedHold ()
+        {
+            if (!enabled)
+                return;
             _spd = vesselState.speedSurface;
             SpeedHoldEnabled = true;
-            core.thrust.users.Add(this);
-            AccelerationPIDController.Reset();
-        }
-        public void DisableSpeedHold(){
-            if (!enabled) return;
-            SpeedHoldEnabled = false;
-            core.thrust.users.Remove(this);
+            core.thrust.users.Add (this);
+            AccelerationPIDController.Reset ();
         }
 
-        public void EnableVertSpeedHold(){
-            if (!enabled) return;
-            VertSpeedHoldEnabled = true;
-            VertSpeedPIDController.Reset();
+        public void DisableSpeedHold ()
+        {
+            if (!enabled)
+                return;
+            SpeedHoldEnabled = false;
+            core.thrust.users.Remove (this);
         }
-        public void DisableVertSpeedHold(){
-            if (!enabled) return;
+
+        public void EnableVertSpeedHold ()
+        {
+            if (!enabled)
+                return;
+            VertSpeedHoldEnabled = true;
+            VertSpeedPIDController.Reset ();
+        }
+
+        public void DisableVertSpeedHold ()
+        {
+            if (!enabled)
+                return;
             VertSpeedHoldEnabled = false;
         }
 
-        public void EnableAltitudeHold(){
-            if (!enabled) return;
+        public void EnableAltitudeHold ()
+        {
+            if (!enabled)
+                return;
             AltitudeHoldEnabled = true;
-            if (VertSpeedHoldEnabled) VertSpeedPIDController.Reset ();
-            else EnableVertSpeedHold ();
+            if (VertSpeedHoldEnabled)
+                VertSpeedPIDController.Reset ();
+            else
+                EnableVertSpeedHold ();
         }
-        public void DisableAltitudeHold(){
-            if (!enabled) return;
+
+        public void DisableAltitudeHold ()
+        {
+            if (!enabled)
+                return;
             AltitudeHoldEnabled = false;
             DisableVertSpeedHold ();
         }
 
-        double fixVertSpeed(double deltaAltitude){
+        double fixVertSpeed (double deltaAltitude)
+        {
             double reference = 4;
             if (reference < 2)
                 reference = 2;
@@ -106,7 +126,8 @@ namespace MuMech
                 return -deltaAltitude * deltaAltitude / (reference * reference);
         }
 
-        public void UpdatePID(){
+        public void UpdatePID ()
+        {
             VertSpeedPIDController.Kp = VerKp;
             VertSpeedPIDController.Ki = VerKi;
             VertSpeedPIDController.Kd = VerKd;
@@ -115,10 +136,10 @@ namespace MuMech
             AccelerationPIDController.Kd = AccKd;
         }
 
-        public double a_err,v_err,exp_act,cur_acc;
-        public double RealVertSpeedTarget,RealRollTarget,RealAccelerationTarget;
-        public override void OnFixedUpdate()
+        public double a_err, v_err, exp_act, cur_acc;
+        public double RealVertSpeedTarget, RealRollTarget, RealAccelerationTarget;
 
+        public override void OnFixedUpdate ()
         {
             UpdatePID ();
 
@@ -126,31 +147,32 @@ namespace MuMech
                 double spd = vesselState.speedSurface;
                 cur_acc = (spd - _spd) / Time.fixedDeltaTime;
                 _spd = spd;
-                RealAccelerationTarget = (SpeedTarget - spd)/4;
+                RealAccelerationTarget = (SpeedTarget - spd) / 4;
                 a_err = (RealAccelerationTarget - cur_acc);
-                AccelerationPIDController.intAccum = MuUtils.Clamp(AccelerationPIDController.intAccum,-1/AccKi,1/AccKi);
+                AccelerationPIDController.intAccum = MuUtils.Clamp (AccelerationPIDController.intAccum, -1 / AccKi, 1 / AccKi);
                 //float t_act = (float)AccelerationPIDController.Compute(a_err);
-                double t_act = AccelerationPIDController.Compute(a_err);
+                double t_act = AccelerationPIDController.Compute (a_err);
                 if (!double.IsNaN (t_act)) {
                     //Debug.Log(t_act);
-                    core.thrust.targetThrottle = (float)MuUtils.Clamp(t_act,0,1);
-                }
-                else {
+                    core.thrust.targetThrottle = (float)MuUtils.Clamp (t_act, 0, 1);
+                } else {
                     core.thrust.targetThrottle = 0.0f;
                     AccelerationPIDController.Reset ();
                 }
             }
 
             //Pitch ctrl
-            if (AltitudeHoldEnabled)RealVertSpeedTarget = MuUtils.Clamp (fixVertSpeed(AltitudeTarget - vesselState.altitudeASL), -VertSpeedMax, VertSpeedMax);
-            else RealVertSpeedTarget = VertSpeedTarget;
+            if (AltitudeHoldEnabled)
+                RealVertSpeedTarget = MuUtils.Clamp (fixVertSpeed (AltitudeTarget - vesselState.altitudeASL), -VertSpeedMax, VertSpeedMax);
+            else
+                RealVertSpeedTarget = VertSpeedTarget;
 
             if (VertSpeedHoldEnabled) {
                 double vertspd = vesselState.speedVertical;
-                v_err=RealVertSpeedTarget - vertspd;
-                VertSpeedPIDController.intAccum = MuUtils.Clamp(VertSpeedPIDController.intAccum,-60/AccKi,60/AccKi);
+                v_err = RealVertSpeedTarget - vertspd;
+                VertSpeedPIDController.intAccum = MuUtils.Clamp (VertSpeedPIDController.intAccum, -60 / AccKi, 60 / AccKi);
                 exp_act = Mathf.Asin (Mathf.Clamp ((float)(RealVertSpeedTarget / vesselState.speedSurface), -1, 1)) * 57.2957795;
-                double p_act =exp_act + VertSpeedPIDController.Compute (v_err);
+                double p_act = exp_act + VertSpeedPIDController.Compute (v_err);
                 //Debug.Log(p_act);
                 if (!double.IsNaN (p_act)) {
                     pitch = MuUtils.Clamp (p_act, -60, 60);
@@ -158,31 +180,27 @@ namespace MuMech
                     pitch = vesselState.vesselPitch;
                     VertSpeedPIDController.Reset ();
                 }
-            }
-            else{
-                pitch=vesselState.vesselPitch;
+            } else {
+                pitch = vesselState.vesselPitch;
             }
 
             if (HeadingHoldEnabled) {
                 //heading = HeadingTarget;
-                double toturn = MuUtils.ClampDegrees180(HeadingTarget - vesselState.vesselHeading);
-                RealRollTarget = MuUtils.Clamp (toturn*2, -RollMax, RollMax);
-                heading = MuUtils.ClampDegrees360(vesselState.vesselHeading+RealRollTarget/10);
+                double toturn = MuUtils.ClampDegrees180 (HeadingTarget - vesselState.vesselHeading);
+                RealRollTarget = MuUtils.Clamp (toturn * 2, -RollMax, RollMax);
+                heading = MuUtils.ClampDegrees360 (vesselState.vesselHeading + RealRollTarget / 10);
                 if (-3 < toturn && toturn < 3)
                     heading = HeadingTarget;
-            }
-            else {
+            } else {
                 RealRollTarget = RollTarget;
-                heading = MuUtils.ClampDegrees360(vesselState.vesselHeading+RealRollTarget/10);
+                heading = MuUtils.ClampDegrees360 (vesselState.vesselHeading + RealRollTarget / 10);
             }
             if (RollHoldEnabled) {
                 roll = RealRollTarget;
-            }
-            else {
+            } else {
                 roll = vesselState.vesselPitch;
             }
-            core.attitude.attitudeTo (heading, pitch, roll, this, AltitudeHoldEnabled||VertSpeedHoldEnabled, HeadingHoldEnabled, RollHoldEnabled);
-            //core.attitude.AxisControl (AutoPitchCtrl,AutoHeadingCtrl,AutoRollCtrl);
+            core.attitude.attitudeTo (heading, pitch, roll, this, AltitudeHoldEnabled || VertSpeedHoldEnabled, HeadingHoldEnabled, RollHoldEnabled && vessel.situation != Vessel.Situations.LANDED && vessel.situation != Vessel.Situations.PRELAUNCH);
         }
     }
 }

--- a/MechJeb2/MechJebModuleAirplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleAirplaneGuidance.cs
@@ -93,8 +93,6 @@ namespace MuMech
                         autopilot.DisableVertSpeedHold ();
                 }
                 VertSpeedTargettmp.text = GUILayout.TextField (VertSpeedTargettmp.text, GUILayout.ExpandWidth (true), GUILayout.Width (60));
-                if (VertSpeedTargettmp < 0)
-                    VertSpeedTargettmp = 0;
                 GUILayout.Label ("m/s", GUILayout.ExpandWidth (true));
                 if (GUILayout.Button ("Set", autopilot.VertSpeedTarget == VertSpeedTargettmp ? btWhite : btGreen)) {
                     autopilot.VertSpeedTarget = VertSpeedTargettmp;
@@ -205,6 +203,30 @@ namespace MuMech
                 GUILayout.EndHorizontal ();
                 if (autopilot.VertSpeedHoldEnabled)
                     GUILayout.Label ("error:" + autopilot.v_err.ToString ("F2") + " Target:" + autopilot.RealVertSpeedTarget.ToString ("F2") + " Cur:" + vesselState.speedVertical.ToString ("F2"), GUILayout.ExpandWidth (false));
+                
+                GUILayout.BeginHorizontal ();
+                GUILayout.Label ("Roll", GUILayout.ExpandWidth (true));
+                GUILayout.Label ("Kp", GUILayout.ExpandWidth (false));
+                autopilot.RolKp.text = GUILayout.TextField (autopilot.RolKp.text, GUILayout.Width (40));
+                GUILayout.Label ("i", GUILayout.ExpandWidth (false));
+                autopilot.RolKi.text = GUILayout.TextField (autopilot.RolKi.text, GUILayout.Width (40));
+                GUILayout.Label ("d", GUILayout.ExpandWidth (false));
+                autopilot.RolKd.text = GUILayout.TextField (autopilot.RolKd.text, GUILayout.Width (40));
+                GUILayout.EndHorizontal ();
+
+                GUILayout.BeginHorizontal ();
+                GUILayout.Label ("Yaw", GUILayout.ExpandWidth (true));
+                GUILayout.Label ("Kp", GUILayout.ExpandWidth (false));
+                autopilot.YawKp.text = GUILayout.TextField (autopilot.YawKp.text, GUILayout.Width (40));
+                GUILayout.Label ("i", GUILayout.ExpandWidth (false));
+                autopilot.YawKi.text = GUILayout.TextField (autopilot.YawKi.text, GUILayout.Width (40));
+                GUILayout.Label ("d", GUILayout.ExpandWidth (false));
+                autopilot.YawKd.text = GUILayout.TextField (autopilot.YawKd.text, GUILayout.Width (40));
+                GUILayout.EndHorizontal ();
+                GUILayout.BeginHorizontal ();
+                GUILayout.Label ("Yaw Control Limit", GUILayout.ExpandWidth (false));
+                autopilot.YawLimit.text = GUILayout.TextField (autopilot.YawLimit.text, GUILayout.Width (40));
+                GUILayout.EndHorizontal ();
             }
             base.WindowGUI (windowID);
         }

--- a/MechJeb2/MechJebModuleAirplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleAirplaneGuidance.cs
@@ -8,118 +8,111 @@ namespace MuMech
 
         private static GUIStyle btNormal, btActive, btAuto, btGreen, btWhite;
 
-        public MechJebModuleAirplaneAutopilot autopilot { get { return core.GetComputerModule<MechJebModuleAirplaneAutopilot>(); } }
+        public MechJebModuleAirplaneAutopilot autopilot { get { return core.GetComputerModule<MechJebModuleAirplaneAutopilot> (); } }
 
-        public MechJebModuleAirplaneGuidance(MechJebCore core) : base(core)
+        public MechJebModuleAirplaneGuidance (MechJebCore core) : base (core)
         {
 
         }
 
         bool showpid = false;
 
-        [Persistent(pass = (int)Pass.Global)]
-        EditableDouble AltitudeTargettmp = 0,HeadingTargettmp = 90,RollTargettmp = 0,SpeedTargettmp = 0,VertSpeedTargettmp = 0, VertSpeedMaxtmp = 10, RollMaxtmp = 30;
+        [Persistent (pass = (int)Pass.Global)]
+        EditableDouble AltitudeTargettmp = 0, HeadingTargettmp = 90, RollTargettmp = 0, SpeedTargettmp = 0, VertSpeedTargettmp = 0, VertSpeedMaxtmp = 10, RollMaxtmp = 30;
 
-        protected override void WindowGUI(int windowID)
+        protected override void WindowGUI (int windowID)
         {
-            if (btNormal == null)
-            {
-                btNormal = new GUIStyle(GUI.skin.button);
+            if (btNormal == null) {
+                btNormal = new GUIStyle (GUI.skin.button);
                 btNormal.normal.textColor = btNormal.focused.textColor = Color.white;
                 btNormal.hover.textColor = btNormal.active.textColor = Color.yellow;
                 btNormal.onNormal.textColor = btNormal.onFocused.textColor = btNormal.onHover.textColor = btNormal.onActive.textColor = Color.green;
                 //btNormal.padding = new RectOffset(8, 8, 8, 8);
 
-                btActive = new GUIStyle(btNormal);
+                btActive = new GUIStyle (btNormal);
                 btActive.active = btActive.onActive;
                 btActive.normal = btActive.onNormal;
                 btActive.onFocused = btActive.focused;
                 btActive.hover = btActive.onHover;
 
-                btGreen = new GUIStyle(btNormal);
+                btGreen = new GUIStyle (btNormal);
                 btGreen.normal.textColor = Color.green;
                 btGreen.fixedWidth = 35;
 
-                btWhite = new GUIStyle(btNormal);
+                btWhite = new GUIStyle (btNormal);
                 btWhite.normal.textColor = Color.white;
                 btWhite.fixedWidth = 35;
 
-                btAuto = new GUIStyle(btNormal);
-                btAuto.padding = new RectOffset(8, 8, 8, 8);
+                btAuto = new GUIStyle (btNormal);
+                btAuto.padding = new RectOffset (8, 8, 8, 8);
                 btAuto.normal.textColor = Color.red;
                 btAuto.onActive = btAuto.onFocused = btAuto.onHover = btAuto.onNormal = btAuto.active = btAuto.focused = btAuto.hover = btAuto.normal;
             }
 
-            if (autopilot.enabled)
-            {
-                if (GUILayout.Button("Disengage autopilot",btActive))
-                {
-                    autopilot.users.Remove(this);
+            if (autopilot.enabled) {
+                if (GUILayout.Button ("Disengage autopilot", btActive)) {
+                    autopilot.users.Remove (this);
                 }
-            }
-            else if(core.attitude.enabled && core.attitude.users.Count (u => !this.Equals (u)) > 0){
+            } else if (core.attitude.enabled && core.attitude.users.Count (u => !this.Equals (u)) > 0) {
                 if (core.attitude.users.Contains (this))
                     core.attitude.users.Remove (this); // so we don't suddenly turn on when the other autopilot finishes
                 GUILayout.Button ("Auto", btAuto, GUILayout.ExpandWidth (true));
-            }
-            else
-            {
-                if (GUILayout.Button("Engage autopilot"))
-                {
-                    autopilot.users.Add(this);
+            } else {
+                if (GUILayout.Button ("Engage autopilot")) {
+                    autopilot.users.Add (this);
                 }
             }
 
-            GUILayout.BeginHorizontal();
-            bool AltitudeHold=autopilot.AltitudeHoldEnabled;
-            autopilot.AltitudeHoldEnabled = GUILayout.Toggle(autopilot.AltitudeHoldEnabled, "Altitude Hold",GUILayout.Width (140));
+            GUILayout.BeginHorizontal ();
+            bool AltitudeHold = autopilot.AltitudeHoldEnabled;
+            autopilot.AltitudeHoldEnabled = GUILayout.Toggle (autopilot.AltitudeHoldEnabled, "Altitude Hold", GUILayout.Width (140));
             if (AltitudeHold != autopilot.AltitudeHoldEnabled) {
-                if (autopilot.AltitudeHoldEnabled) autopilot.EnableAltitudeHold ();
-                else autopilot.DisableAltitudeHold ();
+                if (autopilot.AltitudeHoldEnabled)
+                    autopilot.EnableAltitudeHold ();
+                else
+                    autopilot.DisableAltitudeHold ();
             }
-            //GUILayout.Label("ALTI", GUILayout.Width (50));
-            AltitudeTargettmp.text = GUILayout.TextField(AltitudeTargettmp.text, GUILayout.ExpandWidth(true), GUILayout.Width(60));
-            if (AltitudeTargettmp < 0) AltitudeTargettmp = 0;
-            GUILayout.Label("m", GUILayout.ExpandWidth(true));
-            if (GUILayout.Button("Set", autopilot.AltitudeTarget == AltitudeTargettmp ? btWhite : btGreen))
-            {
+            AltitudeTargettmp.text = GUILayout.TextField (AltitudeTargettmp.text, GUILayout.ExpandWidth (true), GUILayout.Width (60));
+            if (AltitudeTargettmp < 0)
+                AltitudeTargettmp = 0;
+            GUILayout.Label ("m", GUILayout.ExpandWidth (true));
+            if (GUILayout.Button ("Set", autopilot.AltitudeTarget == AltitudeTargettmp ? btWhite : btGreen)) {
                 autopilot.AltitudeTarget = AltitudeTargettmp;
             }
-            GUILayout.EndHorizontal();
+            GUILayout.EndHorizontal ();
+
 
             if (!autopilot.AltitudeHoldEnabled) {
                 bool _VertSpeedHoldEnabled = autopilot.VertSpeedHoldEnabled;
                 GUILayout.BeginHorizontal ();
-                autopilot.VertSpeedHoldEnabled = GUILayout.Toggle (autopilot.VertSpeedHoldEnabled, "VERTSPEED Hold",GUILayout.Width (140));
-                if(_VertSpeedHoldEnabled != autopilot.VertSpeedHoldEnabled){
+                autopilot.VertSpeedHoldEnabled = GUILayout.Toggle (autopilot.VertSpeedHoldEnabled, "VERTSPEED Hold", GUILayout.Width (140));
+                if (_VertSpeedHoldEnabled != autopilot.VertSpeedHoldEnabled) {
                     if (autopilot.VertSpeedHoldEnabled)
                         autopilot.EnableVertSpeedHold ();
                     else
                         autopilot.DisableVertSpeedHold ();
                 }
-                //GUILayout.Label ("VERT", GUILayout.Width (50));
                 VertSpeedTargettmp.text = GUILayout.TextField (VertSpeedTargettmp.text, GUILayout.ExpandWidth (true), GUILayout.Width (60));
-                if (VertSpeedTargettmp < 0) VertSpeedTargettmp = 0;
-                GUILayout.Label("m/s", GUILayout.ExpandWidth(true));
-                if (GUILayout.Button("Set", autopilot.VertSpeedTarget == VertSpeedTargettmp ? btWhite : btGreen))
-                {
+                if (VertSpeedTargettmp < 0)
+                    VertSpeedTargettmp = 0;
+                GUILayout.Label ("m/s", GUILayout.ExpandWidth (true));
+                if (GUILayout.Button ("Set", autopilot.VertSpeedTarget == VertSpeedTargettmp ? btWhite : btGreen)) {
                     autopilot.VertSpeedTarget = VertSpeedTargettmp;
                 }
                 GUILayout.EndHorizontal ();
             } else {
-                
                 GUILayout.BeginHorizontal ();
                 GUILayout.Label ("    VERTSPEED Limit", GUILayout.Width (140));
-                //GUILayout.Label ("VERT±", GUILayout.Width (50));
                 VertSpeedMaxtmp.text = GUILayout.TextField (VertSpeedMaxtmp.text, GUILayout.ExpandWidth (true), GUILayout.Width (60));
-                if (VertSpeedMaxtmp < 0) VertSpeedMaxtmp = 0;
-                GUILayout.Label("m/s", GUILayout.ExpandWidth(true));
-                if (GUILayout.Button("Set", autopilot.VertSpeedMax == VertSpeedMaxtmp ? btWhite : btGreen))
-                {
+                if (VertSpeedMaxtmp < 0)
+                    VertSpeedMaxtmp = 0;
+                GUILayout.Label ("m/s", GUILayout.ExpandWidth (true));
+                if (GUILayout.Button ("Set", autopilot.VertSpeedMax == VertSpeedMaxtmp ? btWhite : btGreen)) {
                     autopilot.VertSpeedMax = VertSpeedMaxtmp;
                 }
                 GUILayout.EndHorizontal ();
             }
+
 
             GUILayout.BeginHorizontal ();
             bool _HeadingHoldEnabled = autopilot.HeadingHoldEnabled;
@@ -130,75 +123,65 @@ namespace MuMech
                 else
                     autopilot.DisableHeadingHold ();
             }
-//            GUILayout.Label ("NAV", GUILayout.Width (50));
             HeadingTargettmp.text = GUILayout.TextField (HeadingTargettmp.text, GUILayout.ExpandWidth (true), GUILayout.Width (60));
             HeadingTargettmp = MuUtils.ClampDegrees360 (HeadingTargettmp);
-            GUILayout.Label("°", GUILayout.ExpandWidth(true));
-            if (GUILayout.Button("Set", autopilot.HeadingTarget == HeadingTargettmp ? btWhite : btGreen))
-            {
+            GUILayout.Label ("°", GUILayout.ExpandWidth (true));
+            if (GUILayout.Button ("Set", autopilot.HeadingTarget == HeadingTargettmp ? btWhite : btGreen)) {
                 autopilot.HeadingTarget = HeadingTargettmp;
             }
             GUILayout.EndHorizontal ();
 
+
             if (!autopilot.HeadingHoldEnabled) {
                 GUILayout.BeginHorizontal ();
                 autopilot.RollHoldEnabled = GUILayout.Toggle (autopilot.RollHoldEnabled, "Roll Hold", GUILayout.Width (140));
-                //GUILayout.Label ("Roll", GUILayout.Width (50));
                 RollTargettmp.text = GUILayout.TextField (RollTargettmp.text, GUILayout.ExpandWidth (true), GUILayout.Width (60));
-                RollTargettmp = MuUtils.Clamp (RollTargettmp,-90,90);
-                GUILayout.Label("°", GUILayout.ExpandWidth(true));
-                if (GUILayout.Button("Set", autopilot.RollTarget == RollTargettmp ? btWhite : btGreen))
-                {
+                RollTargettmp = MuUtils.Clamp (RollTargettmp, -90, 90);
+                GUILayout.Label ("°", GUILayout.ExpandWidth (true));
+                if (GUILayout.Button ("Set", autopilot.RollTarget == RollTargettmp ? btWhite : btGreen)) {
                     autopilot.RollTarget = RollTargettmp;
                 }
                 GUILayout.EndHorizontal ();
-            }
-            else {
-                //GUILayout.Label ("Roll Limit", GUILayout.ExpandWidth (false));
+            } else {
                 GUILayout.BeginHorizontal ();
                 GUILayout.Label ("    Roll Limit ±", GUILayout.Width (140));
                 RollMaxtmp.text = GUILayout.TextField (RollMaxtmp.text, GUILayout.ExpandWidth (true), GUILayout.Width (60));
-                RollMaxtmp = MuUtils.Clamp (RollMaxtmp,-60,60);
-                GUILayout.Label("°", GUILayout.ExpandWidth(true));
-                if (GUILayout.Button("Set", autopilot.RollMax == RollMaxtmp ? btWhite : btGreen))
-                {
+                RollMaxtmp = MuUtils.Clamp (RollMaxtmp, -60, 60);
+                GUILayout.Label ("°", GUILayout.ExpandWidth (true));
+                if (GUILayout.Button ("Set", autopilot.RollMax == RollMaxtmp ? btWhite : btGreen)) {
                     autopilot.RollMax = RollMaxtmp;
                 }
                 GUILayout.EndHorizontal ();
             }
 
+
             GUILayout.BeginHorizontal ();
             bool _AutoThrustCtrl = autopilot.SpeedHoldEnabled;
-            autopilot.SpeedHoldEnabled = GUILayout.Toggle (autopilot.SpeedHoldEnabled, "Speed Hold",GUILayout.Width (140));
+            autopilot.SpeedHoldEnabled = GUILayout.Toggle (autopilot.SpeedHoldEnabled, "Speed Hold", GUILayout.Width (140));
             if (autopilot.SpeedHoldEnabled != _AutoThrustCtrl) {
                 if (autopilot.SpeedHoldEnabled)
                     autopilot.EnableSpeedHold ();
                 else
                     autopilot.DisableSpeedHold ();
             }
-            //GUILayout.Label ("Speed", GUILayout.Width (50));
             SpeedTargettmp.text = GUILayout.TextField (SpeedTargettmp.text, GUILayout.ExpandWidth (true), GUILayout.Width (60));
-            if (SpeedTargettmp < 0) SpeedTargettmp = 0;
+            if (SpeedTargettmp < 0)
+                SpeedTargettmp = 0;
             GUILayout.Label ("m/s", GUILayout.ExpandWidth (true));
-            if (GUILayout.Button("Set", autopilot.SpeedTarget == SpeedTargettmp ? btWhite : btGreen))
-            {
+            if (GUILayout.Button ("Set", autopilot.SpeedTarget == SpeedTargettmp ? btWhite : btGreen)) {
                 autopilot.SpeedTarget = SpeedTargettmp;
             }
             GUILayout.EndHorizontal ();
 
+
             if (!showpid) {
-                if (GUILayout.Button("PID",GUILayout.Width (40)))
-                {
+                if (GUILayout.Button ("PID", GUILayout.Width (40))) {
                     showpid = true;
                 }
-            }
-            else {
-                if (GUILayout.Button("Hide PID",GUILayout.Width (140)))
-                {
+            } else {
+                if (GUILayout.Button ("Hide PID", GUILayout.Width (140))) {
                     showpid = false;
                 }
-
-                //GUILayout.Label ("Acceleration PID", GUILayout.ExpandWidth (false));
                 GUILayout.BeginHorizontal ();
                 GUILayout.Label ("Accceleration", GUILayout.ExpandWidth (true));
                 GUILayout.Label ("Kp", GUILayout.ExpandWidth (false));
@@ -209,10 +192,8 @@ namespace MuMech
                 autopilot.AccKd.text = GUILayout.TextField (autopilot.AccKd.text, GUILayout.Width (40));
                 GUILayout.EndHorizontal ();
                 if (autopilot.SpeedHoldEnabled)
-                    GUILayout.Label ("error:" + autopilot.a_err.ToString ("F2") + " Target:" + autopilot.RealAccelerationTarget.ToString ("F2")+" Cur:"+autopilot.cur_acc.ToString("F2"), GUILayout.ExpandWidth (false));
+                    GUILayout.Label ("error:" + autopilot.a_err.ToString ("F2") + " Target:" + autopilot.RealAccelerationTarget.ToString ("F2") + " Cur:" + autopilot.cur_acc.ToString ("F2"), GUILayout.ExpandWidth (false));
 
-
-                //GUILayout.Label ("VertSpeed PID", GUILayout.ExpandWidth (false));
                 GUILayout.BeginHorizontal ();
                 GUILayout.Label ("VertSpeed", GUILayout.ExpandWidth (true));
                 GUILayout.Label ("Kp", GUILayout.ExpandWidth (false));
@@ -223,17 +204,17 @@ namespace MuMech
                 autopilot.VerKd.text = GUILayout.TextField (autopilot.VerKd.text, GUILayout.Width (40));
                 GUILayout.EndHorizontal ();
                 if (autopilot.VertSpeedHoldEnabled)
-                    GUILayout.Label ("error:" + autopilot.v_err.ToString ("F2") + " Target:" + autopilot.RealVertSpeedTarget.ToString ("F2")+" Cur:"+vesselState.speedVertical.ToString("F2"), GUILayout.ExpandWidth (false));
+                    GUILayout.Label ("error:" + autopilot.v_err.ToString ("F2") + " Target:" + autopilot.RealVertSpeedTarget.ToString ("F2") + " Cur:" + vesselState.speedVertical.ToString ("F2"), GUILayout.ExpandWidth (false));
             }
-            base.WindowGUI(windowID);
+            base.WindowGUI (windowID);
         }
 
-        public override GUILayoutOption[] WindowOptions()
+        public override GUILayoutOption[] WindowOptions ()
         {
-            return new GUILayoutOption[] { GUILayout.Width(300), GUILayout.Height(200) };
+            return new GUILayoutOption[] { GUILayout.Width (300), GUILayout.Height (200) };
         }
 
-        public override string GetName()
+        public override string GetName ()
         {
             return "Airplane AutoPilot";
         }


### PR DESCRIPTION
- Format The Code
- disable roll control on the ground
  - may prevent aircraft from turning over
  - using autopilot on the ground is still not recommended
- Release thrust control when autopilot disengaged
- avoid #932
- optimize VerticalSpeedHold