### PR TITLE
Use ascent guidance orbital inclination GUIStyle

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -149,7 +149,7 @@ namespace MuMech
                 GUIStyle si = new GUIStyle(GUI.skin.label);
                 if (!autopilot.enabled && Math.Abs(desiredInclination) < Math.Abs(vesselState.latitude))
                     si.onHover.textColor = si.onNormal.textColor = XKCDColors.Orange;
-                GuiUtils.SimpleTextBox("Orbit inclination", desiredInclination, "º");
+                GuiUtils.SimpleTextBox("Orbit inclination", desiredInclination, "º", rightLabelStyle: si);
 
                 core.thrust.LimitToPreventOverheatsInfoItem();
                 //core.thrust.LimitToTerminalVelocityInfoItem();


### PR DESCRIPTION
A GUIStyle was already set up to turn the label orange if the entered
inclination is less than the vessel's latitude, but was never used.

Used a named parameter to avoid hard-coding the width, so if the default
is later changed everything will change uniformly.