### PR TITLE
Fix flight recorder gravity/steering losses calcs

### DIFF
--- a/MechJeb2/MechJebModuleFlightRecorder.cs
+++ b/MechJeb2/MechJebModuleFlightRecorder.cs
@@ -237,11 +237,10 @@ namespace MuMech
                 return;
             }
 
-            gravityLosses += vesselState.deltaT * Vector3d.Dot(-vesselState.surfaceVelocity.normalized, vesselState.gravityForce);
-            gravityLosses -= vesselState.deltaT * Vector3d.Dot(vesselState.surfaceVelocity.normalized, vesselState.up * vesselState.radius * Math.Pow(2 * Math.PI / part.vessel.mainBody.rotationPeriod, 2));
+            gravityLosses += vesselState.deltaT * Vector3d.Dot(-vesselState.orbitalVelocity.normalized, vesselState.gravityForce);
             dragLosses += vesselState.deltaT * vesselState.drag;
             deltaVExpended += vesselState.deltaT * vesselState.currentThrustAccel;
-            steeringLosses += vesselState.deltaT * vesselState.currentThrustAccel * (1 - Vector3d.Dot(vesselState.surfaceVelocity.normalized, vesselState.forward));
+            steeringLosses += vesselState.deltaT * vesselState.currentThrustAccel * (1 - Vector3d.Dot(vesselState.orbitalVelocity.normalized, vesselState.forward));
 
             maxDragGees = Math.Max(maxDragGees, vesselState.drag / 9.81);
 


### PR DESCRIPTION
Patch from lamont on #RO:

    < lamont> steering and gravity losses don’t depend on the rotation
              of the planet below — think about an orbit over a spinning
              airless planet — so surfaceVelocity has to be incorrect

lamont also removed the gravityLosses -= <expr> because that was
compensating for surfaceVelocity being used in the initial gravityLosses
calculation instead of orbitalVelocity.