### PR TITLE
Added "engine" clarification to "Prevent overheats" option

### DIFF
--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -62,12 +62,12 @@ namespace MuMech
         [Persistent(pass = (int)Pass.Global)]
         public bool limitToPreventOverheats = false;
 
-        [GeneralInfoItem("Prevent overheats", InfoItem.Category.Thrust)]
+        [GeneralInfoItem("Prevent engine overheats", InfoItem.Category.Thrust)]
         public void LimitToPreventOverheatsInfoItem()
         {
             GUIStyle s = new GUIStyle(GUI.skin.toggle);
             if (limiter == LimitMode.Temperature) s.onHover.textColor = s.onNormal.textColor = Color.green;
-            limitToPreventOverheats = GUILayout.Toggle(limitToPreventOverheats, "Prevent overheats", s);
+            limitToPreventOverheats = GUILayout.Toggle(limitToPreventOverheats, "Prevent engine overheats", s);
         }
 
         [ToggleInfoItem("Smooth throttle", InfoItem.Category.Thrust)]


### PR DESCRIPTION
Thought the "Prevent overheats" option would prevent my turning my rocket into a fireball, but according to [this](https://www.reddit.com/r/KerbalAcademy/comments/8bkca3/mechjeb_ascent_overheat_prevention_not_working/dx7ewv2/) it's actually just *engine* overheats it prevents. So thought it could be good to clarify that in the option name?