### PR TITLE
Fix areaDrag calculation when using FAR

### DIFF
--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -862,7 +862,7 @@ namespace MuMech
             if (isLoadedFAR)
             {
                 dragCoef = FARVesselDragCoeff(vessel);
-                areaDrag = FARVesselRefArea(vessel);
+                areaDrag = FARVesselRefArea(vessel) * dragCoef * PhysicsGlobals.DragMultiplier;
             }
             else
             {


### PR DESCRIPTION
Didn't read the code closely enough (more specifically, didn't read the
comment at the areaDrag declaration), and thought that areaDrag was the
same as the reference area...