### PR TITLE
Replace Hohmann Transfer with Bi-Impulsive Transfers

### DIFF
--- a/MechJeb2/GoodingSolver.cs
+++ b/MechJeb2/GoodingSolver.cs
@@ -18,6 +18,10 @@ namespace MuMech {
         public static void Solve(Vector3d R1, Vector3d V1, Vector3d R2, Vector3d V2, double tof, CelestialBody primary, int nrev, out Vector3d Vi, out Vector3d Vf) {
             /* most of this function lifted from https://www.mathworks.com/matlabcentral/fileexchange/39530-lambert-s-problem/content/glambert.m */
 
+            // if we don't catch this edge condition, the solver will spin forever (internal state will NaN and produce great sadness)
+            if ( tof == 0 )
+                throw new Exception( "MechJeb's Gooding Lambert Solver does not support zero time of flight (teleportation)" );
+
             double VR11, VT11, VR12, VT12;
             double VR21, VT21, VR22, VT22;
             int n;

--- a/MechJeb2/Maneuver/OperationTransfer.cs
+++ b/MechJeb2/Maneuver/OperationTransfer.cs
@@ -4,7 +4,9 @@ namespace MuMech
 {
     public class OperationGeneric : Operation
     {
-        public override string getName() { return "Hohmann transfer to target";}
+        public override string getName() { return "bi-impulsive (Hohmann) transfer to target";}
+
+        public bool intercept_only = false;
 
         public OperationGeneric ()
         {
@@ -12,6 +14,7 @@ namespace MuMech
 
         public override void DoParametersGUI(Orbit o, double universalTime, MechJebModuleTargetController target)
         {
+            intercept_only = GUILayout.Toggle(intercept_only, "intercept only, no capture burn (impact/flyby)");
             GUILayout.Label("Schedule the burn at the next transfer window.");
         }
 
@@ -19,33 +22,16 @@ namespace MuMech
         {
             if (!target.NormalTargetExists)
             {
-                throw new OperationException("must select a target for the Hohmann transfer.");
+                throw new OperationException("must select a target for the Bi-impulsive transfer.");
             }
             else if (o.referenceBody != target.TargetOrbit.referenceBody)
             {
-                throw new OperationException("target for Hohmann transfer must be in the same sphere of influence.");
-            }
-            else if (o.eccentricity > 1)
-            {
-                throw new OperationException("starting orbit for Hohmann transfer must not be hyperbolic.");
-            }
-            else if (target.TargetOrbit.eccentricity > 1)
-            {
-                throw new OperationException("target orbit for Hohmann transfer must not be hyperbolic.");
-            }
-            else if (o.RelativeInclination(target.TargetOrbit) > 30 && o.RelativeInclination(target.TargetOrbit) < 150)
-            {
-                errorMessage = "Warning: target's orbital plane is at a " + o.RelativeInclination(target.TargetOrbit).ToString("F0") + "º angle to starting orbit's plane (recommend at most 30º). Planned transfer may not intercept target properly.";
-            }
-            else if (o.eccentricity > 0.2)
-            {
-                errorMessage = "Warning: Recommend starting Hohmann transfers from a near-circular orbit (eccentricity < 0.2). Planned transfer is starting from an orbit with eccentricity " + o.eccentricity.ToString("F2") + " and so may not intercept target properly.";
+                throw new OperationException("target for Bi-impulsive transfer must be in the same sphere of influence.");
             }
 
-            Vector3d dV = OrbitalManeuverCalculator.DeltaVAndTimeForHohmannTransfer(o, target.TargetOrbit, UT, out UT);
+            Vector3d dV = OrbitalManeuverCalculator.DeltaVAndTimeForBiImpulsiveAnnealed(o, target.TargetOrbit, UT, out UT, intercept_only);
 
             return new ManeuverParameters(dV, UT);
         }
     }
 }
-

--- a/MechJeb2/MathExtensions.cs
+++ b/MechJeb2/MathExtensions.cs
@@ -19,7 +19,7 @@ namespace MuMech
         {
             return new Vector3(Math.Abs(vector.x), Math.Abs(vector.y), Math.Abs(vector.z));
         }
-        
+
         public static Vector3d Reorder(this Vector3d vector, int order)
         {
             switch (order)
@@ -141,7 +141,24 @@ namespace MuMech
             return vector - Vector3d.Project(vector, planeNormal);
         }
 
+        // +/- infinity is not a finite number (not finite)
+        // NaN is also not a finite number (not a number)
+        public static bool IsFinite(this double v)
+        {
+            return !Double.IsNaN(v) && !Double.IsInfinity(v);
+        }
 
+        public static double NextGaussian(this System.Random r, double mu = 0, double sigma = 1)
+        {
+            var u1 = r.NextDouble();
+            var u2 = r.NextDouble();
 
+            var rand_std_normal = Math.Sqrt(-2.0 * Math.Log(u1)) *
+                Math.Sin(2.0 * Math.PI * u2);
+
+            var rand_normal = mu + sigma * rand_std_normal;
+
+            return rand_normal;
+        }
     }
 }

--- a/MechJeb2/MechJebModuleAscentClassicMenu.cs
+++ b/MechJeb2/MechJebModuleAscentClassicMenu.cs
@@ -65,7 +65,7 @@ namespace MuMech
             {
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Turn start when Altitude is ", GUILayout.ExpandWidth(false));
-                GUILayout.Label(MuUtils.ToSI(path.autoTurnStartAltitude, -1, 2) + "m", GUILayout.ExpandWidth(false));
+                GUILayout.Label(MuUtils.ToSI(path.autoTurnStartAltitude, -1, 2) + "m ", GUILayout.ExpandWidth(false));
                 GUILayout.Label("or Velocity reach ", GUILayout.ExpandWidth(false));
                 GUILayout.Label(MuUtils.ToSI(path.autoTurnStartVelocity, -1, 3) + "m/s", GUILayout.ExpandWidth(false));
                 GUILayout.EndHorizontal();

--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 
+
 namespace MuMech
 {
     public static class OrbitalManeuverCalculator
@@ -415,26 +416,35 @@ namespace MuMech
             return burnDV;
         }
 
-        //Computes the delta-V of a burn at a given time that will put an object with a given orbit on a
-        //course to intercept a target at a specific interceptUT.
         public static Vector3d DeltaVToInterceptAtTime(Orbit o, double UT, Orbit target, double interceptUT, double offsetDistance = 0, bool shortway = true)
         {
-            double initialT = UT;
-            Vector3d initialRelPos = o.SwappedRelativePositionAtUT(initialT);
-            double finalT = interceptUT;
-            Vector3d finalRelPos = target.SwappedRelativePositionAtUT(finalT);
+            Vector3d finalVelocity;
+            return  DeltaVToInterceptAtTime(o, UT, target, interceptUT, out finalVelocity, offsetDistance, shortway);
+        }
 
-            Vector3d initialVelocity, finalVelocity;
-            LambertSolver.Solve(initialRelPos, finalRelPos, finalT - initialT, o.referenceBody, shortway, out initialVelocity, out finalVelocity);
+        //Computes the delta-V of a burn at a given time that will put an object with a given orbit on a
+        //course to intercept a target at a specific interceptUT.
+        public static Vector3d DeltaVToInterceptAtTime(Orbit o, double initialUT, Orbit target, double finalUT, out Vector3d secondDV, double offsetDistance = 0, bool shortway = true)
+        {
+            Vector3d initialRelPos = o.SwappedRelativePositionAtUT(initialUT);
+            Vector3d finalRelPos = target.SwappedRelativePositionAtUT(finalUT);
+
+            Vector3d initialVelocity = o.SwappedOrbitalVelocityAtUT(initialUT);
+            Vector3d finalVelocity = target.SwappedOrbitalVelocityAtUT(finalUT);
+
+            Vector3d transferVi, transferVf;
+
+            GoodingSolver.Solve(initialRelPos, initialVelocity, finalRelPos, finalVelocity, finalUT - initialUT, o.referenceBody, 0, out transferVi, out transferVf);
 
             if (offsetDistance != 0)
             {
                 finalRelPos += offsetDistance * Vector3d.Cross(finalVelocity, finalRelPos).normalized;
-                LambertSolver.Solve(initialRelPos, finalRelPos, finalT - initialT, o.referenceBody, shortway, out initialVelocity, out finalVelocity);
+                GoodingSolver.Solve(initialRelPos, initialVelocity, finalRelPos, finalVelocity, finalUT - initialUT, o.referenceBody, 0, out transferVi, out transferVf);
             }
 
-            Vector3d currentInitialVelocity = o.SwappedOrbitalVelocityAtUT(initialT);
-            return initialVelocity - currentInitialVelocity;
+            secondDV = finalVelocity - transferVf;
+
+            return transferVi - initialVelocity;
         }
 
 
@@ -601,6 +611,200 @@ namespace MuMech
             return ejectionVelocity - preEjectionVelocity;
         }
 
+        public struct LambertProblem
+        {
+            public Orbit o;
+            public Orbit target;
+            public bool shortway;
+            public bool intercept_only;
+            public double zeroUT;
+        }
+
+        // x[0] is the burn time before/after zeroUT
+        // x[1] is the time of the transfer
+        //
+        // f[1] is the cost of the burn
+        //
+        // prob.shortway is which lambert solution to find
+        // prob.intercept_only omits adding the second burn to the cost
+        //
+        public static void LambertCost(double []x, double []f, object obj)
+        {
+            LambertProblem prob = (LambertProblem) obj;
+            double UT1 = x[0] + prob.zeroUT;
+            double UT2 = UT1 + x[1];
+            Vector3d finalVelocity;
+
+            try {
+                f[0] = DeltaVToInterceptAtTime(prob.o, UT1, prob.target, UT2, out finalVelocity, 0, prob.shortway).magnitude;
+                if (!prob.intercept_only)
+                {
+                    f[0] += finalVelocity.magnitude;
+                }
+            }
+            catch (Exception e)
+            {
+                // need Sqrt of MaxValue so least-squares can square it without an infinity
+                f[0] = Math.Sqrt(Double.MaxValue);
+            }
+        }
+
+        // Levenburg-Marquardt local optimization of a two burn transfer.  This is used to refine the results of the simulated annealing global
+        // optimization search.
+        //
+        // FIXME: minUT/maxUT is the min/max centered UT, so it already needs to have UT (the zero) guess subtracted off of it. it does the
+        //        right thing, but is named awkwardly.
+        public static Vector3d DeltaVAndTimeForBiImpulsiveTransfer(Orbit o, Orbit target, double UT, double TT, out double burnUT, double minUT = Double.NegativeInfinity, double maxUT = Double.PositiveInfinity, double maxTT = Double.PositiveInfinity, double maxUTplusT = Double.PositiveInfinity, bool intercept_only = false, double eps = 1e-9, int maxIter = 10000, bool shortway = false)
+        {
+            double zeroUT = UT;
+
+            double[] x = { 0, TT };
+            double[] scale = { o.period / 2, TT };
+
+            // absolute final time constraint: x[0] + x[1] <= maxUTplusT
+            double[,] C = { { 1, 1, maxUTplusT } };
+            int[] CT = { -1 };
+
+            double[] bndl = { minUT, 0 };
+            double[] bndu = { maxUT, maxTT };
+
+            alglib.minlmstate state;
+            alglib.minlmreport rep = new alglib.minlmreport();
+            alglib.minlmcreatev(1, x, 0.000001, out state);
+            alglib.minlmsetscale(state, scale);
+            alglib.minlmsetbc(state, bndl, bndu);
+            if ( maxUTplusT != Double.PositiveInfinity )
+                alglib.minlmsetlc(state, C, CT);
+            alglib.minlmsetcond(state, eps, maxIter);
+
+            LambertProblem prob = new LambertProblem();
+            prob.o = o;
+            prob.target = target;
+            prob.shortway = shortway;
+            prob.zeroUT = UT;
+            prob.intercept_only = intercept_only;
+
+            // solve it the long way
+            alglib.minlmoptimize(state, LambertCost, null, prob);
+            alglib.minlmresultsbuf(state, ref x, rep);
+            if ( rep.terminationtype != 2 )
+                Debug.Log("MechJeb Lambert Transfer minlmoptimize termination code: " + rep.terminationtype);
+
+            burnUT = UT + x[0];
+
+            return DeltaVToInterceptAtTime(o, burnUT, target, UT + x[0] + x[1], 0, shortway);
+        }
+
+        public static double acceptanceProbabilityForBiImpulsive(double currentCost, double newCost, double temp)
+        {
+            if ( newCost < currentCost )
+                return 1.0;
+            return Math.Exp( (currentCost - newCost) / temp );
+        }
+
+        // Simulated Annealing global search for a two burn transfer.
+        //
+        public static Vector3d DeltaVAndTimeForBiImpulsiveAnnealed(Orbit o, Orbit target, double UT, out double burnUT, bool intercept_only = false)
+        {
+            double MAXTEMP = 10000;
+            double temp = MAXTEMP;
+            double coolingRate = 0.003;
+            double[] f = new double[1];
+            double[] x = new double[2];
+            double bestUT = 0;
+            double bestTT = 0;
+            double bestCost = Double.MaxValue;
+            double currentCost = Double.MaxValue;
+            bool bestshortway = false;
+            System.Random random = new System.Random();
+
+            LambertProblem prob = new LambertProblem();
+            prob.o = o;
+            prob.target = target;
+            prob.zeroUT = UT;
+            prob.intercept_only = intercept_only;
+
+            double minUT = 0.0; // FIXME: allow tweaking?
+            double maxUTplusT = Double.PositiveInfinity;
+            double maxUT = 1.5 * o.SynodicPeriod(target); // FIXME: allow tweaking
+
+            // min transfer time must be > 0 (no teleportation)
+            double minTT = 1e-15;
+
+            // figure the max transfer time of a Hohmann orbit using the SMAs of the two orbits instead of the radius (as a guess), multiplied by 2
+            double a = ( o.semiMajorAxis + target.semiMajorAxis ) / 2;
+            double maxTT = 2 * Math.PI * Math.Sqrt( a * a * a / o.referenceBody.gravParameter );   // FIXME: allow tweaking
+
+            // can't leave if our orbit has disappeared
+            if (o.patchEndTransition != Orbit.PatchTransitionType.FINAL)
+                maxUT = Math.Min(maxUT, o.EndUT - UT);
+
+            if (target.patchEndTransition != Orbit.PatchTransitionType.FINAL)
+            {
+                // can't leave if our target orbit has disappeared
+                maxUT = Math.Min(maxUT, target.EndUT - UT);
+                // longest possible transfer time would leave now and arrive at the target patch end
+                maxTT = Math.Min(maxTT, target.EndUT - UT);
+                // constraint on UT + TT <= maxUTplusT to arrive before the target orbit ends
+                maxUTplusT = Math.Min(maxUTplusT, target.EndUT - UT);
+            }
+
+            double currentUT = maxUT / 2;
+            double currentTT = maxTT / 2;
+
+            System.Diagnostics.Stopwatch stopwatch = new System.Diagnostics.Stopwatch();
+
+            int n = 0;
+
+            stopwatch.Start();
+            while( temp > 1 )
+            {
+                // shrink the neighborhood based on temp
+                double windowUT = temp / MAXTEMP * maxUT / 4;
+                double windowTT = temp / MAXTEMP * maxTT / 4;
+
+                // compute the neighbor
+                x[0] = MuUtils.Clamp(random.NextGaussian(currentUT, windowUT), minUT, maxUT);
+                x[1] = MuUtils.Clamp(random.NextGaussian(currentTT, windowTT), minTT, maxTT);
+                x[1] = Math.Min(x[1], maxUTplusT - x[0]);
+
+                // just randomize the shortway
+                prob.shortway = random.NextDouble() > 0.5;
+
+                LambertCost(x, f, prob);
+
+                if ( f[0] < bestCost )
+                {
+                    bestUT = x[0];
+                    bestTT = x[1];
+                    bestshortway = prob.shortway;
+                    bestCost = f[0];
+                    currentUT = bestUT;
+                    currentTT = bestTT;
+                    currentCost = bestCost;
+                }
+                else if ( acceptanceProbabilityForBiImpulsive(currentCost, f[0], temp) > random.NextDouble() )
+                {
+                    currentUT = x[0];
+                    currentTT = x[1];
+                    currentCost = f[0];
+                }
+
+                temp *= 1 - coolingRate;
+
+                n++;
+            }
+            stopwatch.Stop();
+
+            Debug.Log("MechJeb DeltaVAndTimeForBiImpulsiveAnnealed N = " + n + " time = " + stopwatch.Elapsed);
+
+            burnUT = UT + bestUT;
+
+            //return DeltaVToInterceptAtTime(o, UT + bestUT, target, UT + bestUT + bestTT, shortway: bestshortway);
+
+            return DeltaVAndTimeForBiImpulsiveTransfer(o, target, UT + bestUT, bestTT, out burnUT, minUT: minUT, maxUT: maxUT, maxTT: maxTT, maxUTplusT: maxUTplusT, intercept_only: intercept_only, shortway: bestshortway);
+        }
+
         //Like DeltaVAndTimeForHohmannTransfer, but adds an additional step that uses the Lambert
         //solver to adjust the initial burn to produce an exact intercept instead of an approximate
         public static Vector3d DeltaVAndTimeForHohmannLambertTransfer(Orbit o, Orbit target, double UT, out double burnUT, double subtractProgradeDV = 0)
@@ -628,8 +832,7 @@ namespace MuMech
                 Debug.Log("i + " + i + ", trying for intercept at UT = " + interceptUT);
 
                 //Try both short and long way
-                bool shortway = true;
-                Vector3d interceptBurn = DeltaVToInterceptAtTime(o, burnUT, target, interceptUT, 0, shortway);
+                Vector3d interceptBurn = DeltaVToInterceptAtTime(o, burnUT, target, interceptUT, 0, true);
                 double cost = (interceptBurn - subtractedProgradeDV).magnitude;
                 Debug.Log("short way dV = " + interceptBurn.magnitude + "; subtracted cost = " + cost);
                 if (cost < minCost)
@@ -638,8 +841,7 @@ namespace MuMech
                     minCost = cost;
                 }
 
-                shortway = false;
-                interceptBurn = DeltaVToInterceptAtTime(o, burnUT, target, interceptUT, 0, shortway);
+                interceptBurn = DeltaVToInterceptAtTime(o, burnUT, target, interceptUT, 0, false);
                 cost = (interceptBurn - subtractedProgradeDV).magnitude;
                 Debug.Log("long way dV = " + interceptBurn.magnitude + "; subtracted cost = " + cost);
                 if (cost < minCost)


### PR DESCRIPTION
The existing Hohmann Transfer planner only does circular-to-circular
coplanar transfer planning.

The new functionality does full Bi-Impulsive Transfer planning with
non-coplanar, non-elliptical orbits, including hyperbolic source
and target orbits.

It does this with a first pass through a simulated annealing algorithm
that does global optimization to try to find the lowest basin.  It then
hands that off to Levenburg-Marquardt to find the local minimum.

Since the simulated annealing algorithm uses a random search, it may
not find exactly the same answer every single time. The answers it finds
should be nearby and nearly the same dV but typically off by a few
orbital periods of either the source or destination or both (when the
search space has many possible orbits -- it should pick one of the
better ones, but not necessarily the absolute best).