### PR TITLE
Docking AP Move To Start safeguard

### DIFF
--- a/MechJeb2/MechJebModuleDockingAutopilot.cs
+++ b/MechJeb2/MechJebModuleDockingAutopilot.cs
@@ -180,16 +180,11 @@ namespace MuMech
                     break;
 
                 case DockingStep.MOVING_TO_START:
-                    
-                    timeToAxis = Math.Abs(lateralSep.magnitude / latApproachSpeed );
-                    timeToTargetSize = Math.Abs((zSep - targetSize) / zApproachSpeed);
 
-                    if (zSep < targetSize)
+                    if (zSep < safeDistance)
                         zApproachSpeed *= -1;
-                    if (((zSep <= lateralSep.magnitude * 10) || (timeToTargetSize <= timeToAxis * 10)) && (timeToAxis > 0 && timeToTargetSize > 0))
-                    {
-                        latApproachSpeed *= 2;
-                    }
+                    else
+                        zApproachSpeed *= 0;
 
                     status = "Moving toward the starting point at " + zApproachSpeed.ToString("F2") + " m/s.";
                     break;


### PR DESCRIPTION
* Simplified and made safer the part of the docking AP where it is 'moving toward start' (if Z separation is inside of the safe zone then move BACK. Otherwise hold distance until we finish moving laterally)