### PR TITLE
cleanup the periodOffset stuff

### DIFF
--- a/MechJeb2/Maneuver/OperationTransfer.cs
+++ b/MechJeb2/Maneuver/OperationTransfer.cs
@@ -85,13 +85,20 @@ namespace MuMech
 
             Vector3d dV;
 
+            Orbit targetOrbit = new Orbit(target.TargetOrbit);
+
+            if ( periodOffset != 0 )
+            {
+                targetOrbit.MutatedOrbit(periodOffset: periodOffset);
+            }
+
             if (timeSelector.timeReference == TimeReference.COMPUTED)
             {
-                dV = OrbitalManeuverCalculator.DeltaVAndTimeForBiImpulsiveAnnealed(o, target.TargetOrbit, universalTime, out UT, intercept_only: intercept_only, periodOffset: periodOffset);
+                dV = OrbitalManeuverCalculator.DeltaVAndTimeForBiImpulsiveAnnealed(o, targetOrbit, universalTime, out UT, intercept_only: intercept_only);
             }
             else
             {
-                dV = OrbitalManeuverCalculator.DeltaVAndTimeForBiImpulsiveAnnealed(o, target.TargetOrbit, UT, out UT, intercept_only: intercept_only, fixed_ut: true, periodOffset: periodOffset);
+                dV = OrbitalManeuverCalculator.DeltaVAndTimeForBiImpulsiveAnnealed(o, targetOrbit, UT, out UT, intercept_only: intercept_only, fixed_ut: true);
             }
 
             return new ManeuverParameters(dV, UT);

--- a/MechJeb2/OrbitExtensions.cs
+++ b/MechJeb2/OrbitExtensions.cs
@@ -80,7 +80,7 @@ namespace MuMech
         //normalized vector parallel to the planet's surface and pointing in the eastward direction
         public static Vector3d East(this Orbit o, double UT)
         {
-            return Vector3d.Cross(o.Up(UT), o.North(UT)); //I think this is the opposite of what it should be, but it gives the right answer
+            return Vector3d.Cross(o.Up(UT), o.North(UT));
         }
 
         //distance from the center of the planet
@@ -94,6 +94,19 @@ namespace MuMech
         {
             //should these in fact be swapped?
             return MuUtils.OrbitFromStateVectors(o.SwappedAbsolutePositionAtUT(UT), o.SwappedOrbitalVelocityAtUT(UT) + dV, o.referenceBody, UT);
+        }
+
+        // This does not allocate a new orbit object and the caller should call new Orbit if/when required
+        public static void MutatedOrbit(this Orbit o, double periodOffset = Double.NegativeInfinity)
+        {
+            double UT = Planetarium.GetUniversalTime();
+
+            if (periodOffset.IsFinite())
+            {
+                Vector3d pos, vel;
+                o.GetOrbitalStateVectorsAtUT(UT + o.period * periodOffset, out pos, out vel);
+                o.UpdateFromStateVectors(pos, vel, o.referenceBody, UT);
+            }
         }
 
         //mean motion is rate of increase of the mean anomaly

--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -416,10 +416,10 @@ namespace MuMech
             return burnDV;
         }
 
-        public static Vector3d DeltaVToInterceptAtTime(Orbit o, double UT, Orbit target, double interceptUT, double offsetDistance = 0, bool shortway = true, double periodOffset = 0)
+        public static Vector3d DeltaVToInterceptAtTime(Orbit o, double UT, Orbit target, double interceptUT, double offsetDistance = 0, bool shortway = true)
         {
             Vector3d finalVelocity;
-            return  DeltaVToInterceptAtTime(o, UT, target, interceptUT, out finalVelocity, offsetDistance, shortway, periodOffset);
+            return  DeltaVToInterceptAtTime(o, UT, target, interceptUT, out finalVelocity, offsetDistance, shortway);
         }
 
         // Computes the delta-V of a burn at a given time that will put an object with a given orbit on a
@@ -427,15 +427,14 @@ namespace MuMech
         //
         // offsetDistance: this is used by the Rendezvous Autopilot and is only going to be valid over very short distances
         // shortway: the shortway parameter to feed into the Lambert solver
-        // periodOffset: offset fractional period to the target orbit's position
         //
-        public static Vector3d DeltaVToInterceptAtTime(Orbit o, double initialUT, Orbit target, double finalUT, out Vector3d secondDV, double offsetDistance = 0, bool shortway = true, double periodOffset = 0)
+        public static Vector3d DeltaVToInterceptAtTime(Orbit o, double initialUT, Orbit target, double finalUT, out Vector3d secondDV, double offsetDistance = 0, bool shortway = true)
         {
             Vector3d initialRelPos = o.SwappedRelativePositionAtUT(initialUT);
-            Vector3d finalRelPos = target.SwappedRelativePositionAtUT(finalUT + target.period * periodOffset);
+            Vector3d finalRelPos = target.SwappedRelativePositionAtUT(finalUT);
 
             Vector3d initialVelocity = o.SwappedOrbitalVelocityAtUT(initialUT);
-            Vector3d finalVelocity = target.SwappedOrbitalVelocityAtUT(finalUT + target.period * periodOffset);
+            Vector3d finalVelocity = target.SwappedOrbitalVelocityAtUT(finalUT);
 
             Vector3d transferVi, transferVf;
 
@@ -624,7 +623,6 @@ namespace MuMech
             public Orbit target;
             public bool shortway;
             public bool intercept_only;  // omit the second burn from the cost
-            public double periodOffset;    // true anomaly angle to lead or lag the target in its orbit (deg)
             public double zeroUT;
         }
 
@@ -644,7 +642,7 @@ namespace MuMech
             Vector3d finalVelocity;
 
             try {
-                f[0] = DeltaVToInterceptAtTime(prob.o, UT1, prob.target, UT2, out finalVelocity, 0, prob.shortway, prob.periodOffset).magnitude;
+                f[0] = DeltaVToInterceptAtTime(prob.o, UT1, prob.target, UT2, out finalVelocity, 0, prob.shortway).magnitude;
                 if (!prob.intercept_only)
                 {
                     f[0] += finalVelocity.magnitude;
@@ -663,7 +661,7 @@ namespace MuMech
         // optimization search.
         //
         // NOTE TO SELF: all UT times here are non-zero centered.
-        public static Vector3d DeltaVAndTimeForBiImpulsiveTransfer(Orbit o, Orbit target, double UT, double TT, out double burnUT, double minUT = Double.NegativeInfinity, double maxUT = Double.PositiveInfinity, double maxTT = Double.PositiveInfinity, double maxUTplusT = Double.PositiveInfinity, bool intercept_only = false, double eps = 1e-9, int maxIter = 10000, bool shortway = false, double periodOffset = 0)
+        public static Vector3d DeltaVAndTimeForBiImpulsiveTransfer(Orbit o, Orbit target, double UT, double TT, out double burnUT, double minUT = Double.NegativeInfinity, double maxUT = Double.PositiveInfinity, double maxTT = Double.PositiveInfinity, double maxUTplusT = Double.PositiveInfinity, bool intercept_only = false, double eps = 1e-9, int maxIter = 10000, bool shortway = false)
         {
             double[] x = { 0, TT };
             double[] scale = { o.period / 2, TT };
@@ -690,7 +688,6 @@ namespace MuMech
             prob.shortway = shortway;
             prob.zeroUT = UT;
             prob.intercept_only = intercept_only;
-            prob.periodOffset = periodOffset;
 
             // solve it the long way
             alglib.minlmoptimize(state, LambertCost, null, prob);
@@ -702,7 +699,7 @@ namespace MuMech
 
             burnUT = UT + x[0];
 
-            return DeltaVToInterceptAtTime(o, burnUT, target, burnUT + x[1], 0, shortway, periodOffset);
+            return DeltaVToInterceptAtTime(o, burnUT, target, burnUT + x[1], 0, shortway);
         }
 
         public static double acceptanceProbabilityForBiImpulsive(double currentCost, double newCost, double temp)
@@ -717,7 +714,7 @@ namespace MuMech
         // FIXME: there's some very confusing nomenclature between DeltaVAndTimeForBiImpulsiveTransfer and this
         //        the minUT/maxUT values here are zero-centered on this methods UT.  the minUT/maxUT parameters to
         //        the other method are proper UT times and not zero centered at all.
-        public static Vector3d DeltaVAndTimeForBiImpulsiveAnnealed(Orbit o, Orbit target, double UT, out double burnUT, double minUT = 0.0, double maxUT = Double.PositiveInfinity, bool intercept_only = false, bool fixed_ut = false, double periodOffset = 0)
+        public static Vector3d DeltaVAndTimeForBiImpulsiveAnnealed(Orbit o, Orbit target, double UT, out double burnUT, double minUT = 0.0, double maxUT = Double.PositiveInfinity, bool intercept_only = false, bool fixed_ut = false)
         {
             double MAXTEMP = 10000;
             double temp = MAXTEMP;
@@ -736,7 +733,6 @@ namespace MuMech
             prob.target = target;
             prob.zeroUT = UT;
             prob.intercept_only = intercept_only;
-            prob.periodOffset = periodOffset;
 
             double maxUTplusT = Double.PositiveInfinity;
 
@@ -832,11 +828,11 @@ namespace MuMech
 
             Debug.Log("Annealing results burnUT = " + burnUT + " zero'd burnUT = " + bestUT + " TT = " + bestTT + " Cost = " + bestCost);
 
-            //return DeltaVToInterceptAtTime(o, UT + bestUT, target, UT + bestUT + bestTT, shortway: bestshortway, periodOffset: periodOffset);
+            //return DeltaVToInterceptAtTime(o, UT + bestUT, target, UT + bestUT + bestTT, shortway: bestshortway);
 
             // FIXME: srsly this minUT = UT + minUT / maxUT = UT + maxUT / maxUTplusT = maxUTplusT - bestUT rosetta stone here needs to go
             // and some consistency needs to happen.  this is just breeding bugs.
-            return DeltaVAndTimeForBiImpulsiveTransfer(o, target, UT + bestUT, bestTT, out burnUT, minUT: UT + minUT, maxUT: UT + maxUT, maxTT: maxTT, maxUTplusT: maxUTplusT - bestUT, intercept_only: intercept_only, shortway: bestshortway, periodOffset: periodOffset);
+            return DeltaVAndTimeForBiImpulsiveTransfer(o, target, UT + bestUT, bestTT, out burnUT, minUT: UT + minUT, maxUT: UT + maxUT, maxTT: maxTT, maxUTplusT: maxUTplusT - bestUT, intercept_only: intercept_only, shortway: bestshortway);
         }
 
         //Like DeltaVAndTimeForHohmannTransfer, but adds an additional step that uses the Lambert


### PR DESCRIPTION
make the caller responsible for mutating the target orbit and eliminate
some parameters here (also make the caller responsible for allocating
the new target orbit to mutate, which is going to be good for reduced garbage
later)
