### PR TITLE
target period offset and NaN bugfix

### DIFF
--- a/MechJeb2/Maneuver/OperationTransfer.cs
+++ b/MechJeb2/Maneuver/OperationTransfer.cs
@@ -9,6 +9,8 @@ namespace MuMech
         public bool intercept_only = false;
 
         [Persistent(pass = (int)Pass.Global)]
+        public EditableDouble periodOffset = 0;
+        [Persistent(pass = (int)Pass.Global)]
         public EditableTime MinDepartureUT = 0;
         [Persistent(pass = (int)Pass.Global)]
         public EditableTime MaxDepartureUT = 0;
@@ -23,6 +25,7 @@ namespace MuMech
         public override void DoParametersGUI(Orbit o, double universalTime, MechJebModuleTargetController target)
         {
             intercept_only = GUILayout.Toggle(intercept_only, "intercept only, no capture burn (impact/flyby)");
+            GuiUtils.SimpleTextBox("fractional target period offset:", periodOffset);
             timeSelector.DoChooseTimeGUI();
         }
 
@@ -84,11 +87,11 @@ namespace MuMech
 
             if (timeSelector.timeReference == TimeReference.COMPUTED)
             {
-                dV = OrbitalManeuverCalculator.DeltaVAndTimeForBiImpulsiveAnnealed(o, target.TargetOrbit, universalTime, out UT, intercept_only: intercept_only);
+                dV = OrbitalManeuverCalculator.DeltaVAndTimeForBiImpulsiveAnnealed(o, target.TargetOrbit, universalTime, out UT, intercept_only: intercept_only, periodOffset: periodOffset);
             }
             else
             {
-                dV = OrbitalManeuverCalculator.DeltaVAndTimeForBiImpulsiveAnnealed(o, target.TargetOrbit, UT, out UT, intercept_only: intercept_only, fixed_ut: true);
+                dV = OrbitalManeuverCalculator.DeltaVAndTimeForBiImpulsiveAnnealed(o, target.TargetOrbit, UT, out UT, intercept_only: intercept_only, fixed_ut: true, periodOffset: periodOffset);
             }
 
             return new ManeuverParameters(dV, UT);

--- a/MechJeb2/MechJebModuleRendezvousAutopilot.cs
+++ b/MechJeb2/MechJebModuleRendezvousAutopilot.cs
@@ -35,7 +35,7 @@ namespace MuMech
 
             core.node.autowarp = core.node.autowarp && core.target.Distance > 1000;
 
-            //If we get within the target distance and then next maneuver node is still 
+            //If we get within the target distance and then next maneuver node is still
             //far in the future, delete it and we will create a new one to match velocities immediately.
             //This can often happen because the target vessel's orbit shifts slightly when it is unpacked.
             if (core.target.Distance < desiredDistance
@@ -99,7 +99,7 @@ namespace MuMech
 
                     double UT = vesselState.time + 15;
                     double interceptUT = UT + closingTime;
-                    Vector3d dV = OrbitalManeuverCalculator.DeltaVToInterceptAtTime(orbit, UT, core.target.TargetOrbit, interceptUT, 0);
+                    Vector3d dV = OrbitalManeuverCalculator.DeltaVToInterceptAtTime(orbit, UT, core.target.TargetOrbit, interceptUT);
                     vessel.PlaceManeuverNode(orbit, dV, UT);
 
                     status = "Close to target: plotting intercept";
@@ -107,7 +107,7 @@ namespace MuMech
             }
             else if (orbit.NextClosestApproachDistance(core.target.TargetOrbit, vesselState.time) < core.target.TargetOrbit.semiMajorAxis / 25)
             {
-                //We're not close to the target, but we're on an approximate intercept course. 
+                //We're not close to the target, but we're on an approximate intercept course.
                 //Kill relative velocities at closest approach
                 double UT = orbit.NextClosestApproachTime(core.target.TargetOrbit, vesselState.time);
                 Vector3d dV = OrbitalManeuverCalculator.DeltaVToMatchVelocities(orbit, UT, core.target.TargetOrbit);
@@ -130,7 +130,7 @@ namespace MuMech
             else if (orbit.RelativeInclination(core.target.TargetOrbit) < 0.05 && orbit.eccentricity < 0.05)
             {
                 //We're not on an intercept course, but we have a circular orbit in the right plane.
-                
+
                 double hohmannUT;
                 Vector3d hohmannDV = OrbitalManeuverCalculator.DeltaVAndTimeForHohmannTransfer(orbit, core.target.TargetOrbit, vesselState.time, out hohmannUT);
 


### PR DESCRIPTION
The target period allows entering values of e.g. "0.25" to lead a target in an e.g. circular orbit by 90 degrees.  Would also work for a Molniya orbit, but they would be equally spaced in time rather than equally spaced in distance.  Not really that you want to do that though, you want offset LANs for that.  But maybe for an interplanetary constellation chuck them so their apoapsis was over the north pole at the edge of Kerbin's SOI and put 2 or 3 equally spaced up there.

Handy for satellite constellations:

![screen shot 2018-10-16 at 8 27 12 pm](https://user-images.githubusercontent.com/454857/47061787-e6563680-d187-11e8-83b4-cad5183c40b6.png)

Also sneaks in a bugfix for a stackdump that would randomly happen.
