### PR TITLE
Changed DriveCircularizationBurn to set launchLANDifference off of co…

### DIFF
--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -282,7 +282,7 @@ namespace MuMech
                 {
                     MechJebModuleFlightRecorder recorder = core.GetComputerModule<MechJebModuleFlightRecorder>();
                     if (recorder != null) launchPhaseAngle = recorder.phaseAngleFromMark;
-                    if (recorder != null) launchLANDifference = vesselState.orbitLAN - recorder.markLAN;
+                    if (core.target != null) launchLANDifference = vesselState.orbitLAN - core.target.orbit.LAN;
 
                     //finished circularize
                     this.users.Clear();


### PR DESCRIPTION
…re.target.orbit.LAN instead of recorder.markLAN.  This fixes launching into plane of target.