### PR TITLE
Change angmom check to angvel

### DIFF
--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -134,7 +134,7 @@ namespace MuMech
             //autowarp, but only if we're already aligned with the node
             if (autowarp && !burnTriggered)
             {
-                if ((core.attitude.attitudeAngleFromTarget() < 1 && core.vessel.angularMomentum.magnitude < 0.05) || (core.attitude.attitudeAngleFromTarget() < 10 && !MuUtils.PhysicsRunning()))
+                if ((core.attitude.attitudeAngleFromTarget() < 1 && core.vessel.angularVelocity.magnitude < 0.0002) || (core.attitude.attitudeAngleFromTarget() < 10 && !MuUtils.PhysicsRunning()))
                 {
                     core.warp.WarpToUT(node.UT - halfBurnTime - leadTime);
                 }


### PR DESCRIPTION
Should address a lot of the node executor stuck and won't warp
complaints.

Not sure about the threshold.  If its still a bit buggy then we
can bump it up in powers of two or so until it goes away.