### PR TITLE
Landing tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
 			XDG_DATA_HOME := ${HOME}/.local/share
 		endif
 		ifndef KSPDIR
-			KSPDIR := ${XDG_DATA_HOME}/Steam/SteamApps/common/Kerbal Space Program
+			KSPDIR := ${XDG_DATA_HOME}/Steam/steamapps/common/Kerbal Space Program
 		endif
 		MANAGED := ${KSPDIR}/KSP_Data/Managed/
 	endif

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -85,8 +85,13 @@ namespace MuMech
                 }
                 else
                 {
+                    float previous_trans_spd_act = core.thrust.trans_spd_act;
+
                     // last 200 meters:
                     core.thrust.trans_spd_act = -Mathf.Lerp(0, (float)Math.Sqrt((vesselState.limitedMaxThrustAccel - vesselState.localg) * 2 * 200) * 0.90F, (float)minalt / 200);
+
+                    // Sometimes during the descent we end up going up a bit due to overthrusting during breaking, avoid thrusting up even more and destabilizing the rocket
+                    core.thrust.trans_spd_act = (float)Math.Max(previous_trans_spd_act, core.thrust.trans_spd_act);
 
                     // take into account desired landing speed:
                     core.thrust.trans_spd_act = (float)Math.Min(-core.landing.touchdownSpeed, core.thrust.trans_spd_act);

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -91,16 +91,12 @@ namespace MuMech
                     // take into account desired landing speed:
                     core.thrust.trans_spd_act = (float)Math.Min(-core.landing.touchdownSpeed, core.thrust.trans_spd_act);
 
-//                    core.thrust.tmode = MechJebModuleThrustController.TMode.KEEP_VERTICAL;
-//                    core.thrust.trans_kill_h = true;
-
-//                    if (Math.Abs(Vector3d.Angle(-vessel.surfaceVelocity, vesselState.up)) < 10)
                     if (vesselState.speedSurfaceHorizontal < 5)
                     {
                         // if we're falling more or less straight down, control vertical speed and 
                         // kill horizontal velocity
                         core.thrust.tmode = MechJebModuleThrustController.TMode.KEEP_VERTICAL;
-                        core.thrust.trans_kill_h = true;
+                        core.thrust.trans_kill_h = false; // rockets are long, and will fall over if you attempt to do any manouvers to kill that last bit of horizontal speed
                     }
                     else
                     {

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -10,6 +10,7 @@ namespace MuMech
 
             private IDescentSpeedPolicy aggressivePolicy;
             private float thrustAt200Meters;
+            private bool forceVerticalMode = false;
 
             public FinalDescent(MechJebCore core) : base(core)
             {
@@ -99,7 +100,14 @@ namespace MuMech
                     // take into account desired landing speed:
                     core.thrust.trans_spd_act = (float)Math.Max(core.landing.touchdownSpeed, core.thrust.trans_spd_act);
 
+                    // Prevent that we switch back from Vertical mode to KeepSurface mode
+                    // When that happens the rocket will start tilting and end up falling over
                     if (vesselState.speedSurfaceHorizontal < 5)
+                    {
+                        forceVerticalMode = true;
+                    }
+
+                    if (forceVerticalMode)
                     {
                         // if we're falling more or less straight down, control vertical speed and 
                         // kill horizontal velocity

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -97,6 +97,11 @@ namespace MuMech
                         // kill horizontal velocity
                         core.thrust.tmode = MechJebModuleThrustController.TMode.KEEP_VERTICAL;
                         core.thrust.trans_kill_h = false; // rockets are long, and will fall over if you attempt to do any manouvers to kill that last bit of horizontal speed
+                        if (core.landing.rcsAdjustment) // If allowed, use RCS to stablize the rocket
+                            core.rcs.enabled = true;
+                        // Turn on SAS because we are likely to have a bit of horizontal speed left that needs to stabilize
+                        // Use SmartASS, because Mechjeb doesn't expect SAS to be used (i.e. it is automatically turned off again)
+                        core.EngageSmartASSControl(MechJebModuleSmartASS.Mode.SURFACE, MechJebModuleSmartASS.Target.VERTICAL_PLUS);
                     }
                     else
                     {

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -101,7 +101,7 @@ namespace MuMech
                             core.rcs.enabled = true;
                         // Turn on SAS because we are likely to have a bit of horizontal speed left that needs to stabilize
                         // Use SmartASS, because Mechjeb doesn't expect SAS to be used (i.e. it is automatically turned off again)
-                        core.EngageSmartASSControl(MechJebModuleSmartASS.Mode.SURFACE, MechJebModuleSmartASS.Target.VERTICAL_PLUS);
+                        core.EngageSmartASSControl(MechJebModuleSmartASS.Mode.SURFACE, MechJebModuleSmartASS.Target.VERTICAL_PLUS, true);
                     }
                     else
                     {

--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -170,6 +170,7 @@ namespace MuMech
                     masterSmartASS.target = target;
 
                     masterSmartASS.Engage();
+                    masterSmartASS.enabled = true; // show GUI
                 }
                 else
                 {
@@ -200,6 +201,7 @@ namespace MuMech
                     masterSmartRcs.target = target;
 
                     masterSmartRcs.Engage();
+                    masterSmartRcs.enabled = true; // show GUI
                 }
                 else
                 {

--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -146,12 +146,12 @@ namespace MuMech
 
                 if (!masterSmartASS.hidden)
                 {
-                    EngageSmartASSControl(MechJebModuleSmartASS.Mode.ORBITAL, target);
+                    EngageSmartASSControl(MechJebModuleSmartASS.Mode.ORBITAL, target, false);
                 }
             }
         }
 
-        public void EngageSmartASSControl(MechJebModuleSmartASS.Mode mode, MechJebModuleSmartASS.Target target)
+        public void EngageSmartASSControl(MechJebModuleSmartASS.Mode mode, MechJebModuleSmartASS.Target target, bool forceEnable)
         {
             MechJebCore masterMechJeb = this.vessel.GetMasterMechJeb();
 
@@ -161,6 +161,11 @@ namespace MuMech
 
                 if (masterSmartASS != null)
                 {
+                    if (forceEnable)
+                    {
+                        // Prevent that the presence of other attitude controllers disables SmartASS
+                        masterSmartASS.autoDisableSmartASS = false;
+                    }
                     masterSmartASS.mode = mode;
                     masterSmartASS.target = target;
 

--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -144,16 +144,31 @@ namespace MuMech
             {
                 MechJebModuleSmartASS masterSmartASS = masterMechJeb.GetComputerModule<MechJebModuleSmartASS>();
 
-                if (masterSmartASS != null && !masterSmartASS.hidden)
+                if (!masterSmartASS.hidden)
                 {
-                    masterSmartASS.mode = MechJebModuleSmartASS.Mode.ORBITAL;
+                    EngageSmartASSControl(MechJebModuleSmartASS.Mode.ORBITAL, target);
+                }
+            }
+        }
+
+        public void EngageSmartASSControl(MechJebModuleSmartASS.Mode mode, MechJebModuleSmartASS.Target target)
+        {
+            MechJebCore masterMechJeb = this.vessel.GetMasterMechJeb();
+
+            if (masterMechJeb != null)
+            {
+                MechJebModuleSmartASS masterSmartASS = masterMechJeb.GetComputerModule<MechJebModuleSmartASS>();
+
+                if (masterSmartASS != null)
+                {
+                    masterSmartASS.mode = mode;
                     masterSmartASS.target = target;
 
                     masterSmartASS.Engage();
                 }
                 else
                 {
-                    Debug.LogError("MechJeb couldn't find MechJebModuleSmartASS for orbital control via action group.");
+                    Debug.LogError("MechJeb couldn't find MechJebModuleSmartASS for orbital control.");
                 }
             }
             else

--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -173,7 +173,37 @@ namespace MuMech
                 }
                 else
                 {
-                    Debug.LogError("MechJeb couldn't find MechJebModuleSmartASS for orbital control.");
+                    Debug.LogError("MechJeb couldn't find MechJebModuleSmartASS for control.");
+                }
+            }
+            else
+            {
+                Debug.LogError("MechJeb couldn't find the master MechJeb module for the current vessel.");
+            }
+        }
+
+        public void EngageSmartRcsControl(MechJebModuleSmartRcs.Target target, bool forceEnable)
+        {
+            MechJebCore masterMechJeb = this.vessel.GetMasterMechJeb();
+
+            if (masterMechJeb != null)
+            {
+                MechJebModuleSmartRcs masterSmartRcs = masterMechJeb.GetComputerModule<MechJebModuleSmartRcs>();
+
+                if (masterSmartRcs != null)
+                {
+                    if (forceEnable)
+                    {
+                        // Prevent that the presence of other rcs controllers disables SmartRcs
+                        masterSmartRcs.autoDisableSmartRCS = false;
+                    }
+                    masterSmartRcs.target = target;
+
+                    masterSmartRcs.Engage();
+                }
+                else
+                {
+                    Debug.LogError("MechJeb couldn't find MechJebModuleSmartRcs for control.");
                 }
             }
             else

--- a/MechJeb2/MechJebModuleLandingAutopilot.cs
+++ b/MechJeb2/MechJebModuleLandingAutopilot.cs
@@ -164,7 +164,7 @@ namespace MuMech
             core.thrust.ThrustOff();
             core.thrust.users.Remove(this);
             // Do not disable RCS, because it is still useful for stabilizing the rocket
-            core.EngageSmartRcsControl(MechJebModuleSmartRcs.Target.ZERO_RVEL, true);
+            core.EngageSmartRcsControl(MechJebModuleSmartRcs.Target.ZERO_VEL, true);
             setStep(null);
         }
 

--- a/MechJeb2/MechJebModuleLandingAutopilot.cs
+++ b/MechJeb2/MechJebModuleLandingAutopilot.cs
@@ -164,7 +164,10 @@ namespace MuMech
             core.thrust.ThrustOff();
             core.thrust.users.Remove(this);
             // Do not disable RCS, because it is still useful for stabilizing the rocket
-            core.EngageSmartRcsControl(MechJebModuleSmartRcs.Target.ZERO_VEL, true);
+            if (vessel.LandedOrSplashed)
+            {
+                core.EngageSmartRcsControl(MechJebModuleSmartRcs.Target.ZERO_VEL, true);
+            }
             setStep(null);
         }
 

--- a/MechJeb2/MechJebModuleLandingAutopilot.cs
+++ b/MechJeb2/MechJebModuleLandingAutopilot.cs
@@ -164,6 +164,7 @@ namespace MuMech
             core.thrust.ThrustOff();
             core.thrust.users.Remove(this);
             // Do not disable RCS, because it is still useful for stabilizing the rocket
+            core.EngageSmartRcsControl(MechJebModuleSmartRcs.Target.ZERO_RVEL, true);
             setStep(null);
         }
 

--- a/MechJeb2/MechJebModuleLandingAutopilot.cs
+++ b/MechJeb2/MechJebModuleLandingAutopilot.cs
@@ -208,7 +208,7 @@ namespace MuMech
             // Consider lowering the langing gear
             {
                 double minalt = Math.Min(vesselState.altitudeBottom, Math.Min(vesselState.altitudeASL, vesselState.altitudeTrue));
-                if (deployGears && !deployedGears && (minalt < 1000))
+                if (deployGears && !deployedGears && (minalt < 2000))
                     DeployLandingGears();
             }
 

--- a/MechJeb2/MechJebModuleLandingAutopilot.cs
+++ b/MechJeb2/MechJebModuleLandingAutopilot.cs
@@ -163,8 +163,7 @@ namespace MuMech
             this.users.Clear();
             core.thrust.ThrustOff();
             core.thrust.users.Remove(this);
-            if (core.landing.rcsAdjustment)
-                core.rcs.enabled = false;
+            // Do not disable RCS, because it is still useful for stabilizing the rocket
             setStep(null);
         }
 
@@ -232,8 +231,7 @@ namespace MuMech
             predictor.descentSpeedPolicy = null;
             core.thrust.ThrustOff();
             core.thrust.users.Remove(this);
-            if (core.landing.rcsAdjustment)
-                core.rcs.enabled = false;
+            // Do not disable RCS, because it is still useful for stabilizing the rocket
             setStep(null);
         }
 

--- a/MechJeb2/MechJebModuleSmartRcs.cs
+++ b/MechJeb2/MechJebModuleSmartRcs.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace MuMech
 {
-    class MechJebModuleSmartRcs : DisplayModule
+    public class MechJebModuleSmartRcs : DisplayModule
     {
 
         public enum Target

--- a/MechJeb2/MechJebModuleSmartRcs.cs
+++ b/MechJeb2/MechJebModuleSmartRcs.cs
@@ -14,7 +14,7 @@ namespace MuMech
 
         public static readonly string[] TargetTexts = { "OFF", "ZERO RVEL"};
 
-        public Target target;
+        public Target target = Target.OFF;
 
         private static GUIStyle btNormal, btActive, btAuto;
 
@@ -74,17 +74,12 @@ namespace MuMech
                 }
                 GUILayout.Button("AUTO", btAuto, GUILayout.ExpandWidth(true));
             }
-            else if (core.target.Target == null)
-            {
-                GUILayout.Label("Choose a target");
-            }
             else
             {
                 GUILayout.BeginVertical();
 
                 TargetButton(Target.OFF);
                 TargetButton(Target.ZERO_RVEL);
-                //TargetButton(Target.HOLD_RPOS);
 
                 GUILayout.EndVertical();
             }

--- a/MechJeb2/MechJebModuleSmartRcs.cs
+++ b/MechJeb2/MechJebModuleSmartRcs.cs
@@ -10,9 +10,10 @@ namespace MuMech
         {
             OFF,
             ZERO_RVEL,
+            ZERO_VEL,
         }
 
-        public static readonly string[] TargetTexts = { "OFF", "ZERO RVEL"};
+        public static readonly string[] TargetTexts = { "OFF", "ZERO RELATIVE VELOCITY", "ZERO VELOCITY"};
 
         public Target target = Target.OFF;
 
@@ -80,6 +81,7 @@ namespace MuMech
 
                 TargetButton(Target.OFF);
                 TargetButton(Target.ZERO_RVEL);
+                TargetButton(Target.ZERO_VEL);
 
                 GUILayout.EndVertical();
             }
@@ -99,6 +101,10 @@ namespace MuMech
                 case Target.ZERO_RVEL:
                     core.rcs.users.Add(this);
                     core.rcs.SetTargetRelative(Vector3d.zero);
+                    break;
+                case Target.ZERO_VEL:
+                    core.rcs.users.Add(this);
+                    core.rcs.SetTargetWorldVelocity(Vector3d.zero);
                     break;
             }
         }


### PR DESCRIPTION
This is an attempt at tweaking the Landing Guidance to actually land first stage rockets without them falling over. In essence it tries not to turn the rocket above the ground to burn off last bit of horizontal velocity. Instead it turns on SmartASS to stabilize the last few seconds the landing, and SmartRcs after the landing is done.

This only fixes the unguided landing for me, the guided one still does silly things like 100% throttle just above ground with a Trust To Weight ratio of 30, which will throw the rocket into the sky and make it spin.

I'm looking for feedback/approval/etc before moving onto tweaking the guided landing.