### PR TITLE
Autoland improvements: fixed approach and flare issues; added steering

### DIFF
--- a/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
@@ -98,29 +98,9 @@ namespace MuMech
             return "";
         }
 
-        LineRenderer line;
-
         public override void Drive(FlightCtrlState s)
         {
-            if (line == null)
-            {
-                GameObject obj = new GameObject("Line");
-
-                // Then create renderer itself...
-                line = obj.AddComponent<LineRenderer>();
-                line.useWorldSpace = true;
-
-                line.material = new Material(Shader.Find("Particles/Additive"));
-                line.SetColors(Color.red, Color.red);
-                line.SetWidth(1, 0);
-
-                line.SetVertexCount(2);
-            }
-
             Vector3d vectorToWaypoint = GetAutolandTargetVector();
-
-            line.SetPosition(0, Vector3d.zero);
-            line.SetPosition(1, vectorToWaypoint);
 
             // Make sure autopilot is enabled properly
             if (!Autopilot.HeadingHoldEnabled)

--- a/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
@@ -377,13 +377,13 @@ namespace MuMech
         public double GetAutolandMaxRateOfTurn()
         {
             // Formula is RoT = (g * (180/pi) * tan(Bank)) / v
-            return (runway.GetGravitationalAcceleration() * UtilMath.Rad2Deg * Math.Tan(GetAutolandMaxBankAngle() * UtilMath.Deg2Rad)) / vesselState.speedSurfaceHorizontal;
+            return (runway.GetGravitationalAcceleration() * UtilMath.Rad2Deg * Math.Tan(GetAutolandTargetBankAngle() * UtilMath.Deg2Rad)) / vesselState.speedSurfaceHorizontal;
         }
 
         public double GetAutolandTargetBankAngle()
         {
             // Formula is Bank = atan((v * t) / (g * (180/pi)))
-            return Math.Min(Math.Atan((vesselState.speedSurfaceHorizontal * targetRateOfTurn) / (runway.GetGravitationalAcceleration() * UtilMath.Rad2Deg)) * UtilMath.Rad2Deg, GetAutolandMaxRateOfTurn());
+            return Math.Min(Math.Atan((vesselState.speedSurfaceHorizontal * targetRateOfTurn) / (runway.GetGravitationalAcceleration() * UtilMath.Rad2Deg)) * UtilMath.Rad2Deg, GetAutolandMaxBankAngle());
         }
 
         public double GetAutolandTargetSpeed()

--- a/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
@@ -405,6 +405,11 @@ namespace MuMech
             return approachSpeed;
         }
 
+        public double GetAutolandLateralDistanceToNextWaypoint()
+        {
+            return LateralDistance(vesselState.CoM, GetAutolandTargetVector());
+        }
+
         /// <summary>
         /// Computes and returns the target vector for approach and autoland.
         /// </summary>

--- a/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
@@ -733,13 +733,25 @@ namespace MuMech
             Vector3d runwayStart = GetVectorToTouchdown();
             Vector3d runwayEnd = End();
 
-            // The approach line 
             Vector3d runwayDir = (runwayEnd - runwayStart).normalized;
-            runwayDir = QuaternionD.AngleAxis(Math.Sign(runwayDir.z) * glideslope, Vector3d.up) * runwayDir;
 
-            runwayStart -= distanceOnCenterline * runwayDir;
+            Vector3d glideslopeDir = QuaternionD.AngleAxis(glideslope, Vector3d.up) * runwayDir;
+            Vector3d pointOnGlideslope = runwayStart - (distanceOnCenterline * glideslopeDir);
 
-            return runwayStart;
+            double latAtDistance, lonAtDistance, altAtDistance;
+            body.GetLatLonAlt(pointOnGlideslope, out latAtDistance, out lonAtDistance, out altAtDistance);
+
+            double latAtTouchdown, lonAtTouchdown, altAtTouchdown;
+            body.GetLatLonAlt(GetVectorToTouchdown(), out latAtTouchdown, out lonAtTouchdown, out altAtTouchdown);
+
+            if (altAtDistance < altAtTouchdown)
+            {
+                // TODO: can we optimize this?
+                glideslopeDir = QuaternionD.AngleAxis(-glideslope, Vector3d.up) * runwayDir;
+                pointOnGlideslope = runwayStart - (distanceOnCenterline * glideslopeDir);
+            }
+
+            return pointOnGlideslope;
         }
     }
 }

--- a/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
@@ -57,6 +57,7 @@ namespace MuMech
                 if (autoland.enabled)
                 {
                     GUILayout.Label("State: " + autoland.AutolandApproachStateToHumanReadableDescription());
+                    GUILayout.Label(string.Format("Distance to waypoint: {0} m", Math.Round(autoland.GetAutolandLateralDistanceToNextWaypoint(), 0)));
                     GUILayout.Label(string.Format("Target speed: {0} m/s", Math.Round(autoland.Autopilot.SpeedTarget, 1)));
                     GUILayout.Label(string.Format("Target altitude: {0} m", Math.Round(autoland.GetAutolandTargetAltitude(autoland.GetAutolandTargetVector()), 0)));
                     GUILayout.Label(string.Format("Target vertical speed: {0} m/s", Math.Round(autoland.Autopilot.VertSpeedTarget, 1)));

--- a/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
@@ -49,9 +49,10 @@ namespace MuMech
                 if (GUILayout.Button("Autoland")) autoland.Autoland(this);
                 if (autoland.enabled && GUILayout.Button("Abort"))
                     autoland.AutopilotOff();
-
+                
                 GuiUtils.SimpleTextBox("Autoland glideslope:", autoland.glideslope);
                 GuiUtils.SimpleTextBox("Approach speed:", autoland.approachSpeed);
+                autoland.bEngageReverseIfAvailable = GUILayout.Toggle(autoland.bEngageReverseIfAvailable, "Reverse thrust upon touchdown");
 
                 if (autoland.enabled)
                 {
@@ -61,7 +62,6 @@ namespace MuMech
                     GUILayout.Label(string.Format("Target vertical speed: {0} m/s", Math.Round(autoland.Autopilot.VertSpeedTarget, 1)));
                     GUILayout.Label(string.Format("Target heading: {0}º", Math.Round(autoland.Autopilot.HeadingTarget, 0)));
                 }
-                    
             }
 
             GUILayout.EndVertical();

--- a/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
@@ -50,12 +50,8 @@ namespace MuMech
                 if (autoland.enabled && GUILayout.Button("Abort"))
                     autoland.AutopilotOff();
 
-                GuiUtils.SimpleTextBox("Autoland glideslope:", autoland.glideslope, "º");
-                GuiUtils.SimpleTextBox("Cruise speed:", autoland.cruiseSpeed, "m/s");
-                GuiUtils.SimpleTextBox("Minimum approach speed:", autoland.minimumApproachSpeed, "m/s");
-                GuiUtils.SimpleTextBox("Target rate of turn:", autoland.targetRateOfTurn, "º/s");
-                GuiUtils.SimpleTextBox("Maximum safe bank angle:", autoland.maximumSafeBankAngle, "º");
-                GuiUtils.SimpleTextBox("Maximum safe vertical speed:", autoland.maximumSafeVerticalSpeed, "m/s");
+                GuiUtils.SimpleTextBox("Autoland glideslope:", autoland.glideslope);
+                GuiUtils.SimpleTextBox("Approach speed:", autoland.approachSpeed);
 
                 if (autoland.enabled)
                 {


### PR DESCRIPTION
- Aircraft now tries to maintain glideslope altitude as much as possible.
- Added reverse thrusting (if available) and steering on rollout.
- Fixed approach and flare issues; flare height is now 20 meters with 15-degree target AoA.
- Fixed a bug where approach waypoints were below the surface.
- Fixed an error in the equation that determined bank angle for the target rate of turn (those equations for RoT, bank and radius which work in real life, only sort of work on KSP and have a decent bit of error).
- Fixed a critical bug where autoland bank angle and turn radius was calculated incorrectly.

Tested all stock aircraft for approaches to runways 09 & 27 at KSP. The autopilot has trouble controlling vertical speed on some of the aircraft (which can be improved by allowing ailerons to pitch as well as roll). Certain aircraft get stuck on dolphin dives for a long time due to these issues, but they seem to straighten out after a while.