### PR TITLE
Don't use FAR for lift/drag if vessel is packed or not moving

### DIFF
--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -1087,7 +1087,7 @@ namespace MuMech
 
             Vector3d liftDir = -Vector3d.Cross(vessel.transform.right, -surfaceVelocity.normalized);
 
-            if (isLoadedFAR)
+            if (isLoadedFAR && !vessel.packed)
             {
                 Vector3 farForce = Vector3.zero;
                 Vector3 farTorque = Vector3.zero;

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -1087,7 +1087,7 @@ namespace MuMech
 
             Vector3d liftDir = -Vector3d.Cross(vessel.transform.right, -surfaceVelocity.normalized);
 
-            if (isLoadedFAR && !vessel.packed)
+            if (isLoadedFAR && !vessel.packed && surfaceVelocity != Vector3d.zero)
             {
                 Vector3 farForce = Vector3.zero;
                 Vector3 farTorque = Vector3.zero;


### PR DESCRIPTION
FAR emits NREs if CalculateVesselAeroForces is called on a packed vessel:

```
[EXC 18:33:14.121] NullReferenceException: Object reference not set to an instance of an object
	FerramAerospaceResearch.FARAeroComponents.FARVesselAero.SimulateAeroProperties (UnityEngine.Vector3& aeroForce, UnityEngine.Vector3& aeroTorque, Vector3 velocityWorldVector, Double altitude)
	FerramAerospaceResearch.FARAPI.InstanceCalcVesselAeroForces (.Vessel vessel, UnityEngine.Vector3& aeroForce, UnityEngine.Vector3& aeroTorque, Vector3 velocityWorldVector, Double altitude)
	FerramAerospaceResearch.FARAPI.CalculateVesselAeroForces (.Vessel vessel, UnityEngine.Vector3& aeroForce, UnityEngine.Vector3& aeroTorque, Vector3 velocityWorldVector, Double altitude)
	MuMech.VesselState.AnalyzeParts (.Vessel vessel, MuMech.EngineInfo einfo, MuMech.IntakeInfo iinfo)
	MuMech.VesselState.Update (.Vessel vessel)
	MuMech.MechJebCore.FixedUpdate ()
```

Found by/fix proposed by lamont