### PR TITLE
Add "Current" button for target orbital inclination

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -149,7 +149,13 @@ namespace MuMech
                 GUIStyle si = new GUIStyle(GUI.skin.label);
                 if (!autopilot.enabled && Math.Abs(desiredInclination) < Math.Abs(vesselState.latitude))
                     si.onHover.textColor = si.onNormal.textColor = XKCDColors.Orange;
-                GuiUtils.SimpleTextBox("Orbit inclination", desiredInclination, "º", rightLabelStyle: si);
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Orbit inc.", si, GUILayout.ExpandWidth(true));
+                desiredInclination.text = GUILayout.TextField(desiredInclination.text, GUILayout.ExpandWidth(true), GUILayout.Width(100));
+                GUILayout.Label("º", GUILayout.ExpandWidth(false));
+                if (GUILayout.Button("Current"))
+                    desiredInclination.val = vesselState.latitude;
+                GUILayout.EndHorizontal();
 
                 core.thrust.LimitToPreventOverheatsInfoItem();
                 //core.thrust.LimitToTerminalVelocityInfoItem();


### PR DESCRIPTION
Basically inlined the SimpleTextBox method.

Had to shorten "Orbit inclination" to "Orbit inc." to avoid making the horizontal box too long. Might be able to keep "Orbit inclination" if the text box is made thinner.

Can result in some amount of orange flickering of the orbital inclination label due to `vesselState.latitude` changing by small amounts while the vessel is ostensibly sitting still.