### PR TITLE
more transfer calculator fixes

### DIFF
--- a/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
+++ b/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
@@ -4,139 +4,139 @@ using Object = UnityEngine.Object;
 
 namespace MuMech
 {
-	public class OperationAdvancedTransfer : Operation
-	{
-		enum Mode
-		{
-			LimitedTime,
-			Porkchop
-		}
-		static string[] modeNames = {"Limited time", "Porkchop selection"};
-		public override string getName() { return "advanced transfer to another planet";}
+    public class OperationAdvancedTransfer : Operation
+    {
+        enum Mode
+        {
+            LimitedTime,
+            Porkchop
+        }
+        static string[] modeNames = {"Limited time", "Porkchop selection"};
+        public override string getName() { return "advanced transfer to another planet";}
 
-		double minDepartureTime;
-		double minTransferTime;
-		double maxDepartureTime;
-		double maxTransferTime;
+        double minDepartureTime;
+        double minTransferTime;
+        double maxDepartureTime;
+        double maxTransferTime;
 
-		public EditableTime maxArrivalTime = new EditableTime();
+        public EditableTime maxArrivalTime = new EditableTime();
 
-		const double minSamplingStep = 12 * 3600;
+        const double minSamplingStep = 12 * 3600;
 
-		private Mode selectionMode = Mode.Porkchop;
-		int windowWidth;
+        private Mode selectionMode = Mode.Porkchop;
+        int windowWidth;
 
-		TransferCalculator worker;
-		private PlotArea plot;
+        TransferCalculator worker;
+        private PlotArea plot;
 
         private static Texture2D texture;
 
         bool _draggable = true;
-		public override bool draggable { get { return _draggable;}}
+        public override bool draggable { get { return _draggable;}}
 
-		const int porkchop_Height = 200;
+        const int porkchop_Height = 200;
 
-		private string CheckPreconditions(Orbit o, MechJebModuleTargetController target)
-		{
-			if (o.eccentricity >= 1)
-				return "initial orbit must not be hyperbolic";
+        private string CheckPreconditions(Orbit o, MechJebModuleTargetController target)
+        {
+            if (o.eccentricity >= 1)
+                return "initial orbit must not be hyperbolic";
 
             if (o.ApR >= o.referenceBody.sphereOfInfluence)
                 return "initial orbit must not escape " + o.referenceBody.displayName + " sphere of influence.";
 
             if (!target.NormalTargetExists)
-				return "must select a target for the interplanetary transfer.";
+                return "must select a target for the interplanetary transfer.";
 
-			if (o.referenceBody.referenceBody == null)
-				return "doesn't make sense to plot an interplanetary transfer from an orbit around " + o.referenceBody.displayName + ".";
+            if (o.referenceBody.referenceBody == null)
+                return "doesn't make sense to plot an interplanetary transfer from an orbit around " + o.referenceBody.displayName + ".";
 
-			if (o.referenceBody.referenceBody != target.TargetOrbit.referenceBody)
-			{
-				if (o.referenceBody == target.TargetOrbit.referenceBody)
-					return "use regular Hohmann transfer function to intercept another body orbiting " + o.referenceBody.displayName + ".";
-				return "an interplanetary transfer from within " + o.referenceBody.displayName + "'s sphere of influence must target a body that orbits " + o.referenceBody.displayName + "'s parent, " + o.referenceBody.referenceBody.displayName + ".";
-			}
+            if (o.referenceBody.referenceBody != target.TargetOrbit.referenceBody)
+            {
+                if (o.referenceBody == target.TargetOrbit.referenceBody)
+                    return "use regular Hohmann transfer function to intercept another body orbiting " + o.referenceBody.displayName + ".";
+                return "an interplanetary transfer from within " + o.referenceBody.displayName + "'s sphere of influence must target a body that orbits " + o.referenceBody.displayName + "'s parent, " + o.referenceBody.referenceBody.displayName + ".";
+            }
 
-		    if (o.referenceBody == Planetarium.fetch.Sun)
-		    {
+            if (o.referenceBody == Planetarium.fetch.Sun)
+            {
                 return "use regular Hohmann transfer function to intercept another body orbiting the Sun.";
             }
 
-		    if (target.Target is CelestialBody && o.referenceBody == target.targetBody)
-		    {
+            if (target.Target is CelestialBody && o.referenceBody == target.targetBody)
+            {
                 return "you are already orbiting " + o.referenceBody.displayName + ".";
             }
 
-		    return null;
-		}
+            return null;
+        }
 
-		void ComputeStuff(Orbit o, double universalTime, MechJebModuleTargetController target)
-		{
-			errorMessage = CheckPreconditions(o, target);
-			if (errorMessage == null)
-				errorMessage = "";
-			else
-				return;
+        void ComputeStuff(Orbit o, double universalTime, MechJebModuleTargetController target)
+        {
+            errorMessage = CheckPreconditions(o, target);
+            if (errorMessage == null)
+                errorMessage = "";
+            else
+                return;
 
-			if (worker != null)
-				worker.stop = true;
-			plot = null;
+            if (worker != null)
+                worker.stop = true;
+            plot = null;
 
-			switch (selectionMode)
-			{
-			case Mode.LimitedTime:
-				worker = new TransferCalculator (o, target.TargetOrbit, universalTime, maxArrivalTime, minSamplingStep);
-				break;
-			case Mode.Porkchop:
-				worker = new AllGraphTransferCalculator(o, target.TargetOrbit, minDepartureTime, maxDepartureTime, minTransferTime, maxTransferTime, windowWidth, porkchop_Height);
-				break;
-			}
-		}
+            switch (selectionMode)
+            {
+            case Mode.LimitedTime:
+                worker = new TransferCalculator (o, target.TargetOrbit, universalTime, maxArrivalTime, minSamplingStep);
+                break;
+            case Mode.Porkchop:
+                worker = new AllGraphTransferCalculator(o, target.TargetOrbit, minDepartureTime, maxDepartureTime, minTransferTime, maxTransferTime, windowWidth, porkchop_Height);
+                break;
+            }
+        }
 
-		void ComputeTimes(Orbit o, Orbit destination, double universalTime)
-		{
-			if (destination == null || o == null || o.referenceBody.orbit == null)
-				return;
+        void ComputeTimes(Orbit o, Orbit destination, double universalTime)
+        {
+            if (destination == null || o == null || o.referenceBody.orbit == null)
+                return;
 
-			double synodic_period = o.referenceBody.orbit.SynodicPeriod(destination);
-			double hohmann_transfer_time = OrbitUtil.GetTransferTime(o.referenceBody.orbit, destination);
+            double synodic_period = o.referenceBody.orbit.SynodicPeriod(destination);
+            double hohmann_transfer_time = OrbitUtil.GetTransferTime(o.referenceBody.orbit, destination);
 
             // Both orbit have the same period
-		    if (double.IsInfinity(synodic_period))
-		        synodic_period = o.referenceBody.orbit.period;
+            if (double.IsInfinity(synodic_period))
+                synodic_period = o.referenceBody.orbit.period;
 
             minDepartureTime = universalTime;
-			minTransferTime = 3600;
+            minTransferTime = 3600;
 
-			maxDepartureTime = minDepartureTime + synodic_period * 1.5;
-			maxTransferTime = hohmann_transfer_time * 1.5;
-			maxArrivalTime.val = (synodic_period + hohmann_transfer_time) * 1.5;
-		}
+            maxDepartureTime = minDepartureTime + synodic_period * 1.5;
+            maxTransferTime = hohmann_transfer_time * 1.5;
+            maxArrivalTime.val = (synodic_period + hohmann_transfer_time) * 1.5;
+        }
 
-	    private bool layoutSkipped = false;
+        private bool layoutSkipped = false;
 
-		private void DoPorkchopGui(Orbit o, double universalTime, MechJebModuleTargetController target)
-		{
+        private void DoPorkchopGui(Orbit o, double universalTime, MechJebModuleTargetController target)
+        {
             // That mess is why you should not compute anything inside a GUI call
             // TODO : rewrite all that...
-			if (worker == null)
-			{
-			    if (Event.current.type == EventType.Layout)
-			        layoutSkipped = true;
-			    return;
-			}
+            if (worker == null)
+            {
+                if (Event.current.type == EventType.Layout)
+                    layoutSkipped = true;
+                return;
+            }
             if (Event.current.type == EventType.Layout)
                 layoutSkipped = false;
             if (layoutSkipped)
                 return;
 
             string dv = " - ";
-			string departure = " - ";
-			string duration = " - ";
-			if (worker.Finished && worker.computed.GetLength(1) == porkchop_Height)
-			{
-				if (plot == null && Event.current.type == EventType.Layout)
-				{
+            string departure = " - ";
+            string duration = " - ";
+            if (worker.Finished && worker.computed.GetLength(1) == porkchop_Height)
+            {
+                if (plot == null && Event.current.type == EventType.Layout)
+                {
 
                     int width = worker.computed.GetLength(0);
                     int height = worker.computed.GetLength(1);
@@ -153,151 +153,154 @@ namespace MuMech
                     Porkchop.RefreshTexture(worker.computed, texture);
 
                     plot = new PlotArea(
-						worker.minDepartureTime,
-						worker.maxDepartureTime,
-						worker.minTransferTime,
-						worker.maxTransferTime,
-						texture,
-						(xmin, xmax, ymin, ymax) => {
-							minDepartureTime = Math.Max(xmin, universalTime);
-							maxDepartureTime = xmax;
-							minTransferTime = Math.Max(ymin, 3600);
-							maxTransferTime = ymax;
-							GUI.changed = true;
-						});
-					plot.selectedPoint = new int[]{worker.bestDate, worker.bestDuration};
-				}
-			}
-			if (plot != null)
-			{
-				var point = plot.selectedPoint;
-				if (plot.hoveredPoint != null)
-					point = plot.hoveredPoint;
+                        worker.minDepartureTime,
+                        worker.maxDepartureTime,
+                        worker.minTransferTime,
+                        worker.maxTransferTime,
+                        texture,
+                        (xmin, xmax, ymin, ymax) => {
+                            minDepartureTime = Math.Max(xmin, universalTime);
+                            maxDepartureTime = xmax;
+                            minTransferTime = Math.Max(ymin, 3600);
+                            maxTransferTime = ymax;
+                            GUI.changed = true;
+                        });
+                    plot.selectedPoint = new int[]{worker.bestDate, worker.bestDuration};
+                }
+            }
+            if (plot != null)
+            {
+                var point = plot.selectedPoint;
+                if (plot.hoveredPoint != null)
+                    point = plot.hoveredPoint;
 
-				var p = worker.computed[point[0], point[1]];
-				if (p != null)
-				{
-					dv = MuUtils.ToSI(p.dV.magnitude) + "m/s";
-					if (worker.DateFromIndex(point[0]) < Planetarium.GetUniversalTime())
-						departure = "any time now";
-					else
-						departure = GuiUtils.TimeToDHMS(worker.DateFromIndex(point[0]) - Planetarium.GetUniversalTime());
-					duration = GuiUtils.TimeToDHMS(worker.DurationFromIndex(point[1]));
-				}
-				plot.DoGUI();
-				if (!plot.draggable) _draggable = false;
-			}
-			else
-			{
-				GUIStyle progressStyle = new GUIStyle
-				{
-					font = GuiUtils.skin.font,
-					fontSize = GuiUtils.skin.label.fontSize,
-					fontStyle = GuiUtils.skin.label.fontStyle,
-					normal = {textColor = GuiUtils.skin.label.normal.textColor}
-				};
+                var p = worker.computed[point[0], point[1]];
+                if (p != null)
+                {
+                    dv = MuUtils.ToSI(p.dV.magnitude) + "m/s";
+                    if (worker.DateFromIndex(point[0]) < Planetarium.GetUniversalTime())
+                        departure = "any time now";
+                    else
+                        departure = GuiUtils.TimeToDHMS(worker.DateFromIndex(point[0]) - Planetarium.GetUniversalTime());
+                    duration = GuiUtils.TimeToDHMS(worker.DurationFromIndex(point[1]));
+                }
+                plot.DoGUI();
+                if (!plot.draggable) _draggable = false;
+            }
+            else
+            {
+                GUIStyle progressStyle = new GUIStyle
+                {
+                    font = GuiUtils.skin.font,
+                    fontSize = GuiUtils.skin.label.fontSize,
+                    fontStyle = GuiUtils.skin.label.fontStyle,
+                    normal = {textColor = GuiUtils.skin.label.normal.textColor}
+                };
 
-				GUILayout.Box("Computing: " + worker.Progress + "%", progressStyle, GUILayout.Width(windowWidth), GUILayout.Height(porkchop_Height));
-			}
-			GUILayout.BeginHorizontal();
-			GUILayout.Label("ΔV: " + dv);
-			GUILayout.FlexibleSpace();
-			if (GUILayout.Button("Reset", GuiUtils.yellowOnHover))
-				ComputeTimes(o, target.TargetOrbit, universalTime);
-			GUILayout.EndHorizontal();
+                GUILayout.Box("Computing: " + worker.Progress + "%", progressStyle, GUILayout.Width(windowWidth), GUILayout.Height(porkchop_Height));
+            }
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("ΔV: " + dv);
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Reset", GuiUtils.yellowOnHover))
+                ComputeTimes(o, target.TargetOrbit, universalTime);
+            GUILayout.EndHorizontal();
 
-			GUILayout.BeginHorizontal();
-			GUILayout.Label("Select: ");
-			GUILayout.FlexibleSpace();
-			if (GUILayout.Button("Lowest ΔV"))
-			{
-				plot.selectedPoint = new int[]{ worker.bestDate, worker.bestDuration };
-				GUI.changed = false;
-			}
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Select: ");
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Lowest ΔV"))
+            {
+                plot.selectedPoint = new int[]{ worker.bestDate, worker.bestDuration };
+                GUI.changed = false;
+            }
 
-			if (GUILayout.Button("ASAP"))
-			{
-				int bestDuration = 0;
-				for (int i = 1; i < worker.computed.GetLength(1); i++)
-				{
-					if (worker.computed[0, bestDuration].dV.sqrMagnitude > worker.computed[0, i].dV.sqrMagnitude)
-						bestDuration = i;
-				}
-				plot.selectedPoint = new int[]{ 0, bestDuration };
-				GUI.changed = false;
-			}
-			GUILayout.EndHorizontal();
+            if (GUILayout.Button("ASAP"))
+            {
+                int bestDuration = 0;
+                for (int i = 1; i < worker.computed.GetLength(1); i++)
+                {
+                    if (worker.computed[0, bestDuration].dV.sqrMagnitude > worker.computed[0, i].dV.sqrMagnitude)
+                        bestDuration = i;
+                }
+                plot.selectedPoint = new int[]{ 0, bestDuration };
+                GUI.changed = false;
+            }
+            GUILayout.EndHorizontal();
 
-			GUILayout.Label("Departure in " + departure);
-			GUILayout.Label("Transit duration " + duration);
-		}
+            GUILayout.Label("Departure in " + departure);
+            GUILayout.Label("Transit duration " + duration);
+        }
 
-		public override void DoParametersGUI(Orbit o, double universalTime, MechJebModuleTargetController target)
-		{
-			_draggable = true;
-			if (worker != null && !target.NormalTargetExists && Event.current.type == EventType.Layout)
-			{
-				worker.stop = true;
-				worker = null;
-				plot = null;
-			}
+        public override void DoParametersGUI(Orbit o, double universalTime, MechJebModuleTargetController target)
+        {
+            _draggable = true;
+            if (worker != null && !target.NormalTargetExists && Event.current.type == EventType.Layout)
+            {
+                worker.stop = true;
+                worker = null;
+                plot = null;
+            }
 
-			selectionMode = (Mode) GuiUtils.ComboBox.Box((int) selectionMode, modeNames, this);
-			if (Event.current.type == EventType.Repaint)
-				windowWidth = (int)GUILayoutUtility.GetLastRect().width;
+            selectionMode = (Mode) GuiUtils.ComboBox.Box((int) selectionMode, modeNames, this);
+            if (Event.current.type == EventType.Repaint)
+                windowWidth = (int)GUILayoutUtility.GetLastRect().width;
 
-			switch (selectionMode)
-			{
-			case Mode.LimitedTime:
-				GuiUtils.SimpleTextBox("Max arrival time", maxArrivalTime);
-				if (worker != null && !worker.Finished)
-					GuiUtils.SimpleLabel("Computing: " + worker.Progress + "%");
-				break;
-			case Mode.Porkchop:
-				DoPorkchopGui(o, universalTime, target);
-				break;
-			}
+            switch (selectionMode)
+            {
+            case Mode.LimitedTime:
+                GuiUtils.SimpleTextBox("Max arrival time", maxArrivalTime);
+                if (worker != null && !worker.Finished)
+                    GuiUtils.SimpleLabel("Computing: " + worker.Progress + "%");
+                break;
+            case Mode.Porkchop:
+                DoPorkchopGui(o, universalTime, target);
+                break;
+            }
 
-			if (worker == null || worker.destinationOrbit != target.TargetOrbit || worker.originOrbit != o)
-				ComputeTimes(o, target.TargetOrbit, universalTime);
+            if (worker == null || worker.destinationOrbit != target.TargetOrbit || worker.originOrbit != o)
+                ComputeTimes(o, target.TargetOrbit, universalTime);
 
-			if (GUI.changed || worker == null || worker.destinationOrbit != target.TargetOrbit || worker.originOrbit != o)
-				ComputeStuff(o, universalTime, target);
-		}
+            if (GUI.changed || worker == null || worker.destinationOrbit != target.TargetOrbit || worker.originOrbit != o)
+                ComputeStuff(o, universalTime, target);
+        }
 
-		public override ManeuverParameters MakeNodeImpl(Orbit o, double UT, MechJebModuleTargetController target)
-		{
-			// Check preconditions
-			string message = CheckPreconditions(o, target);
-			if (message != null)
-				throw new OperationException(message);
+        public override ManeuverParameters MakeNodeImpl(Orbit o, double UT, MechJebModuleTargetController target)
+        {
+            // Check preconditions
+            string message = CheckPreconditions(o, target);
+            if (message != null)
+                throw new OperationException(message);
 
-			// Check if computation is finished
-			if (worker != null && !worker.Finished)
-				throw new OperationException("Computation not finished");
-			if (worker == null)
-			{
-				ComputeStuff(o, UT, target);
-				throw new OperationException("Started computation");
-			}
+            // Check if computation is finished
+            if (worker != null && !worker.Finished)
+                throw new OperationException("Computation not finished");
+            if (worker == null)
+            {
+                ComputeStuff(o, UT, target);
+                throw new OperationException("Started computation");
+            }
 
-			if (worker.result == null)
-			{
-				throw new OperationException("Computation failed");
-			}
-			if (selectionMode == Mode.Porkchop)
-			{
-				if (plot == null || plot.selectedPoint == null)
-					throw new OperationException("Invalid point selected.");
-				return TransferCalculator.OptimizeEjection(
-					worker.computed[plot.selectedPoint[0], plot.selectedPoint[1]],
-					o, worker.destinationOrbit,
-					worker.DateFromIndex(plot.selectedPoint[0]) + worker.DurationFromIndex(plot.selectedPoint[1]),
-					UT);
-			}
+            if (worker.result == null)
+            {
+                throw new OperationException("Computation failed");
+            }
+            if (selectionMode == Mode.Porkchop)
+            {
+                if (plot == null || plot.selectedPoint == null)
+                    throw new OperationException("Invalid point selected.");
+                return TransferCalculator.OptimizeEjection(
+                    worker.computed[plot.selectedPoint[0], plot.selectedPoint[1]],
+                    o, worker.destinationOrbit, target.Target as CelestialBody,
+                    worker.DateFromIndex(plot.selectedPoint[0]) + worker.DurationFromIndex(plot.selectedPoint[1]),
+                    UT);
+            }
 
-			return worker.OptimizedResult;
-		}
-	}
+            return TransferCalculator.OptimizeEjection(
+                    worker.computed[worker.bestDate, worker.bestDuration],
+                    o, worker.destinationOrbit, target.Target as CelestialBody,
+                    worker.DateFromIndex(worker.bestDate) + worker.DurationFromIndex(worker.bestDuration),
+                    UT);
+        }
+    }
 }
-

--- a/MechJeb2/OrbitExtensions.cs
+++ b/MechJeb2/OrbitExtensions.cs
@@ -117,7 +117,7 @@ namespace MuMech
             return (a.SwappedAbsolutePositionAtUT(UT) - b.SwappedAbsolutePositionAtUT(UT)).magnitude;
         }
 
-        //Time during a's next orbit at which object a comes nearest to object b. 
+        //Time during a's next orbit at which object a comes nearest to object b.
         //If a is hyperbolic, the examined interval is the next 100 units of mean anomaly.
         //This is quite a large segment of the hyperbolic arc. However, for extremely high
         //hyperbolic eccentricity it may not find the actual closest approach.
@@ -215,7 +215,7 @@ namespace MuMech
             }
         }
 
-        //Gives the true anomaly (in a's orbit) at which a crosses its ascending node 
+        //Gives the true anomaly (in a's orbit) at which a crosses its ascending node
         //with b's orbit.
         //The returned value is always between 0 and 360.
         public static double AscendingNodeTrueAnomaly(this Orbit a, Orbit b)
@@ -224,7 +224,7 @@ namespace MuMech
             return a.TrueAnomalyFromVector(vectorToAN);
         }
 
-        //Gives the true anomaly (in a's orbit) at which a crosses its descending node 
+        //Gives the true anomaly (in a's orbit) at which a crosses its descending node
         //with b's orbit.
         //The returned value is always between 0 and 360.
         public static double DescendingNodeTrueAnomaly(this Orbit a, Orbit b)
@@ -331,7 +331,7 @@ namespace MuMech
 
             //If the vector points to the infalling part of the orbit then we need to do 360 minus the
             //angle from Pe to get the true anomaly. Test this by taking the the cross product of the
-            //orbit normal and vector to the periapsis. This gives a vector that points to center of the 
+            //orbit normal and vector to the periapsis. This gives a vector that points to center of the
             //outgoing side of the orbit. If vectorToAN is more than 90 degrees from this vector, it occurs
             //during the infalling part of the orbit.
             if (Math.Abs(Vector3d.Angle(projected, Vector3d.Cross(oNormal, vectorToPe))) < 90)
@@ -419,7 +419,7 @@ namespace MuMech
 
         //Returns the next time at which a will cross its ascending node with b.
         //For elliptical orbits this is a time between UT and UT + a.period.
-        //For hyperbolic orbits this can be any time, including a time in the past if 
+        //For hyperbolic orbits this can be any time, including a time in the past if
         //the ascending node is in the past.
         //NOTE: this function will throw an ArgumentException if a is a hyperbolic orbit and the "ascending node"
         //occurs at a true anomaly that a does not actually ever attain
@@ -430,7 +430,7 @@ namespace MuMech
 
         //Returns the next time at which a will cross its descending node with b.
         //For elliptical orbits this is a time between UT and UT + a.period.
-        //For hyperbolic orbits this can be any time, including a time in the past if 
+        //For hyperbolic orbits this can be any time, including a time in the past if
         //the descending node is in the past.
         //NOTE: this function will throw an ArgumentException if a is a hyperbolic orbit and the "descending node"
         //occurs at a true anomaly that a does not actually ever attain
@@ -440,9 +440,9 @@ namespace MuMech
         }
 
         //Returns the next time at which the orbiting object will cross the equator
-        //moving northward, if o is east-moving, or southward, if o is west-moving. 
+        //moving northward, if o is east-moving, or southward, if o is west-moving.
         //For elliptical orbits this is a time between UT and UT + o.period.
-        //For hyperbolic orbits this can by any time, including a time in the past if the 
+        //For hyperbolic orbits this can by any time, including a time in the past if the
         //ascending node is in the past.
         //NOTE: this function will throw an ArgumentException if o is a hyperbolic orbit and the
         //"ascending node" occurs at a true anomaly that o does not actually ever attain.
@@ -452,9 +452,9 @@ namespace MuMech
         }
 
         //Returns the next time at which the orbiting object will cross the equator
-        //moving southward, if o is east-moving, or northward, if o is west-moving. 
+        //moving southward, if o is east-moving, or northward, if o is west-moving.
         //For elliptical orbits this is a time between UT and UT + o.period.
-        //For hyperbolic orbits this can by any time, including a time in the past if the 
+        //For hyperbolic orbits this can by any time, including a time in the past if the
         //descending node is in the past.
         //NOTE: this function will throw an ArgumentException if o is a hyperbolic orbit and the
         //"descending node" occurs at a true anomaly that o does not actually ever attain.
@@ -474,7 +474,7 @@ namespace MuMech
             return Math.Abs(1.0 / (1.0 / a.period - sign * 1.0 / b.period)); //period after which the phase angle repeats
         }
 
-        //Computes the phase angle between two orbiting objects. 
+        //Computes the phase angle between two orbiting objects.
         //This only makes sence if a.referenceBody == b.referenceBody.
         public static double PhaseAngle(this Orbit a, Orbit b, double UT)
         {
@@ -498,7 +498,7 @@ namespace MuMech
         }
 
         //Finds the next time at which the orbiting object will achieve a given radius
-        //from the center of the primary. 
+        //from the center of the primary.
         //If the given radius is impossible for this orbit, an ArgumentException is thrown.
         //For elliptical orbits this will be a time between UT and UT + period
         //For hyperbolic orbits this can be any time. If the given radius will be achieved


### PR DESCRIPTION
the major point of this fix is actually the removal of the line

orbit.StartUT = t

which seems to cause issues.  that was being done so that
PatchedConics.CalculatePatch() could be called with orbit.StartUT
consistently, but i unrolled the loop so it gets called with 't'
first and then orbit.StartUT.  more code, but avoids the hack.

then there's some successive APIs that are called:

- getTruePositionAtUT (if we're not even in the correct solar transfer
orbit somehow)
- getRelativePositionAtUT (for the solar transfer orbit)
- getRelativePositionFromTrueAnomaly(0) (aka periapsis distance once we
  get into the target SOI)
- difference in dV once we're hitting the planet pretty much exactly

since the magnitude takes sucessive jumps up at every step the optimizer
should be able to handle is and continuously trickle down to the target.

i pinned the UT_arrival time again.  i don't think it makes a lot of
sense to try to optimize that since someone may have tried to pick a
target off of the porkchop plot and they should get more or less what
they pick.

did a bunch of whitespace cleanup as well.

closes #843