### PR TITLE
fix some bugs and optimize FLARE in auto landing

### DIFF
--- a/MechJeb2/MechJebModuleAirplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleAirplaneAutopilot.cs
@@ -147,7 +147,7 @@ namespace MuMech
             if (speed > 600)
                 return 0.5;
             else
-                return speed * -0.00125 + 1.25;
+                return speed * -0.0015 + 1.5;
         }
 
         void UpdatePID ()

--- a/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
@@ -52,7 +52,9 @@ namespace MuMech
                 
                 GuiUtils.SimpleTextBox("Autoland glideslope:", autoland.glideslope);
                 GuiUtils.SimpleTextBox("Approach speed:", autoland.approachSpeed);
+                GuiUtils.SimpleTextBox("Touchdown speed:", autoland.touchdownSpeed);
                 autoland.bEngageReverseIfAvailable = GUILayout.Toggle(autoland.bEngageReverseIfAvailable, "Reverse thrust upon touchdown");
+                autoland.bBreakAsSoonAsLanded = GUILayout.Toggle(autoland.bBreakAsSoonAsLanded, "Break As Soon As Landed");
 
                 if (autoland.enabled)
                 {


### PR DESCRIPTION
AutolandApproachState.FLARE <- This State did badly when landing at a high speed.
I don't think it is necessary to flare on propose. When the aircraft touches down at a low speed and low sink rate, it will automatically flare. Otherwise, my plane can't land if its speed is high.

My solution is to keep vertical speed control on until rollout, and adjust vertical speed target.

Now, it can land Aeris-3A smoothly ranging in speed from 50 to 200 m/s, and stop at the end of the runway.
![](https://raw.githubusercontent.com/zyayoung/image-repository/master/1518456750690.gif)
other changes:
- increased a bit pid at low speed
- disable AltitudeHold when autoland enabled
- add a touch down speed TextBox.

Touch down speed textBox controls how fast the airplane touch the ground.
Approach speed controls the speed before final approach.
Maybe there are some mistakes in using the language, hope they can be fixed.

Sorry for my English -_-#