### PR TITLE
fix PID wiggles

### DIFF
--- a/MechJeb2/MechJebModuleAttitudeController.cs
+++ b/MechJeb2/MechJebModuleAttitudeController.cs
@@ -76,8 +76,6 @@ namespace MuMech
             }
         }
 
-        protected Quaternion _oldAttitudeTarget = Quaternion.identity;
-        protected Quaternion _lastAttitudeTarget = Quaternion.identity;
         protected Quaternion _attitudeTarget = Quaternion.identity;
         public Quaternion attitudeTarget
         {
@@ -87,10 +85,8 @@ namespace MuMech
             }
             set
             {
-                if (Math.Abs(Vector3d.Angle(_lastAttitudeTarget * Vector3d.forward, value * Vector3d.forward)) > 10)
+                if (Math.Abs(Vector3d.Angle(_attitudeTarget * Vector3d.forward, value * Vector3d.forward)) > 10)
                 {
-                    _oldAttitudeTarget = _attitudeTarget;
-                    _lastAttitudeTarget = value;
                     AxisControl(true, true, true);
                     attitudeChanged = true;
                 }


### PR DESCRIPTION
the old code would reset the PID controller every 10 degrees a
rocket pitched over, because it remembered the last value it
reset the pid at, not the actual last value the last tick.

most of the variables here are a bit useless, the variable it sets
at the end is the last value when it starts in the setter.
