### PR TITLE
Use FAR for VesselState aerodynamic updates if available

### DIFF
--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -35,6 +35,7 @@ namespace MuMech
         private static FARVesselDelegate FARVesselDragCoeff;
         private static FARVesselDelegate FARVesselRefArea;
         private static FARVesselDelegate FARVesselTermVelEst;
+        private static FARVesselDelegate FARVesselDynPres;
         private delegate void FARCalculateVesselAeroForcesDelegate(Vessel vessel, out Vector3 aeroForce, out Vector3 aeroTorque, Vector3 velocityWorldVector, double altitude);
         private static FARCalculateVesselAeroForcesDelegate FARCalculateVesselAeroForces;
 
@@ -295,7 +296,7 @@ namespace MuMech
             isLoadedFAR = isAssemblyLoaded("FerramAerospaceResearch");
             if (isLoadedFAR)
             {
-                List<string> farNames = new List<string>{ "VesselDragCoeff", "VesselRefArea", "VesselTermVelEst" };
+                List<string> farNames = new List<string>{ "VesselDragCoeff", "VesselRefArea", "VesselTermVelEst", "VesselDynPres" };
                 foreach (var name in farNames)
                 {
                     var methodInfo = getMethodByReflection(
@@ -632,7 +633,15 @@ namespace MuMech
             double temperature = FlightGlobals.getExternalTemperature(altitudeASL);
             atmosphericDensity = FlightGlobals.getAtmDensity(atmosphericPressure, temperature);
             atmosphericDensityGrams = atmosphericDensity * 1000;
-            dynamicPressure = vessel.dynamicPressurekPa * 1000;
+            if (isLoadedFAR)
+            {
+                dynamicPressure = FARVesselDynPres(vessel) * 1000;
+            }
+            else
+            {
+                dynamicPressure = vessel.dynamicPressurekPa * 1000;
+            }
+
 
             speedOfSound = vessel.speedOfSound;
 

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -330,6 +330,32 @@ namespace MuMech
                 return type.GetField(fieldName);
         }
 
+        static MethodInfo getMethodByReflection(String assemblyString, String className, String methodName, BindingFlags flags, Type[] args)
+        {
+            string assemblyName = "";
+
+            foreach (AssemblyLoader.LoadedAssembly loaded in AssemblyLoader.loadedAssemblies)
+            {
+                if (loaded.assembly.GetName().Name == assemblyString)
+                {
+                    assemblyName = loaded.assembly.FullName;
+                }
+            }
+
+            if (assemblyName == "")
+            {
+                return null;
+            }
+
+            Type type = Type.GetType(className + ", " + assemblyName);
+
+            if (type == null)
+            {
+                return null;
+            }
+            return type.GetMethod(methodName, flags, null, args, null);
+        }
+
 
         public VesselState()
         {


### PR DESCRIPTION
Used delegates instead of MethodInfo.Invoke because the methods are called frequently and delegates supposedly perform better than MethodInfo.Invoke.

Don't know if the last two commits are strictly necessary, but figured might as well have MJ use whatever FAR is using for consistency.