### PR TITLE
Add antenna auto-deploy to ascent guidance and antenna / solar panel toggle to Utilities

### DIFF
--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -39,6 +39,7 @@ namespace MuMech
         public MechJebModuleRoverController rover;
         public MechJebModuleNodeExecutor node;
         public MechJebModuleSolarPanelController solarpanel;
+        public MechJebModuleDeployableAntennaController antennaControl;
         public MechJebModuleLandingAutopilot landing;
         public MechJebModuleSettings settings;
         public MechJebModuleAirplaneAutopilot airplane;
@@ -749,6 +750,7 @@ namespace MuMech
             rover = GetComputerModule<MechJebModuleRoverController>();
             node = GetComputerModule<MechJebModuleNodeExecutor>();
             solarpanel = GetComputerModule<MechJebModuleSolarPanelController>();
+            antennaControl = GetComputerModule<MechJebModuleDeployableAntennaController>();
             landing = GetComputerModule<MechJebModuleLandingAutopilot>();
             settings = GetComputerModule<MechJebModuleSettings>();
             airplane = GetComputerModule<MechJebModuleAirplaneAutopilot>();

--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -45,21 +45,16 @@ namespace MuMech
         public MechJebModuleAirplaneAutopilot airplane;
 
         public VesselState vesselState = new VesselState();
-
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "MechJeb"), UI_Toggle(disabledText = "Disabled", enabledText = "Enabled")]
         public bool running = true;
-
         private Vessel controlledVessel; //keep track of which vessel we've added our onFlyByWire callback to
-
         public string version = "";
-
         private bool deactivateControl = false;
-
         public MechJebCore MasterMechJeb
         {
             get { return vessel.GetMasterMechJeb(); }
         }
-
+        
         // Allow other mods to kill MJ ability to control vessel (RemoteTech, RO...)
         public bool DeactivateControl
         {

--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -33,10 +33,16 @@ namespace MuMech
         public bool forceRoll = true;
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public EditableDouble verticalRoll = new EditableDouble(90);
+
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public EditableDouble turnRoll = new EditableDouble(90);
+
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public bool autodeploySolarPanels = true;
+
+        [Persistent(pass = (int)(Pass.Type | Pass.Global))]
+        public bool autoDeployAntennas = true;
+
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public bool skipCircularization = false;
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
@@ -197,14 +203,26 @@ namespace MuMech
 
         }
 
-        void DriveSolarPanels(FlightCtrlState s)
+        void DriveDeployableComponents(FlightCtrlState s)
         {
             if (autodeploySolarPanels)
             {
                 if (vesselState.altitudeASL > mainBody.RealMaxAtmosphereAltitude())
+                {
                     core.solarpanel.ExtendAll();
+                }
                 else
+                {
                     core.solarpanel.RetractAll();
+                }
+            }
+
+            if (autoDeployAntennas)
+            {
+                if (vesselState.altitudeASL > mainBody.RealMaxAtmosphereAltitude())
+                    core.antennaControl.ExtendAll();
+                else
+                    core.antennaControl.RetractAll();
             }
         }
 
@@ -255,7 +273,7 @@ namespace MuMech
                 return;
             }
 
-            DriveSolarPanels(s);
+            DriveDeployableComponents(s);
 
             if ( ascentPath.DriveAscent(s) ) {
                 if (GameSettings.VERBOSE_DEBUG_LOG) { Debug.Log("Remaining in Ascent"); }
@@ -274,7 +292,7 @@ namespace MuMech
                 return;
             }
 
-            DriveSolarPanels(s);
+            DriveDeployableComponents(s);
 
             if (placedCircularizeNode)
             {

--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -33,16 +33,12 @@ namespace MuMech
         public bool forceRoll = true;
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public EditableDouble verticalRoll = new EditableDouble(90);
-
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public EditableDouble turnRoll = new EditableDouble(90);
-
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public bool autodeploySolarPanels = true;
-
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public bool autoDeployAntennas = true;
-
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public bool skipCircularization = false;
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -206,6 +206,9 @@ namespace MuMech
                 autopilot.autodeploySolarPanels = GUILayout.Toggle(autopilot.autodeploySolarPanels,
                         "Auto-deploy solar panels");
 
+                autopilot.autoDeployAntennas = GUILayout.Toggle(autopilot.autoDeployAntennas,
+                        "Auto-deploy antennas");
+
                 GUILayout.BeginHorizontal();
                 core.node.autowarp = GUILayout.Toggle(core.node.autowarp, "Auto-warp");
                 autopilot.skipCircularization = GUILayout.Toggle(autopilot.skipCircularization, "Skip Circularization");

--- a/MechJeb2/MechJebModuleDeployableAntennaController.cs
+++ b/MechJeb2/MechJebModuleDeployableAntennaController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace MuMech
@@ -37,6 +38,19 @@ namespace MuMech
         protected override List<ModuleDeployablePart> getModules(Part p)
         {
             return p.Modules.GetModules<ModuleDeployableAntenna>().ConvertAll(x => (ModuleDeployablePart)x);
+        }
+
+        protected override string getButtonText(DeployablePartState deployablePartState)
+        {
+            switch (deployablePartState)
+            {
+                case DeployablePartState.EXTENDED:
+                    return "Toggle antennas (currently extended)";
+                case DeployablePartState.RETRACTED:
+                    return "Toggle antennas (currently retracted)";
+                default:
+                    return "Toggle antennas";
+            }
         }
     }
 }

--- a/MechJeb2/MechJebModuleDeployableAntennaController.cs
+++ b/MechJeb2/MechJebModuleDeployableAntennaController.cs
@@ -3,25 +3,23 @@ using UnityEngine;
 
 namespace MuMech
 {
-    public class MechJebModuleSolarPanelController : MechJebModuleDeployableController
+    public class MechJebModuleDeployableAntennaController : MechJebModuleDeployableController
     {
-        public MechJebModuleSolarPanelController(MechJebCore core)
-            : base(core)
+        public MechJebModuleDeployableAntennaController(MechJebCore core) : base(core)
         { }
 
         public override void OnStart(PartModule.StartState state)
         {
             base.OnStart(state);
-            buttonText = "Toggle solar panels";
             extended = !AllRetracted();
+            buttonText = "Toggle antennas";
         }
 
-
-        [GeneralInfoItem("Toggle solar panels", InfoItem.Category.Misc, showInEditor = false)]
-        public void SolarPanelDeployButton()
+        [GeneralInfoItem("Toggle antennas", InfoItem.Category.Misc, showInEditor = false)]
+        public void AntennaDeployButton()
         {
-            autoDeploy = GUILayout.Toggle(autoDeploy, "Auto-deploy solar panels");
-            
+            autoDeploy = GUILayout.Toggle(autoDeploy, "Auto-deploy antennas");
+
             if (GUILayout.Button(buttonText))
             {
                 if (ExtendingOrRetracting())
@@ -42,7 +40,8 @@ namespace MuMech
 
         protected override List<ModuleDeployablePart> getModules(Part p)
         {
-            return p.Modules.GetModules<ModuleDeployableSolarPanel>().ConvertAll(x => (ModuleDeployablePart)x);
+            return p.Modules.GetModules<ModuleDeployableAntenna>().ConvertAll(x => (ModuleDeployablePart)x);
         }
     }
 }
+

--- a/MechJeb2/MechJebModuleDeployableAntennaController.cs
+++ b/MechJeb2/MechJebModuleDeployableAntennaController.cs
@@ -8,14 +8,7 @@ namespace MuMech
     {
         public MechJebModuleDeployableAntennaController(MechJebCore core) : base(core)
         { }
-
-        public override void OnStart(PartModule.StartState state)
-        {
-            base.OnStart(state);
-            extended = !AllRetracted();
-            buttonText = "Toggle antennas";
-        }
-
+        
         [GeneralInfoItem("Toggle antennas", InfoItem.Category.Misc, showInEditor = false)]
         public void AntennaDeployButton()
         {
@@ -30,8 +23,6 @@ namespace MuMech
                     ExtendAll();
                 else
                     RetractAll();
-
-                extended = !extended;
             }
         }
 

--- a/MechJeb2/MechJebModuleDeployableAntennaController.cs
+++ b/MechJeb2/MechJebModuleDeployableAntennaController.cs
@@ -26,13 +26,9 @@ namespace MuMech
                     return;
 
                 if (!extended)
-                {
                     ExtendAll();
-                }
                 else
-                {
                     RetractAll();
-                }
 
                 extended = !extended;
             }

--- a/MechJeb2/MechJebModuleDeployableController.cs
+++ b/MechJeb2/MechJebModuleDeployableController.cs
@@ -76,10 +76,7 @@ namespace MuMech
                 {
                     ModuleDeployablePart sa = deployable[j];
                     
-                    if (isDeployable(sa) &&
-                        ((sa.deployState == ModuleDeployablePart.DeployState.EXTENDED) ||
-                         (sa.deployState == ModuleDeployablePart.DeployState.EXTENDING) ||
-                         (sa.deployState == ModuleDeployablePart.DeployState.RETRACTING)))
+                    if (isDeployable(sa) && sa.deployState != ModuleDeployablePart.DeployState.RETRACTED)
                     {
                         return false;
                     }
@@ -141,6 +138,8 @@ namespace MuMech
                 buttonText = getButtonText(DeployablePartState.RETRACTED);
             else
                 buttonText = getButtonText(DeployablePartState.EXTENDED);
+
+            extended = !AllRetracted();
         }
 
         protected bool ExtendingOrRetracting()

--- a/MechJeb2/MechJebModuleDeployableController.cs
+++ b/MechJeb2/MechJebModuleDeployableController.cs
@@ -13,6 +13,8 @@ namespace MuMech
         }
 
 
+        List<ModuleDeployablePart> deployableModules;
+
         protected string buttonText;
         protected bool extended;
 
@@ -73,12 +75,7 @@ namespace MuMech
                 for (int j = 0; j < deployable.Count; j++)
                 {
                     ModuleDeployablePart sa = deployable[j];
-
-                    if (!sa.retractable)
-                    {
-                        return false;
-                    }
-
+                    
                     if (isDeployable(sa) &&
                         ((sa.deployState == ModuleDeployablePart.DeployState.EXTENDED) ||
                          (sa.deployState == ModuleDeployablePart.DeployState.EXTENDING) ||
@@ -139,6 +136,11 @@ namespace MuMech
             {
                 prev_autoDeploy = false;
             }
+
+            if (AllRetracted())
+                buttonText = getButtonText(DeployablePartState.RETRACTED);
+            else
+                buttonText = getButtonText(DeployablePartState.EXTENDED);
         }
 
         protected bool ExtendingOrRetracting()
@@ -160,5 +162,14 @@ namespace MuMech
         }
 
         protected abstract List<ModuleDeployablePart> getModules(Part p);
+
+
+        protected enum DeployablePartState
+        {
+            RETRACTED,
+            EXTENDED
+        }
+
+        protected abstract string getButtonText(DeployablePartState deployablePartState);
     }
 }

--- a/MechJeb2/MechJebModuleDeployableController.cs
+++ b/MechJeb2/MechJebModuleDeployableController.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MuMech
+{
+    public abstract class MechJebModuleDeployableController : ComputerModule
+    {
+        public MechJebModuleDeployableController(MechJebCore core) : base(core)
+        {
+            priority = 200;
+            enabled = true;
+        }
+
+
+        protected string buttonText;
+        protected bool extended;
+
+        [Persistent(pass = (int)Pass.Global)]
+        public bool autoDeploy = false;
+
+        [Persistent(pass = (int)(Pass.Local))]
+        protected bool prev_shouldDeploy = false;
+
+        public bool prev_autoDeploy = true;
+
+        protected string type = "";
+        
+        protected bool isDeployable(ModuleDeployablePart sa)
+        {
+            return (sa.Events["Extend"].active || sa.Events["Retract"].active);
+        }
+
+        public void ExtendAll()
+        {
+            vessel.parts.ForEach(p =>
+            {
+                if (p.ShieldedFromAirstream)
+                    return;
+
+                var deployable = getModules(p);
+                for (int j = 0; j < deployable.Count; j++)
+                {
+                    if (isDeployable(deployable[j]))
+                        deployable[j].Extend();
+                }
+            });
+        }
+
+        public void ExtendAll(Callback cb)
+        {
+            RetractAll();
+            cb();
+        }
+
+
+        public void RetractAll()
+        {
+            vessel.parts.ForEach(p =>
+            {
+                if (p.ShieldedFromAirstream)
+                    return;
+
+                var deployable = getModules(p);
+                for (int j = 0; j < deployable.Count; j++)
+                {
+                    if (isDeployable(deployable[j]))
+                        deployable[j].Retract();
+                }
+            });
+        }
+
+        public bool AllRetracted()
+        {
+            for (int i = 0; i < vessel.parts.Count; i++)
+            {
+                Part p = vessel.parts[i];
+                var deployable = getModules(p);
+                for (int j = 0; j < deployable.Count; j++)
+                {
+                    ModuleDeployablePart sa = deployable[j];
+
+                    if (!sa.retractable)
+                    {
+                        return false;
+                    }
+
+                    if (isDeployable(sa) &&
+                        ((sa.deployState == ModuleDeployablePart.DeployState.EXTENDED) ||
+                         (sa.deployState == ModuleDeployablePart.DeployState.EXTENDING) ||
+                         (sa.deployState == ModuleDeployablePart.DeployState.RETRACTING)))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        public bool ShouldDeploy()
+        {
+            if (!mainBody.atmosphere)
+                return true;
+
+            if (!vessel.LiftedOff())
+                return false;
+
+            if (vessel.LandedOrSplashed)
+                return false; // True adds too many complex case
+
+            double dt = 10;
+            double min_alt; // minimum altitude between now and now+dt seconds
+            double t = Planetarium.GetUniversalTime();
+
+            double PeT = orbit.NextPeriapsisTime(t) - t;
+            if (PeT > 0 && PeT < dt)
+                min_alt = orbit.PeA;
+            else
+                min_alt = Math.Sqrt(Math.Min(orbit.getRelativePositionAtUT(t).sqrMagnitude, orbit.getRelativePositionAtUT(t + dt).sqrMagnitude)) - mainBody.Radius;
+
+            if (min_alt > mainBody.RealMaxAtmosphereAltitude())
+                return true;
+
+            return false;
+        }
+
+        public override void OnFixedUpdate()
+        {
+            // Let the ascent guidance handle the solar panels to retract them before launch
+            if (autoDeploy &&
+                !(core.GetComputerModule<MechJebModuleAscentAutopilot>() != null &&
+                    core.GetComputerModule<MechJebModuleAscentAutopilot>().enabled))
+            {
+                bool tmp = ShouldDeploy();
+
+                if (tmp && (!prev_shouldDeploy || (autoDeploy != prev_autoDeploy)))
+                    ExtendAll();
+                else if (!tmp && (prev_shouldDeploy || (autoDeploy != prev_autoDeploy)))
+                    RetractAll();
+
+                prev_shouldDeploy = tmp;
+                prev_autoDeploy = true;
+            }
+            else
+            {
+                prev_autoDeploy = false;
+            }
+        }
+
+        protected bool ExtendingOrRetracting()
+        {
+            bool ret = false;
+            vessel.parts.ForEach(p =>
+            {
+                getModules(p).ForEach(m =>
+                {
+                    if (m.deployState == ModuleDeployablePart.DeployState.EXTENDING || m.deployState == ModuleDeployablePart.DeployState.RETRACTING)
+                    {
+                        ret = true;
+                    }
+                });
+            });
+            return ret;
+        }
+
+        protected abstract List<ModuleDeployablePart> getModules(Part p);
+    }
+}

--- a/MechJeb2/MechJebModuleDeployableController.cs
+++ b/MechJeb2/MechJebModuleDeployableController.cs
@@ -33,41 +33,35 @@ namespace MuMech
 
         public void ExtendAll()
         {
-            vessel.parts.ForEach(p =>
+            List<Part> vp = vessel.parts;
+            for (int i = 0; i < vp.Count; i++)
             {
+                Part p = vp[i];
+
                 if (p.ShieldedFromAirstream)
                     return;
 
                 var deployable = getModules(p);
                 for (int j = 0; j < deployable.Count; j++)
-                {
                     if (isDeployable(deployable[j]))
                         deployable[j].Extend();
-                }
-            });
+            };
         }
-
-        public void ExtendAll(Callback cb)
-        {
-            RetractAll();
-            cb();
-        }
-
-
+        
         public void RetractAll()
         {
-            vessel.parts.ForEach(p =>
-            {
+            List<Part> vp = vessel.parts;
+            for (int i = 0; i < vp.Count; i++) {
+                Part p = vp[i];
+
                 if (p.ShieldedFromAirstream)
                     return;
 
                 var deployable = getModules(p);
                 for (int j = 0; j < deployable.Count; j++)
-                {
                     if (isDeployable(deployable[j]))
                         deployable[j].Retract();
-                }
-            });
+            }
         }
 
         public bool AllRetracted()
@@ -149,18 +143,20 @@ namespace MuMech
 
         protected bool ExtendingOrRetracting()
         {
-            bool ret = false;
-            vessel.parts.ForEach(p =>
+            foreach (Part p in vessel.parts)
             {
-                getModules(p).ForEach(m =>
+                List<ModuleDeployablePart> deployableModules = getModules(p);
+
+                foreach (ModuleDeployablePart deployableModule in deployableModules)
                 {
-                    if (m.deployState == ModuleDeployablePart.DeployState.EXTENDING || m.deployState == ModuleDeployablePart.DeployState.RETRACTING)
+                    if (deployableModule.deployState == ModuleDeployablePart.DeployState.EXTENDING ||
+                        deployableModule.deployState == ModuleDeployablePart.DeployState.RETRACTING)
                     {
-                        ret = true;
+                        return true;
                     }
-                });
-            });
-            return ret;
+                }
+            }
+            return false;
         }
 
         protected abstract List<ModuleDeployablePart> getModules(Part p);

--- a/MechJeb2/MechJebModuleSolarPanelController.cs
+++ b/MechJeb2/MechJebModuleSolarPanelController.cs
@@ -8,15 +8,7 @@ namespace MuMech
         public MechJebModuleSolarPanelController(MechJebCore core)
             : base(core)
         { }
-
-        public override void OnStart(PartModule.StartState state)
-        {
-            base.OnStart(state);
-            buttonText = "Toggle solar panels";
-            extended = !AllRetracted();
-        }
-
-
+        
         [GeneralInfoItem("Toggle solar panels", InfoItem.Category.Misc, showInEditor = false)]
         public void SolarPanelDeployButton()
         {
@@ -31,8 +23,6 @@ namespace MuMech
                     ExtendAll();
                 else
                     RetractAll();
-
-                extended = !extended;
             }
         }
 

--- a/MechJeb2/MechJebModuleSolarPanelController.cs
+++ b/MechJeb2/MechJebModuleSolarPanelController.cs
@@ -40,5 +40,18 @@ namespace MuMech
         {
             return p.Modules.GetModules<ModuleDeployableSolarPanel>().ConvertAll(x => (ModuleDeployablePart)x);
         }
+
+        protected override string getButtonText(DeployablePartState deployablePartState)
+        {
+            switch (deployablePartState)
+            {
+                case DeployablePartState.EXTENDED:
+                    return "Toggle solar panels (currently extended)";
+                case DeployablePartState.RETRACTED:
+                    return "Toggle solar panels (currently retracted)";
+                default:
+                    return "Toggle solar panels";
+            }
+        }
     }
 }

--- a/MechJeb2/MechJebModuleSolarPanelController.cs
+++ b/MechJeb2/MechJebModuleSolarPanelController.cs
@@ -28,13 +28,9 @@ namespace MuMech
                     return;
 
                 if (!extended)
-                {
                     ExtendAll();
-                }
                 else
-                {
                     RetractAll();
-                }
 
                 extended = !extended;
             }

--- a/MechJeb2/MechJebModuleThrustWindow.cs
+++ b/MechJeb2/MechJebModuleThrustWindow.cs
@@ -96,7 +96,8 @@ namespace MuMech
 				}
 			}
 
-            core.solarpanel.AutoDeploySolarPanelsInfoItem();
+            core.solarpanel.SolarPanelDeployButton();
+            core.antennaControl.AntennaDeployButton();
 
             Autostage();
 


### PR DESCRIPTION
Hello MechJeb2 maintainers!

I wrote this module because antennas that are extendable get a better connection when extended. I saw there was no option for this (and because I got frustrated trying to locate my antenna to extend it when in flight) so I added the functionality to MechJeb.

I also added two buttons to extend / retract antennas and solar panels in the utilities window.

This is how the UI looks like with what I added:

![ascent-and-utilities-windows](https://user-images.githubusercontent.com/19394114/35177032-0aad10c4-fd7d-11e7-8247-ccda3775c5c3.jpg)

Since the behaviour to decide wether to deploy solar panels / antennas or not is so similar, I made a base class for the deploy controllers to avoid code duplication (basically the only thing that makes them different is that you either look for solar panels or antennas, and you have to decide the text for the buttons).

Finally, the way the auto deploy for the antennas works is the same as it used to work for the solar panels, so if in utilities you set "auto deploy antennas", it will, just like the solar panels, extend / retract on atmospheric exit / reentry.