### PR TITLE
Make time/date display calendar agnostic

### DIFF
--- a/MechJeb2/GuiUtils.cs
+++ b/MechJeb2/GuiUtils.cs
@@ -402,7 +402,7 @@ namespace MuMech
             try
             {
                 string[] units = { "y", "d", "h", "m", "s" };
-                long[] intervals = { DaysPerYear * HoursPerDay * 3600, HoursPerDay * 3600, 3600, 60, 1 };
+                long[] intervals = { KSPUtil.dateTimeFormatter.Year, KSPUtil.dateTimeFormatter.Day, 3600, 60, 1 };
 
                 if (seconds < 0)
                 {
@@ -438,7 +438,7 @@ namespace MuMech
         public static bool TryParseDHMS(string s, out double seconds)
         {
             string[] units = { "y", "d", "h", "m", "s" };
-            int[] intervals = { DaysPerYear * HoursPerDay * 3600, HoursPerDay * 3600, 3600, 60, 1 };
+            int[] intervals = { KSPUtil.dateTimeFormatter.Year, KSPUtil.dateTimeFormatter.Day, 3600, 60, 1 };
 
             s = s.Trim(' ');
             bool minus = (s.StartsWith("-"));


### PR DESCRIPTION
Don't hardcode day and year length and instead get them from current dateTimeFormatter for compatibility with Kronometer or other custom calendars.

Tested in KSP 1.3.1 (Windows x64) with Kopernicus 1.3.1-3, Sigma Dimensions 0.9.6, RESCALE 1.0.2.8 (6.4x), Kronometer 1.3.1-1

MechJeb display of date/time compared to in-game displayed values for Orbital Period, Time to Apoapsis/Periapis/AN/DN/node.

Tested Maneuver Node Editor adding 1y 3d to time of node.