### PR TITLE
Improving aircraft approach and autoland procedure

### DIFF
--- a/LandingSites.cfg
+++ b/LandingSites.cfg
@@ -20,8 +20,27 @@ MechJeb2Landing
 	{
 		Runway	
 		{
-			name = KSC runway
-			// body = "Kerbin" // if not set defaults to the starting world (Kerbin, Earth for RSS)
+			name = KSC Runway 09
+			body = "Kerbin"
+			touchdown = 100.0
+			start
+			{
+				latitude = -0.0485981
+				longitude = -74.726413
+				altitude = 67
+			}
+			end
+			{
+				latitude = -0.050185
+				longitude = -74.490867
+				altitude = 67
+			}
+		}
+		Runway	
+		{
+			name = KSC Runway 27
+			body = "Kerbin" // if not set defaults to the starting world (Kerbin, Earth for RSS)
+			touchdown = 100.0 // distance in meters from start point
 			start
 			{
 				latitude = -0.050185
@@ -37,7 +56,9 @@ MechJeb2Landing
 		}
 		Runway	
 		{
-			name = Island runway
+			name = Island Runway 09
+			body = "Kerbin"
+			touchdown = 25.0;
 			start
 			{
 				latitude = -1.517306
@@ -48,6 +69,24 @@ MechJeb2Landing
 			{
 				latitude = -1.515980
 				longitude = -71.852408
+				altitude = 132
+			}
+		}
+		Runway	
+		{
+			name = Island Runway 27
+			body = "Kerbin"
+			touchdown = 25.0;
+			end
+			{
+				latitude = -1.515980
+				longitude = -71.852408
+				altitude = 132
+			}
+			start
+			{
+				latitude = -1.517306
+				longitude = -71.965488
 				altitude = 132
 			}
 		}

--- a/MechJeb2/MechJebModuleAirplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleAirplaneGuidance.cs
@@ -85,7 +85,7 @@ namespace MuMech
             if (!autopilot.AltitudeHoldEnabled) {
                 bool _VertSpeedHoldEnabled = autopilot.VertSpeedHoldEnabled;
                 GUILayout.BeginHorizontal ();
-                autopilot.VertSpeedHoldEnabled = GUILayout.Toggle (autopilot.VertSpeedHoldEnabled, "VERTSPEED Hold", GUILayout.Width (140));
+                autopilot.VertSpeedHoldEnabled = GUILayout.Toggle (autopilot.VertSpeedHoldEnabled, "Vertical Speed Hold", GUILayout.Width (140));
                 if (_VertSpeedHoldEnabled != autopilot.VertSpeedHoldEnabled) {
                     if (autopilot.VertSpeedHoldEnabled)
                         autopilot.EnableVertSpeedHold ();
@@ -100,7 +100,7 @@ namespace MuMech
                 GUILayout.EndHorizontal ();
             } else {
                 GUILayout.BeginHorizontal ();
-                GUILayout.Label ("    VERTSPEED Limit", GUILayout.Width (140));
+                GUILayout.Label ("    Vertical Speed Limit", GUILayout.Width (140));
                 VertSpeedMaxtmp.text = GUILayout.TextField (VertSpeedMaxtmp.text, GUILayout.ExpandWidth (true), GUILayout.Width (60));
                 if (VertSpeedMaxtmp < 0)
                     VertSpeedMaxtmp = 0;
@@ -238,7 +238,7 @@ namespace MuMech
 
         public override string GetName ()
         {
-            return "Airplane AutoPilot";
+            return "Aircraft Autopilot";
         }
 
     }

--- a/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
@@ -7,43 +7,32 @@ namespace MuMech
 {
     public class MechJebModuleSpaceplaneAutopilot : ComputerModule
     {
+        public MechJebModuleSpaceplaneAutopilot(MechJebCore core) : base(core) { }
+
+        public MechJebModuleAirplaneAutopilot Autopilot
+        {
+            get
+            {
+                return core.GetComputerModule<MechJebModuleAirplaneAutopilot>();
+            }
+        }
+
         public void Autoland(object controller)
         {
             users.Add(controller);
-            core.attitude.users.Add(this);
-            mode = Mode.AUTOLAND;
-            loweredGear = false;
+            Autopilot.users.Add(this);
+
+            approachState = AutolandApproachState.START;
         }
 
-        public void HoldHeadingAndAltitude(object controller)
-        {
-            users.Add(controller);
-            core.attitude.users.Add(this);
-            mode = Mode.HOLD;
-        }
+        public double saveSpeedTarget, saveHeadingTarget, saveVertSpeedTarget, saveRollMax;
 
         public void AutopilotOff()
         {
-            mode = Mode.OFF;
             users.Clear();
+            Autopilot.users.Remove(this);
             core.attitude.attitudeDeactivate();
         }
-
-        public static List<Runway> runways;
-
-        public enum Mode { AUTOLAND, HOLD, OFF };
-        public Mode mode = Mode.OFF;
-
-        //autoland parameters
-        public Runway runway; //the runway to land at
-        public EditableDouble glideslope = 3;      //the FPA to approach at during autoland
-        public EditableDouble touchdownPoint = 100; //how many meters down the runway to touch down
-
-        //heading and altitude hold parameters
-        public EditableDouble targetAltitude = 1000;
-        public EditableDouble targetHeading = 90;
-
-        bool loweredGear = false;
 
         public override void OnStart(PartModule.StartState state)
         {
@@ -56,129 +45,464 @@ namespace MuMech
             core.attitude.attitudeDeactivate();
         }
 
+        public enum AutolandApproachState
+        {
+            START,
+            IAP,
+            FAP,
+            GLIDESLOPEINTERCEPT,
+            TOUCHDOWN,
+            WAITINGFORFLARE,
+            FLARE,
+            ROLLOUT
+        };
+
+        public AutolandApproachState approachState = AutolandApproachState.START;
+
+        public string AutolandApproachStateToHumanReadableDescription()
+        {
+            switch (approachState)
+            {
+                case AutolandApproachState.START:
+                    return "";
+                case AutolandApproachState.IAP:
+                    return "Proceeding to the initial approach point";
+                case AutolandApproachState.FAP:
+                    return "Proceeding to the final approach point";
+                case AutolandApproachState.GLIDESLOPEINTERCEPT:
+                    return "Intercepting the glide slope";
+                case AutolandApproachState.TOUCHDOWN:
+                    return "Proceeding to touchdown point";
+                case AutolandApproachState.WAITINGFORFLARE:
+                    return "Waiting for flare";
+                case AutolandApproachState.FLARE:
+                    return "Flaring";
+                case AutolandApproachState.ROLLOUT:
+                    return "Rolling out";
+            }
+
+            return "";
+        }
+
+        LineRenderer line;
+
         public override void Drive(FlightCtrlState s)
         {
-            switch (mode)
+            if (line == null)
             {
-                case Mode.AUTOLAND:
-                    DriveAutoland(s);
-                    break;
+                GameObject obj = new GameObject("Line");
 
-                case Mode.HOLD:
-                    DriveHeadingAndAltitudeHold(s);
-                    break;
+                // Then create renderer itself...
+                line = obj.AddComponent<LineRenderer>();
+                line.useWorldSpace = true;
+
+                line.material = new Material(Shader.Find("Particles/Additive"));
+                line.SetColors(Color.red, Color.red);
+                line.SetWidth(1, 0);
+
+                line.SetVertexCount(2);
+            }
+
+            Vector3d vectorToWaypoint = GetAutolandTargetVector();
+
+            line.SetPosition(0, Vector3d.zero);
+            line.SetPosition(1, vectorToWaypoint);
+
+            // Make sure autopilot is enabled properly
+            if (!Autopilot.HeadingHoldEnabled)
+            {
+                Autopilot.EnableHeadingHold();
+                Autopilot.HeadingTarget = vesselState.vesselHeading;
+            }
+
+            if (!Autopilot.VertSpeedHoldEnabled)
+            {
+                Autopilot.EnableVertSpeedHold();
+                Autopilot.VertSpeedTarget = vesselState.speedVertical;
+            }
+
+            if (!Autopilot.SpeedHoldEnabled)
+            {
+                Autopilot.EnableSpeedHold();
+                Autopilot.SpeedTarget = vesselState.speedSurface;
+            }
+
+            // Set autopilot target and max values for navigation
+            Autopilot.SpeedTarget = GetAutolandTargetSpeed();
+            Autopilot.HeadingTarget = GetAutolandTargetHeading(vectorToWaypoint);
+            Autopilot.VertSpeedTarget = GetAutolandTargetVerticalSpeed(vectorToWaypoint);
+            Autopilot.RollMax = GetAutolandTargetBankAngle();
+
+            if (approachState == AutolandApproachState.FLARE)
+            {
+                Autopilot.DisableVertSpeedHold();
+
+                double exponentPerMeter = (Math.Log(targetFlareAoA) / startFlareAtAltitude);
+                double desiredAoA = Math.Exp((startFlareAtAltitude - vesselState.altitudeTrue) * exponentPerMeter);
+
+                core.attitude.attitudeTo(Autopilot.HeadingTarget, Math.Max(desiredAoA, flareStartAoA), 0, this, true, false, false);
+            }
+            else if (approachState == AutolandApproachState.TOUCHDOWN)
+            {
+                vessel.ActionGroups.SetGroup(KSPActionGroup.Gear, true);
+            }
+            else if (approachState == AutolandApproachState.ROLLOUT)
+            {
+                Autopilot.DisableSpeedHold();
+                core.thrust.ThrustOff();
+
+                vessel.ActionGroups.SetGroup(KSPActionGroup.Brakes, true);
             }
         }
 
-        public void DriveHeadingAndAltitudeHold(FlightCtrlState s)
+        /// <summary>
+        /// The runway to land at.
+        /// </summary>
+        public Runway runway;
+
+        /// <summary>
+        /// Glide slope angle for approach (3-5 seems to work best).
+        /// </summary>
+        public EditableDouble glideslope = 3.0;
+
+        /// <summary>
+        /// The angle between the runway centerline and an intercept to that
+        /// line where the lines intersect at the final approach point, on
+        /// both sides. This forms an approach where if the vessel is within
+        /// the cone, it will align with the final approach point. Otherwise,
+        /// it will fly towards the initial approach point and then turn
+        /// around and intercept the glide slope for final approach.
+        /// </summary>
+        private const double lateralApproachConeAngle = 30.0;
+
+        /// <summary>
+        /// Final approach distance in meters, at which point the aircraft
+        /// should be aligned with the runway and only minor adjustments should
+        /// be required.
+        /// </summary>
+        private const double lateralDistanceFromTouchdownToFinalApproach = 3700;
+
+        // The initial approach distance. A vessel outside the approach cone
+        // will fly towards this point.
+        //private const double lateralDistanceFromTouchdownToInitialApproach = 10000.0;
+
+        /// <summary>
+        /// Approach intercept angle; the angle at which the aircraft will
+        /// intercept the glide slope laterally.
+        /// </summary>
+        private const double lateralInterceptAngle = 30.0;
+
+        /// <summary>
+        /// Target angle of attack during flare.
+        /// </summary>
+        private const double targetFlareAoA = 10.0;
+
+        /// <summary>
+        /// Altitude in meters when flare will start.
+        /// </summary>
+        private const double startFlareAtAltitude = 30.0;
+
+        /// <summary>
+        /// Rate of turn in degrees per second.
+        /// </summary>
+        public EditableDouble targetRateOfTurn = 3.0;
+
+        /// <summary>
+        /// Minimum approach speed in meters per second. Stall + 10 seems to
+        /// result in a decent approach and landing.
+        /// </summary>
+        public EditableDouble minimumApproachSpeed = 60.0;
+
+        /// <summary>
+        /// Cruise speed in meters per second.
+        /// </summary>
+        public EditableDouble cruiseSpeed = 100.0;
+
+        /// <summary>
+        /// Maximum safe bank angle the aircraft can handle.
+        /// </summary>
+        public EditableDouble maximumSafeBankAngle = 25.0;
+
+        /// <summary>
+        /// Maximum safe vertical speed the aircraft can handle.
+        /// </summary>
+        public EditableDouble maximumSafeVerticalSpeed = 20.0;
+
+        /// <summary>
+        /// Angle of attack at the start of flare state.
+        /// </summary>
+        private double flareStartAoA = 0.0;
+
+        /// <summary>
+        /// Angle between centerline and aircraft at the point where
+        /// the aircraft is perpendicular to the initial approach point
+        /// at a distance of turn diameter.
+        /// </summary>
+        private double angleToFinalApproachPointTurnDiameter = 20.0;
+
+        public double GetAutolandTargetAltitude(Vector3d vectorToWaypoint)
         {
-            double targetClimbRate = (targetAltitude - vesselState.altitudeASL) / 30.0;
-            double targetFlightPathAngle = UtilMath.Rad2Deg * Math.Asin(Mathf.Clamp((float)(targetClimbRate / vesselState.speedSurface), (float)Math.Sin(-Math.PI / 9), (float)Math.Sin(Math.PI / 9)));
-            AimVelocityVector(targetFlightPathAngle, targetHeading);
+            double lat, lon, alt;
+            runway.body.GetLatLonAlt(vectorToWaypoint, out lat, out lon, out alt);
+
+            return alt;
         }
 
-        public void DriveAutoland(FlightCtrlState s)
+        public double GetAutolandTargetVerticalSpeed(Vector3d vectorToWaypoint)
         {
-            if (!part.vessel.Landed)
-            {
-                Vector3d runwayStart = RunwayStart();
+            double timeToWaypoint = LateralDistance(vesselState.CoM, vectorToWaypoint) / vesselState.speedSurfaceHorizontal;
+            double deltaAlt =  GetAutolandTargetAltitude(vectorToWaypoint) - vesselState.altitudeASL;
 
-                if (!loweredGear && (vesselState.CoM - runwayStart).magnitude < 1000.0)
+            return UtilMath.Clamp(deltaAlt / timeToWaypoint, -maximumSafeVerticalSpeed, maximumSafeVerticalSpeed);
+        }
+
+        public double GetAutolandTargetHeading(Vector3d vectorToWaypoint)
+        {
+            double targetHeading = vesselState.HeadingFromDirection(vectorToWaypoint);
+
+            // If we are on final, align with runway and maintain
+            switch (approachState)
+            {
+                case AutolandApproachState.FAP:
+                case AutolandApproachState.TOUCHDOWN:
+                case AutolandApproachState.WAITINGFORFLARE:
+                case AutolandApproachState.FLARE:
                 {
-                    vessel.ActionGroups.SetGroup(KSPActionGroup.Gear, true);
-                    loweredGear = true;
+                    Vector3d runwayDir = (runway.End() - runway.Start()).normalized;
+                    double alignOffset = Math.Atan2(Vector3d.Dot(runway.Up(), Vector3d.Cross(vectorToWaypoint, runwayDir)), Vector3d.Dot(vectorToWaypoint, runwayDir)) * UtilMath.Rad2Deg;
+                    Debug.Assert(alignOffset < lateralInterceptAngle);
+
+                    double exponentPerDegreeOfError = (Math.Log(2.5) - Math.Log(1.0)) / lateralInterceptAngle;
+                    double offsetMultiplier = Math.Exp((lateralInterceptAngle - Math.Abs(alignOffset)) * exponentPerDegreeOfError);
+
+                    targetHeading -= alignOffset * offsetMultiplier;
+                    break;
+                }
+            }
+
+            return targetHeading;
+        }
+
+        public double GetAutolandMaxBankAngle()
+        {
+            if (approachState == AutolandApproachState.TOUCHDOWN)
+                return 10.0;
+
+            return maximumSafeBankAngle;
+        }
+
+        public double GetAutolandLateralDistanceFromTouchdownToFinalApproach()
+        {
+            // Formula is x = cot(omega) * 2r
+            return (1.0 / Math.Tan(angleToFinalApproachPointTurnDiameter * UtilMath.Deg2Rad)) * GetAutolandTurnRadius() * 2.0;
+        }
+
+        public double GetAutolandTurnRadius()
+        {
+            // Formula is r = v / (RoT * (pi/180))
+            return vesselState.speedSurfaceHorizontal / (GetAutolandMaxRateOfTurn() * UtilMath.Deg2Rad);
+        }
+
+        public double GetAutolandMaxRateOfTurn()
+        {
+            // Formula is RoT = (g * (180/pi) * tan(Bank)) / v
+            return (runway.GetGravitationalAcceleration() * UtilMath.Rad2Deg * Math.Tan(GetAutolandMaxBankAngle() * UtilMath.Deg2Rad)) / vesselState.speedSurfaceHorizontal;
+        }
+
+        public double GetAutolandTargetBankAngle()
+        {
+            // Formula is Bank = atan((v * t) / (g * (180/pi)))
+            return Math.Min(Math.Atan((vesselState.speedSurfaceHorizontal * targetRateOfTurn) / (runway.GetGravitationalAcceleration() * UtilMath.Deg2Rad)) * UtilMath.Rad2Deg, GetAutolandMaxRateOfTurn());
+        }
+
+        public double GetAutolandTargetSpeed()
+        {
+            if (vessel.Landed)
+                return 0;
+
+            switch (approachState)
+            {
+                case AutolandApproachState.FAP:
+                    return minimumApproachSpeed * 1.5;
+
+                case AutolandApproachState.TOUCHDOWN:
+                case AutolandApproachState.WAITINGFORFLARE:
+                    return minimumApproachSpeed;
+
+                case AutolandApproachState.ROLLOUT:
+                case AutolandApproachState.FLARE:
+                    return 0;
+            }
+
+            return cruiseSpeed;
+        }
+
+        /// <summary>
+        /// Computes and returns the target vector for approach and autoland.
+        /// </summary>
+        /// <returns></returns>
+        public Vector3d GetAutolandTargetVector()
+        {
+            // positions of the start and end of the runway
+            Vector3d runwayStart = runway.GetVectorToTouchdown();
+            Vector3d runwayEnd = runway.End();
+
+            // get the initial and final approach vectors
+            Vector3d initialApproachVector = runway.GetPointOnGlideslope(glideslope, GetAutolandLateralDistanceFromTouchdownToFinalApproach() - runway.touchdownPoint);
+            Vector3d finalApproachVector = runway.GetPointOnGlideslope(glideslope, lateralDistanceFromTouchdownToFinalApproach - runway.touchdownPoint);
+
+            // determine whether the vessel is within the approach cone or not
+            Vector3d finalApproachVectorProjectedOnGroundPlane = finalApproachVector.ProjectOnPlane(runway.Up());
+            Vector3d initialApproachVectorProjectedOnGroundPlane = initialApproachVector.ProjectOnPlane(runway.Up());
+            Vector3d runwayDirectionVectorProjectedOnGroundPlane = (runwayEnd - runwayStart).ProjectOnPlane(runway.Up());
+
+            double lateralAngleOfFinalApproachVector = Vector3d.Angle(finalApproachVectorProjectedOnGroundPlane, runwayDirectionVectorProjectedOnGroundPlane);
+            double lateralAngleOfInitialApproachVector = Vector3d.Angle(initialApproachVectorProjectedOnGroundPlane, runwayDirectionVectorProjectedOnGroundPlane);
+
+            if (approachState == AutolandApproachState.START)
+            {
+                if (lateralAngleOfFinalApproachVector < lateralApproachConeAngle)
+                {
+                    // We are within the approach cone, we can skip IAP and
+                    // instead start intercepting the glideslope.
+                    approachState = AutolandApproachState.GLIDESLOPEINTERCEPT;
+                    return FindVectorToGlideslopeIntercept(finalApproachVector, lateralAngleOfFinalApproachVector);
                 }
 
-                Vector3d vectorToWaypoint = ILSAimDirection();
-                double headingToWaypoint = vesselState.HeadingFromDirection(vectorToWaypoint);
-
-                Vector3d vectorToRunway = runwayStart - vesselState.CoM;
-                double verticalDistanceToRunway = Vector3d.Dot(vectorToRunway, vesselState.up) + (vesselState.altitudeTrue - vesselState.altitudeBottom);
-                double horizontalDistanceToRunway = Math.Sqrt(vectorToRunway.sqrMagnitude - verticalDistanceToRunway * verticalDistanceToRunway);
-                double flightPathAngleToRunway = UtilMath.Rad2Deg * Math.Atan2(verticalDistanceToRunway, horizontalDistanceToRunway);
-                double desiredFPA = Mathf.Clamp((float)(flightPathAngleToRunway + 3 * (flightPathAngleToRunway + glideslope)), -20.0F, 0.0F);
-
-                AimVelocityVector(desiredFPA, headingToWaypoint);
+                approachState = AutolandApproachState.IAP;
+                return initialApproachVector;
             }
-            else
+            else if (approachState == AutolandApproachState.IAP)
             {
-                //keep the plane aligned with the runway:
-                Vector3d runwayDir = runway.End(vesselState.CoM) - runway.Start(vesselState.CoM);
-                if (Vector3d.Dot(runwayDir, vesselState.forward) < 0) runwayDir *= -1;
-                double runwayHeading = UtilMath.Rad2Deg * Math.Atan2(Vector3d.Dot(runwayDir, vesselState.east), Vector3d.Dot(runwayDir, vesselState.north));
-                core.attitude.attitudeTo(runwayHeading, 0, 0, this);
+                if (lateralAngleOfInitialApproachVector > 180 - lateralApproachConeAngle)
+                {
+                    // We are within the "bad" cone. We have to go all the way
+                    // to IAP without cutting corners.
+                    return initialApproachVector;
+                }
+
+                if (lateralAngleOfFinalApproachVector < lateralApproachConeAngle)
+                {
+                    // We are in the approach cone, start glideslope intercept.
+                    approachState = AutolandApproachState.GLIDESLOPEINTERCEPT;
+                    return FindVectorToGlideslopeIntercept(finalApproachVector, lateralAngleOfFinalApproachVector);
+                }
+
+                return initialApproachVector;
             }
+            else if (approachState == AutolandApproachState.GLIDESLOPEINTERCEPT)
+            {
+                Vector3d vectorToGlideslopeIntercept = FindVectorToGlideslopeIntercept(finalApproachVector,  lateralAngleOfFinalApproachVector);
+
+                // Determine whether we should start turning towards FAP.
+                double estimatedTimeToTurn = lateralAngleOfFinalApproachVector / GetAutolandMaxRateOfTurn();
+                double timeToGlideslopeIntercept = LateralDistance(vesselState.CoM, vectorToGlideslopeIntercept) / vesselState.speedSurfaceHorizontal;
+
+                if (estimatedTimeToTurn >= timeToGlideslopeIntercept || timeToGlideslopeIntercept < 3)
+                {
+                    approachState = AutolandApproachState.FAP;
+                    return finalApproachVector;
+                }
+
+                // Otherwise, continue flying towards the glideslope intercept.
+                return vectorToGlideslopeIntercept;
+            }
+            else if (approachState == AutolandApproachState.FAP)
+            {
+                if (lateralAngleOfFinalApproachVector > lateralInterceptAngle)
+                {
+                    // Cancel final approach, go back to initial approach.
+                    approachState = AutolandApproachState.IAP;
+                    return initialApproachVector;
+                }
+
+                double timeToFAP = LateralDistance(vesselState.CoM, finalApproachVector) / vesselState.speedSurfaceHorizontal;
+
+                // TODO: this is rather arbitrary
+                if (timeToFAP < 3)
+                {
+                    approachState = AutolandApproachState.TOUCHDOWN;
+                    return runway.GetVectorToTouchdown();
+                }
+
+                return finalApproachVector;
+            }
+            else if (approachState == AutolandApproachState.TOUCHDOWN)
+            {
+                // TODO: also arbitrary
+                if (LateralDistance(vesselState.CoM, runway.GetVectorToTouchdown()) < 200.0 || vesselState.altitudeTrue < 50.0)
+                {
+                    approachState = AutolandApproachState.WAITINGFORFLARE;
+                    return runway.End();
+                }
+
+                return runway.GetVectorToTouchdown();
+            }
+            else if (approachState == AutolandApproachState.WAITINGFORFLARE)
+            {
+                if (vesselState.altitudeTrue < startFlareAtAltitude)
+                {
+                    approachState = AutolandApproachState.FLARE;
+                    flareStartAoA = vesselState.AoA;
+                }
+
+                return runway.End();
+            }
+            else if (approachState == AutolandApproachState.FLARE)
+            {
+                if (vessel.Landed)
+                    approachState = AutolandApproachState.ROLLOUT;
+
+                return runway.End();
+            }
+            else if (approachState == AutolandApproachState.ROLLOUT)
+            {
+                if (vesselState.speedSurface < 1.0)
+                    AutopilotOff();
+
+                return runway.End();
+            }
+
+            Debug.Assert(false);
+            return runway.Start();
         }
 
-        public double stableAoA = 0; //we average AoA over time to get an estimate of what pitch will produce what FPA
-        public double pitchCorrection = 0; //we average (commanded pitch - actual pitch) over time in order to fix this offset in our commands
-        public const float maxYaw = 10.0F;
-        public const float maxRoll = 10.0F;
-        public const float maxPitchCorrection = 5.0F;
-        public const double AoAtimeConstant = 2.0;
-        public const double pitchCorrectionTimeConstant = 15.0;
-
-        void AimVelocityVector(double desiredFpa, double desiredHeading)
+        /// <summary>
+        /// Finds a point on the glide slope intercept where the angle between
+        /// vessel and the point is lateralInterceptAngle degrees.
+        /// </summary>
+        /// <param name="finalApproachVector"></param>
+        /// <param name="lateralAngleOfFinalApproachVector"></param>
+        /// <returns></returns>
+        private Vector3d FindVectorToGlideslopeIntercept(Vector3d finalApproachVector, double lateralAngleOfFinalApproachVector)
         {
-            //horizontal control
-            double velocityHeading = UtilMath.Rad2Deg * Math.Atan2(Vector3d.Dot(vesselState.surfaceVelocity, vesselState.east),
-                                                                Vector3d.Dot(vesselState.surfaceVelocity, vesselState.north));
-            double headingTurn = Mathf.Clamp((float)MuUtils.ClampDegrees180(desiredHeading - velocityHeading), -maxYaw, maxYaw);
-            double noseHeading = velocityHeading + headingTurn;
-            double noseRoll = (maxRoll / maxYaw) * headingTurn;
+            // Determine the three angles of the triangle, one of which is
+            // the lateral angle of final approach vector, and the other is
+            // 180 - lateral intercept angle.
+            double theta = 180 - lateralInterceptAngle;
+            double omega = 180 - lateralAngleOfFinalApproachVector - theta;
 
-            //vertical control
-            double nosePitch = desiredFpa + stableAoA + pitchCorrection;
+            // We know the lateral distance to the final approach point, we
+            // want to find a point on the glide slope which we can
+            // intercept at a given angle.
+            double dist = (LateralDistance(vesselState.CoM, finalApproachVector) * Math.Sin(UtilMath.Deg2Rad * omega)) / Math.Sin(UtilMath.Deg2Rad * theta);
 
-            core.attitude.attitudeTo(noseHeading, nosePitch, noseRoll, this);
+            // If this is a bad intercept, proceed to IAP.
+            if (dist < lateralDistanceFromTouchdownToFinalApproach)
+            {
+                approachState = AutolandApproachState.IAP;
+                return runway.GetPointOnGlideslope(glideslope, GetAutolandLateralDistanceFromTouchdownToFinalApproach() - runway.touchdownPoint);
+            }
 
-            double flightPathAngle = UtilMath.Rad2Deg * Math.Atan2(vesselState.speedVertical, vesselState.speedSurfaceHorizontal);
-            double AoA = vesselState.vesselPitch - flightPathAngle;
-            stableAoA = (AoAtimeConstant * stableAoA + vesselState.deltaT * AoA) / (AoAtimeConstant + vesselState.deltaT); //a sort of integral error
-
-            pitchCorrection = (pitchCorrectionTimeConstant * pitchCorrection + vesselState.deltaT * (nosePitch - vesselState.vesselPitch)) / (pitchCorrectionTimeConstant + vesselState.deltaT);
-            pitchCorrection = Mathf.Clamp((float)pitchCorrection, -maxPitchCorrection, maxPitchCorrection);
+            return runway.GetPointOnGlideslope(glideslope, dist + lateralDistanceFromTouchdownToFinalApproach);
         }
 
-        Vector3d RunwayStart()
+        private double LateralDistance(Vector3d v1, Vector3d v2)
         {
-            Vector3d runwayStart = runway.Start(vesselState.CoM);
-            Vector3d runwayEnd = runway.End(vesselState.CoM);
-            Vector3d runwayDir = (runwayEnd - runwayStart).normalized;
-            runwayStart += touchdownPoint * runwayDir;
-            return runwayStart;
+            return Vector3d.Distance(v1.ProjectOnPlane(runway.Up()), v2.ProjectOnPlane(runway.Up()));
         }
 
-        public Vector3d ILSAimDirection()
-        {
-            //positions of the start and end of the runway
-            Vector3d runwayStart = RunwayStart();
-            Vector3d runwayEnd = runway.End(vesselState.CoM);
-
-            //a coordinate system oriented to the runway
-            Vector3d runwayUpUnit = runway.Up();
-            Vector3d runwayHorizontalUnit = Vector3d.Exclude(runwayUpUnit, runwayStart - runwayEnd).normalized;
-            Vector3d runwayLeftUnit = -Vector3d.Cross(runwayHorizontalUnit, runwayUpUnit).normalized;
-
-            Vector3d vesselUnit = (vesselState.CoM - runwayStart).normalized;
-
-            double leftSpeed = Vector3d.Dot(vesselState.surfaceVelocity, runwayLeftUnit);
-            double verticalSpeed = vesselState.speedVertical;
-            double horizontalSpeed = vesselState.speedSurfaceHorizontal;
-            double flightPathAngle = UtilMath.Rad2Deg * Math.Atan2(verticalSpeed, horizontalSpeed);
-
-            double leftDisplacement = Vector3d.Dot(runwayLeftUnit, vesselState.CoM - runwayStart);
-
-            Vector3d vectorToRunway = runwayStart - vesselState.CoM;
-            double verticalDistanceToRunway = Vector3d.Dot(vectorToRunway, vesselState.up) + (vesselState.altitudeTrue - vesselState.altitudeBottom);
-            double horizontalDistanceToRunway = Math.Sqrt(vectorToRunway.sqrMagnitude - verticalDistanceToRunway * verticalDistanceToRunway);
-            double flightPathAngleToRunway = UtilMath.Rad2Deg * Math.Atan2(verticalDistanceToRunway, horizontalDistanceToRunway);
-
-            Vector3d aimToward = runwayStart - 3 * leftDisplacement * runwayLeftUnit;
-            Vector3d aimDir = aimToward - vesselState.CoM;
-
-            return aimDir;
-        }
+        public static List<Runway> runways;
 
         private void InitRunwaysList()
         {
@@ -192,6 +516,8 @@ namespace MuMech
                     string runwayName = site.GetValue("name");
                     ConfigNode start = site.GetNode("start");
                     ConfigNode end = site.GetNode("end");
+                    double touchdown = 0.0;
+                    double.TryParse(site.GetValue("touchdown"), out touchdown);
 
                     if (runwayName == null || start == null || end == null)
                         continue;
@@ -199,7 +525,7 @@ namespace MuMech
                     string lat = start.GetValue("latitude");
                     string lon = start.GetValue("longitude");
                     string alt = start.GetValue("altitude");
-
+                    
                     if (lat == null || lon == null || alt == null)
                         continue;
 
@@ -229,6 +555,7 @@ namespace MuMech
                         {
                             name = runwayName,
                             body = body,
+                            touchdownPoint = touchdown,
                             start = new Runway.Endpoint { latitude = startLatitude, longitude = startLongitude, altitude = startAltitude },
                             end = new Runway.Endpoint { latitude = endLatitude, longitude = endLongitude, altitude = endAltitude }
                         });
@@ -236,27 +563,47 @@ namespace MuMech
                 }
             }
 
-            // Create a default config file in MJ dir for those ?
-            if (!runways.Any(p => p.name == "KSC runway"))
-                runways.Add(new Runway //The runway at KSC
+            // TODO: deploy LandingSites.cfg?
+            if (!runways.Any(p => p.name == "KSC Runway 09"))
+                runways.Add(new Runway
                 {
-                    name = "KSC runway",
+                    name = "KSC Runway 09",
+                    body = Planetarium.fetch.Home,
+                    start = new Runway.Endpoint { latitude = -0.0485981, longitude = -74.726413, altitude = 69.01 },
+                    end = new Runway.Endpoint { latitude = -0.050185, longitude = -74.490867, altitude = 69.01 },
+                    touchdownPoint = 100.0
+                });
+
+            if (!runways.Any(p => p.name == "KSC Runway 27"))
+                runways.Add(new Runway
+                {
+                    name = "KSC Runway 27",
                     body = Planetarium.fetch.Home,
                     start = new Runway.Endpoint { latitude = -0.050185, longitude = -74.490867, altitude = 69.01 },
-                    end = new Runway.Endpoint { latitude = -0.0485981, longitude = -74.726413, altitude = 69.01 }
+                    end = new Runway.Endpoint { latitude = -0.0485981, longitude = -74.726413, altitude = 69.01 },
+                    touchdownPoint = 100.0
                 });
 
-            if (!runways.Any(p => p.name == "Island runway"))
-                runways.Add(new Runway //The runway on the island off the KSC coast.
+            if (!runways.Any(p => p.name == "Island Runway 09"))
+                runways.Add(new Runway
                 {
-                    name = "Island runway",
+                    name = "Island Runway 09",
                     body = Planetarium.fetch.Home,
                     start = new Runway.Endpoint { latitude = -1.517306, longitude = -71.965488, altitude = 133.17 },
-                    end = new Runway.Endpoint { latitude = -1.515980, longitude = -71.852408, altitude = 133.17 }
+                    end = new Runway.Endpoint { latitude = -1.515980, longitude = -71.852408, altitude = 133.17 },
+                    touchdownPoint = 25.0
+                });
+
+            if (!runways.Any(p => p.name == "Island Runway 27"))
+                runways.Add(new Runway
+                {
+                    name = "Island Runway 27",
+                    body = Planetarium.fetch.Home,
+                    start = new Runway.Endpoint { latitude = -1.515980, longitude = -71.852408, altitude = 133.17 },
+                    end = new Runway.Endpoint { latitude = -1.517306, longitude = -71.965488, altitude = 133.17 },
+                    touchdownPoint = 25.0
                 });
         }
-
-        public MechJebModuleSpaceplaneAutopilot(MechJebCore core) : base(core) { }
     }
 
     public struct Runway
@@ -267,37 +614,55 @@ namespace MuMech
             public double longitude;
             public double altitude;
 
-            public Vector3d Position()
+            public Vector3d Position(CelestialBody body)
             {
-                //hardcoded to use Kerbin for the moment:
-                return FlightGlobals.currentMainBody.GetWorldSurfacePosition(latitude, longitude, altitude);
+                return body.GetWorldSurfacePosition(latitude, longitude, altitude);
+            }
+
+            public Vector3d Up(CelestialBody body)
+            {
+                return body.GetSurfaceNVector(latitude, longitude);
             }
         }
 
         public string name;
+        public double touchdownPoint;
         public CelestialBody body;
         public Endpoint start;
         public Endpoint end;
 
-        public Vector3d Start(Vector3d approachPosition)
+        public Vector3d Start() { return start.Position(body); }
+        public Vector3d End() { return end.Position(body); }
+        public Vector3d Up() { return start.Up(body); }
+
+        public double GetGravitationalAcceleration()
         {
-            Vector3d startPos = start.Position();
-            Vector3d endPos = end.Position();
-            if (Vector3d.Distance(startPos, approachPosition) < Vector3d.Distance(endPos, approachPosition)) return startPos;
-            else return endPos;
+            return body.GeeASL * 9.81;
         }
 
-        public Vector3d End(Vector3d approachPosition)
+        public Vector3d GetVectorToTouchdown()
         {
-            Vector3d startPos = start.Position();
-            Vector3d endPos = end.Position();
-            if (Vector3d.Distance(startPos, approachPosition) < Vector3d.Distance(endPos, approachPosition)) return endPos;
-            else return startPos;
+            Vector3d runwayStart = Start();
+            Vector3d runwayEnd = End();
+
+            Vector3d runwayDir = (runwayEnd - runwayStart).normalized;
+            runwayStart += touchdownPoint * runwayDir;
+
+            return runwayStart;
         }
 
-        public Vector3d Up()
+        public Vector3d GetPointOnGlideslope(double glideslope, double distanceOnCenterline)
         {
-            return FlightGlobals.currentMainBody.GetSurfaceNVector(start.latitude, start.longitude);
+            Vector3d runwayStart = GetVectorToTouchdown();
+            Vector3d runwayEnd = End();
+
+            // The approach line 
+            Vector3d runwayDir = (runwayEnd - runwayStart).normalized;
+            runwayDir = QuaternionD.AngleAxis(Math.Sign(runwayDir.z) * glideslope, Vector3d.up) * runwayDir;
+
+            runwayStart -= distanceOnCenterline * runwayDir;
+
+            return runwayStart;
         }
     }
 }

--- a/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -6,7 +7,7 @@ namespace MuMech
 {
     public class MechJebModuleSpaceplaneGuidance : DisplayModule
     {
-        MechJebModuleSpaceplaneAutopilot autopilot;
+        MechJebModuleSpaceplaneAutopilot autoland;
 
         protected bool _showLandingTarget = false;
 
@@ -39,32 +40,33 @@ namespace MuMech
                 GUILayout.Label("Landing", s);
 
                 runwayIndex = GuiUtils.ComboBox.Box(runwayIndex, availableRunways.Select(p => p.name).ToArray(), this);
-                autopilot.runway = availableRunways[runwayIndex];
+                autoland.runway = availableRunways[runwayIndex];
 
-                GUILayout.Label("Distance to runway: " + MuUtils.ToSI(Vector3d.Distance(vesselState.CoM, autopilot.runway.Start(vesselState.CoM)), 0) + "m");
+                GUILayout.Label("Distance to runway: " + MuUtils.ToSI(Vector3d.Distance(vesselState.CoM, autoland.runway.Start()), 0) + "m");
 
                 showLandingTarget = GUILayout.Toggle(showLandingTarget, "Show landing navball guidance");
 
-                if (GUILayout.Button("Autoland")) autopilot.Autoland(this);
-                if (autopilot.enabled && autopilot.mode == MechJebModuleSpaceplaneAutopilot.Mode.AUTOLAND
-                    && GUILayout.Button("Abort")) autopilot.AutopilotOff();
+                if (GUILayout.Button("Autoland")) autoland.Autoland(this);
+                if (autoland.enabled && GUILayout.Button("Abort"))
+                    autoland.AutopilotOff();
 
-                GuiUtils.SimpleTextBox("Autoland glideslope:", autopilot.glideslope, "º");
+                GuiUtils.SimpleTextBox("Autoland glideslope:", autoland.glideslope, "º");
+                GuiUtils.SimpleTextBox("Cruise speed:", autoland.cruiseSpeed, "m/s");
+                GuiUtils.SimpleTextBox("Minimum approach speed:", autoland.minimumApproachSpeed, "m/s");
+                GuiUtils.SimpleTextBox("Target rate of turn:", autoland.targetRateOfTurn, "º/s");
+                GuiUtils.SimpleTextBox("Maximum safe bank angle:", autoland.maximumSafeBankAngle, "º");
+                GuiUtils.SimpleTextBox("Maximum safe vertical speed:", autoland.maximumSafeVerticalSpeed, "m/s");
+
+                if (autoland.enabled)
+                {
+                    GUILayout.Label("State: " + autoland.AutolandApproachStateToHumanReadableDescription());
+                    GUILayout.Label(string.Format("Target speed: {0} m/s", Math.Round(autoland.Autopilot.SpeedTarget, 1)));
+                    GUILayout.Label(string.Format("Target altitude: {0} m", Math.Round(autoland.GetAutolandTargetAltitude(autoland.GetAutolandTargetVector()), 0)));
+                    GUILayout.Label(string.Format("Target vertical speed: {0} m/s", Math.Round(autoland.Autopilot.VertSpeedTarget, 1)));
+                    GUILayout.Label(string.Format("Target heading: {0}º", Math.Round(autoland.Autopilot.HeadingTarget, 0)));
+                }
+                    
             }
-
-            GUILayout.Label("Hold", s);
-
-            GUILayout.BeginHorizontal();
-            if (GUILayout.Button("Initiate hold:")) autopilot.HoldHeadingAndAltitude(this);
-            GUILayout.Label("Heading:");
-            autopilot.targetHeading.text = GUILayout.TextField(autopilot.targetHeading.text, GUILayout.Width(40));
-            GUILayout.Label("º Altitude:");
-            autopilot.targetAltitude.text = GUILayout.TextField(autopilot.targetAltitude.text, GUILayout.Width(40));
-            GUILayout.Label("m");
-            GUILayout.EndHorizontal();
-
-            if (autopilot.enabled && autopilot.mode == MechJebModuleSpaceplaneAutopilot.Mode.HOLD
-                && GUILayout.Button("Abort")) autopilot.AutopilotOff();
 
             GUILayout.EndVertical();
 
@@ -78,12 +80,12 @@ namespace MuMech
 
         public override void OnFixedUpdate()
         {
-            if (showLandingTarget && autopilot != null)
+            if (showLandingTarget && autoland != null)
             {
                 if (!(core.target.Target is DirectionTarget && core.target.Name == "ILS Guidance")) showLandingTarget = false;
                 else
                 {
-                    core.target.UpdateDirectionTarget(autopilot.ILSAimDirection());
+                    core.target.UpdateDirectionTarget(autoland.GetAutolandTargetVector());
                 }
             }
         }
@@ -92,14 +94,14 @@ namespace MuMech
 
         public override void OnStart(PartModule.StartState state)
         {
-            autopilot = core.GetComputerModule<MechJebModuleSpaceplaneAutopilot>();
+            autoland = core.GetComputerModule<MechJebModuleSpaceplaneAutopilot>();
         }
 
         public MechJebModuleSpaceplaneGuidance(MechJebCore core) : base(core) { }
 
         public override string GetName()
         {
-            return "Spaceplane Guidance";
+            return "Aircraft Approach & Autoland";
         }
     }
 }


### PR DESCRIPTION
I rewrote the approach and autoland code to perform the procedure more reliably using the new autopilot features (thanks, zyayoung!). Here are my notes for the change:
- The procedure follows a simple pattern such that an aircraft has enough time approach a runway using the given cruise speed, max bank angle and target rate of turn parameters.
- I have removed the altitude and heading hold functionality, since it is duplicated by the new autopilot functionality.
- I have added ability to select runway direction (KSC runways 09 & 27, Island runways 09 & 27).
- Runways no longer assume that the body is Kerbin.
- I added the runways to the cfg file; not sure if that file is deployed though since I can't find it in my normal MechJeb2 installation.
- Minimum approach speed seems to work best when set to stall + 10 or 15.
- **I have left in a temporary "line" that is drawn from the vessel to the next waypoint. This is useful for testing purposes but will be removed in my next commit.**
- **Requires a good bit of testing; my tests were limited to stock aircraft. Autoland is also limited by how the autopilot behaves on an aircraft.**

Few areas of improvement for the future:
- Some of the math could be simplified perhaps.
- The autopilot doesn't hold vertical speed very well when throttle is cut suddenly, or when the aircraft is turning left/right.
- Consider (shuttle-like) no-propulsion gliding aircraft. We should calculate best glide slope angle for the aircraft such that it maintains a good approach speed.
- Don't apply brakes immediately on landing, wait until all gears are down.
- Auto apply reverse thrust if available.