### PR TITLE
FuelFlowSimulation fixes

### DIFF
--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -147,7 +147,7 @@ namespace MuMech
             //print("Finished stage " + simStage + " after " + step + " steps");
             if (step == maxSteps) throw new Exception("FuelFlowSimulation.SimulateStage reached max step count of " + maxSteps);
 
-            //Debug.Log("thrust = " + stats.startThrust + " ISP = " + stats.isp + " FuelFlow = " + ( stats.startMass - stats.endMass ) / stats.deltaTime * 1000 );
+            //Debug.Log("thrust = " + stats.startThrust + " ISP = " + stats.isp + " FuelFlow = " + ( stats.startMass - stats.endMass ) / stats.deltaTime * 1000 + " num = " + FindActiveEngines(true).value.Count );
 
             return stats;
         }
@@ -953,6 +953,15 @@ namespace MuMech
 
         public bool CanDrawNeededResources(List<FuelNode> vessel)
         {
+            // XXX: this fix is intended to fix SRBs which have burned out but which
+            // still have an amount of fuel over the resourceRequestRemainingThreshold, which
+            // can happen in RealismOverhaul.  this targets specifically "No propellants" because
+            // we do not want flamed out jet engines to trigger this code if they just don't have
+            // enough intake air, and any other causes.
+            ModuleEngines e = part.Modules[0] as ModuleEngines;
+            if (e != null && e.flameout && e.statusL2 == "No propellants")
+                return false;
+
             foreach (int type in resourceConsumptions.KeysList)
             {
                 var resourceFlowMode = propellantFlows[type];

--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -107,12 +107,12 @@ namespace MuMech
             //need to set initial consumption rates for VesselThrust and AllowedToStage to work right
             for (int i = 0; i < nodes.Count; i++)
             {
-                nodes[i].SetConsumptionRates(throttle, atmDensity, machNumber);
+                nodes[i].SetConsumptionRates(throttle, staticPressure, atmDensity, machNumber);
             }
 
             Stats stats = new Stats();
             stats.startMass = VesselMass(simStage);
-            stats.startThrust = VesselThrust(throttle, staticPressure, atmDensity, machNumber);
+            stats.startThrust = VesselThrust();
             stats.endMass = stats.startMass;
             stats.resourceMass = 0;
             stats.maxAccel = stats.endMass > 0 ? stats.startThrust / stats.endMass : 0;
@@ -147,6 +147,8 @@ namespace MuMech
             //print("Finished stage " + simStage + " after " + step + " steps");
             if (step == maxSteps) throw new Exception("FuelFlowSimulation.SimulateStage reached max step count of " + maxSteps);
 
+            //Debug.Log("thrust = " + stats.startThrust + " ISP = " + stats.isp + " FuelFlow = " + ( stats.startMass - stats.endMass ) / stats.deltaTime * 1000 );
+
             return stats;
         }
 
@@ -163,11 +165,11 @@ namespace MuMech
             }
             for (int i = 0; i < nodes.Count; i++)
             {
-                nodes[i].SetConsumptionRates(throttle, atmDensity, machNumber);
+                nodes[i].SetConsumptionRates(throttle, staticPressure, atmDensity, machNumber);
             }
 
             stats.startMass = VesselMass(simStage);
-            stats.startThrust = VesselThrust(throttle, staticPressure, atmDensity, machNumber); // NK
+            stats.startThrust = VesselThrust();
 
             using (var engines = FindActiveEngines())
             {
@@ -345,15 +347,32 @@ namespace MuMech
             return sum;
         }
 
-        private double VesselThrust(float throttle, double staticPressure, double atmDensity, double machNumber)
+        private double VesselIsp()
         {
-            var param = new Tuple<float, double, double, double>(throttle, staticPressure, atmDensity, machNumber);
-
+            double sumThrust = 0;
+            double sumThrustOverIsp = 0;
             using (var activeEngines = FindActiveEngines())
             {
-                return activeEngines.value.Slinq().Select((eng, t) => eng.EngineThrust(t.Item1, t.Item2, t.Item3, t.Item4), param).Sum();
+                for(int i = 0; i < activeEngines.value.Count; i++)
+                {
+                    sumThrust += activeEngines.value[i].partThrust;
+                    sumThrustOverIsp += activeEngines.value[i].partThrust;
+                }
             }
-            //return FindActiveEngines().Sum(eng => eng.EngineThrust(throttle, staticPressure, atmDensity, machNumber));
+            return sumThrust / sumThrustOverIsp;
+        }
+
+        private double VesselThrust()
+        {
+            double sumThrust = 0;
+            using (var activeEngines = FindActiveEngines())
+            {
+                for(int i = 0; i < activeEngines.value.Count; i++)
+                {
+                    sumThrust += activeEngines.value[i].partThrust;
+                }
+            }
+            return sumThrust;
         }
 
         //Returns a list of engines that fire during the current simulated stage.
@@ -433,27 +452,9 @@ namespace MuMech
         // right-clicking.
         const double DRAINED = 1E-4;
 
-
-        FloatCurve atmosphereCurve;  //the function that gives Isp as a function of atmospheric pressure for this part, if it's an engine
-        bool atmChangeFlow;
-        bool useAtmCurve;
-        FloatCurve atmCurve;
-        bool useVelCurve;
-        FloatCurve velCurve;
-
-        KeyableDictionary<int, float> propellantRatios = new KeyableDictionary<int, float>(); //ratios of propellants used by this engine
         KeyableDictionary<int, ResourceFlowMode> propellantFlows = new KeyableDictionary<int, ResourceFlowMode>();  //flow modes of propellants since the engine can override them
-        float propellantSumRatioTimesDensity;    //a number used in computing propellant consumption rates
 
         readonly List<FuelNode> crossfeedSources = new List<FuelNode>();
-
-        float maxFuelFlow = 0;     //max fuel flow of this part
-        float minFuelFlow = 0;     //min fuel flow of this part
-
-        float thrustPercentage = 0;
-
-        float fwdThrustRatio = 1; // % of thrust moving the ship forwad
-        float g;                  // value of g used for engine flow rate / isp
 
         public int decoupledInStage;    //the stage in which this part will be decoupled from the rocket
         public int inverseStage;        //stage in which this part is activated
@@ -472,6 +473,9 @@ namespace MuMech
         float modulesStagedMass = 0; // the mass of the modules of this part after staging
 
         public string partName; //for debugging
+
+        Part part;
+        bool dVLinearThrust;
 
         private static readonly Pool<FuelNode> pool = new Pool<FuelNode>(Create, Reset);
 
@@ -503,13 +507,12 @@ namespace MuMech
 
         private void Init(Part part, bool dVLinearThrust)
         {
+            this.part = part;
+            this.dVLinearThrust = dVLinearThrust;
             resources.Clear();
             resourceConsumptions.Clear();
             resourceDrains.Clear();
             freeResources.Clear();
-
-            propellantRatios.Clear();
-            propellantFlows.Clear();
 
             crossfeedSources.Clear();
 
@@ -573,91 +576,25 @@ namespace MuMech
                     freeResources[PartResourceLibrary.Instance.GetDefinition("IntakeAtm").id] = true;
             }
 
-            // TODO : handle the multiple active ModuleEngine case ( SXT engines with integrated vernier )
-
-            //record relevant engine stats
-            //ModuleEngines engine = part.Modules.OfType<ModuleEngines>().FirstOrDefault(e => e.isEnabled);
-            ModuleEngines engine = null;
+            // determine if we've got at least one useful ModuleEngine
             for (int i = 0; i < part.Modules.Count; i++)
             {
                 PartModule pm = part.Modules[i];
                 ModuleEngines e = pm as ModuleEngines;
                 if (e != null && e.isEnabled)
                 {
-                    engine = e;
-                    break;
-                }
-            }
-
-            if (engine != null)
-            {
-                //Only count engines that either are ignited or will ignite in the future:
-                if ((HighLogic.LoadedSceneIsEditor || inverseStage < StageManager.CurrentStage || engine.getIgnitionState) && (engine.thrustPercentage > 0 || engine.minThrust > 0))
-                {
-                    //if an engine has been activated early, pretend it is in the current stage:
-                    if (engine.getIgnitionState && inverseStage < StageManager.CurrentStage)
-                        inverseStage = StageManager.CurrentStage;
-
-                    isEngine = true;
-                    isthrottleLocked = engine.throttleLocked;
-                    //print(partName + " isEngine = true and inverseStage=" + inverseStage);
-                    g = engine.g;
-
-                    // If we take into account the engine rotation
-                    if (dVLinearThrust)
+                    // Only count engines that either are ignited or will ignite in the future:
+                    if ((HighLogic.LoadedSceneIsEditor || inverseStage < StageManager.CurrentStage || e.getIgnitionState) && (e.thrustPercentage > 0 || e.minThrust > 0))
                     {
-                        Vector3 thrust = Vector3.zero;
-                        for (int i = 0; i < engine.thrustTransforms.Count; i++)
-                        {
-                            thrust -= engine.thrustTransforms[i].forward * engine.thrustTransformMultipliers[i];
-                        }
+                        // if an engine has been activated early, pretend it is in the current stage:
+                        if (e.getIgnitionState && inverseStage < StageManager.CurrentStage)
+                            inverseStage = StageManager.CurrentStage;
 
-                        Vector3d fwd = HighLogic.LoadedScene == GameScenes.EDITOR ? EditorLogic.VesselRotation * Vector3d.up : engine.part.vessel.GetTransform().up;
-                        fwdThrustRatio = Vector3.Dot(fwd, thrust);
+                        isEngine = true;
+                        isthrottleLocked = engine.throttleLocked;
+                        // we only do these test for the first ModuleEngines in the Part, could any other ones actually differ?
+                        break;
                     }
-                    else
-                    {
-                        fwdThrustRatio = 1;
-                    }
-
-                    thrustPercentage = engine.thrustPercentage;
-
-                    minFuelFlow = engine.minFuelFlow;
-                    maxFuelFlow = engine.maxFuelFlow;
-
-                    // Some brilliant engine mod seems to consider that FuelFlow is not something they should properly initialize
-                    if (minFuelFlow == 0 && engine.minThrust > 0)
-                    {
-                        minFuelFlow = engine.minThrust / (engine.atmosphereCurve.Evaluate(0f) * engine.g);
-                    }
-                    if (maxFuelFlow == 0 && engine.maxThrust > 0)
-                    {
-                        maxFuelFlow = engine.maxThrust / (engine.atmosphereCurve.Evaluate(0f) * engine.g);
-                    }
-
-                    atmosphereCurve = new FloatCurve(engine.atmosphereCurve.Curve.keys);
-                    atmChangeFlow = engine.atmChangeFlow;
-                    useAtmCurve = engine.useAtmCurve;
-                    if (useAtmCurve)
-                        atmCurve = new FloatCurve(engine.atmCurve.Curve.keys);
-                    useVelCurve = engine.useVelCurve;
-                    if (useVelCurve)
-                        velCurve = new FloatCurve(engine.velCurve.Curve.keys);
-
-                    propellantSumRatioTimesDensity = engine.propellants.Slinq().Select(prop => prop.ratio * MuUtils.ResourceDensity(prop.id)).Sum();
-                    float ratio = propellantSumRatioTimesDensity / engine.propellants.Slinq().Where(prop => !prop.ignoreForIsp).Select(prop => prop.ratio * MuUtils.ResourceDensity(prop.id)).Sum();
-                    maxFuelFlow *= ratio;
-                    minFuelFlow *= ratio;
-                    propellantRatios.Clear();
-                    propellantFlows.Clear();
-                    var dics = new Tuple<KeyableDictionary<int, float>, KeyableDictionary<int, ResourceFlowMode>>(propellantRatios, propellantFlows);
-                    engine.propellants.Slinq()
-                        .Where(prop => MuUtils.ResourceDensity(prop.id) > 0)
-                        .ForEach((p, dic) =>
-                        {
-                            dic.Item1.Add(p.id, p.ratio);
-                            dic.Item2.Add(p.id, p.GetFlowMode());
-                        }, dics);
                 }
             }
         }
@@ -705,14 +642,14 @@ namespace MuMech
                             AttachNode attach;
                             if (HighLogic.LoadedSceneIsEditor)
                             {
-                                if (mDecouple.explosiveNodeID != "srf") 
-                                { 
-                                    attach = p.FindAttachNode(mDecouple.explosiveNodeID); 
-                                } 
-                                else 
-                                { 
-                                    attach = p.srfAttachNode; 
-                                } 
+                                if (mDecouple.explosiveNodeID != "srf")
+                                {
+                                    attach = p.FindAttachNode(mDecouple.explosiveNodeID);
+                                }
+                                else
+                                {
+                                    attach = p.srfAttachNode;
+                                }
                             }
                             else
                             {
@@ -870,26 +807,62 @@ namespace MuMech
             Dispatcher.InvokeAsync(() => MonoBehaviour.print("[MechJeb2] " + message));
         }
 
-        public void SetConsumptionRates(float throttle, double atmDensity, double machNumber)
+        public double partThrust;
+
+        public void SetConsumptionRates(float throttle, double atmospheres, double atmDensity, double machNumber)
         {
             if (isEngine)
             {
-                double flowModifier = GetFlowModifier(atmDensity, machNumber);
-
-                double massFlowRate = Mathf.Lerp(minFuelFlow, maxFuelFlow, throttle * 0.01f * thrustPercentage) * flowModifier;
-
-                isDrawingResources = massFlowRate > 0;
-
-                //propellant consumption rate = ratio * massFlowRate / sum(ratio * density)
-                //resourceConsumptions = propellantRatios.Keys.ToDictionary(id => id, id => propellantRatios[id] * massFlowRate / propellantSumRatioTimesDensity);
                 resourceConsumptions.Clear();
-                for (int i = 0; i < propellantRatios.KeysList.Count; i++)
+                propellantFlows.Clear();
+
+                double sumThrustOverIsp = 0;
+                partThrust = 0;
+
+                isDrawingResources = false;
+
+                for (int i = 0; i < part.Modules.Count; i++)
                 {
-                    int id = propellantRatios.KeysList[i];
-                    double rate = propellantRatios[id] * massFlowRate / propellantSumRatioTimesDensity;
-                    //print(partName + " SetConsumptionRates for " + PartResourceLibrary.Instance.GetDefinition(id).name + " is " + rate + " flowModifier=" + flowModifier + " massFlowRate="+ massFlowRate);
-                    resourceConsumptions.Add(id, rate);
+                    PartModule pm = part.Modules[i];
+                    ModuleEngines e = pm as ModuleEngines;
+
+                    if (e != null && e.isEnabled)
+                    {
+                        Vector3d thrust;
+                        double isp, massFlowRate;
+                        e.EngineValuesAtConditions(throttle, atmospheres, atmDensity, machNumber, out thrust, out isp, out massFlowRate, cosLoss: dVLinearThrust);
+                        partThrust += thrust.magnitude;
+
+                        if ( massFlowRate > 0 )
+                            isDrawingResources = true;
+
+                        double totalDensity = 0;
+
+                        for(int j = 0; j < e.propellants.Count; j++)
+                        {
+                            var p = e.propellants[j];
+                            double density = MuUtils.ResourceDensity(p.id);
+
+                            // hopefully different EngineModules in the same part don't have different flow modes for the same propellant
+                            if (!propellantFlows.ContainsKey(p.id))
+                                propellantFlows.Add(p.id, p.GetFlowMode());
+                            totalDensity += p.ratio * density;
+                        }
+
+                        double volumeFlowRate = massFlowRate / totalDensity;
+
+                        for(int j = 0; j < e.propellants.Count; j++)
+                        {
+                            var p = e.propellants[j];
+                            double fracFlowRate = p.ratio * volumeFlowRate;
+                            if (resourceConsumptions.ContainsKey(p.id))
+                                resourceConsumptions[p.id] += fracFlowRate;
+                            else
+                                resourceConsumptions.Add(p.id, fracFlowRate);
+                        }
+                    }
                 }
+                //Debug.Log("done with " + partName);
             }
         }
 
@@ -927,17 +900,6 @@ namespace MuMech
             double resMass = resources.KeysList.Slinq().Select((r, rs) => rs[r] * MuUtils.ResourceDensity(r), resources).Sum();
             return dryMass + resMass +
                    (inverseStage < simStage ? modulesUnstagedMass : modulesStagedMass);
-        }
-
-        public double EngineThrust(float throttle, double atmospheres, double atmDensity, double machNumber)
-        {
-            float Isp = atmosphereCurve.Evaluate((float)atmospheres);
-
-            double flowModifier = GetFlowModifier(atmDensity, machNumber);
-
-            double thrust = Mathf.Lerp(minFuelFlow, maxFuelFlow, throttle * 0.01f * thrustPercentage) * flowModifier * Isp * g;
-
-            return thrust * fwdThrustRatio;
         }
 
         public void ResetDrainRates()
@@ -1107,24 +1069,5 @@ namespace MuMech
                 }
             }
         }
-
-        private double GetFlowModifier(double atmDensity, double machNumber)
-        {
-            double flowModifier = 1.0f;
-            if (atmChangeFlow)
-            {
-                flowModifier = atmDensity * (1d / 1.225);
-                if (useAtmCurve)
-                {
-                    flowModifier = atmCurve.Evaluate((float) flowModifier);
-                }
-            }
-            if (useVelCurve)
-            {
-                flowModifier = flowModifier * velCurve.Evaluate((float)machNumber);
-            }
-            return flowModifier;
-        }
-
     }
 }

--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -591,7 +591,7 @@ namespace MuMech
                             inverseStage = StageManager.CurrentStage;
 
                         isEngine = true;
-                        isthrottleLocked = engine.throttleLocked;
+                        isthrottleLocked = e.throttleLocked;
                         // we only do these test for the first ModuleEngines in the Part, could any other ones actually differ?
                         break;
                     }

--- a/MechJeb2/PartExtensions.cs
+++ b/MechJeb2/PartExtensions.cs
@@ -54,6 +54,103 @@ namespace MuMech
             return false;
         }
 
+        // for a single EngineModule, get thrust + isp + massFlowRate
+        public static void EngineValuesAtConditions(this ModuleEngines e, double throttle, double atmPressure, double atmDensity, double machNumber, out Vector3d thrust, out double isp, out double massFlowRate, bool cosLoss = true)
+        {
+            isp = e.ISPAtConditions(throttle, atmPressure, atmDensity, machNumber);
+            double flowMultiplier = e.FlowMultiplierAtConditions(atmDensity, machNumber);
+            massFlowRate = e.FlowRateAtConditions(throttle, flowMultiplier);
+            thrust = e.ThrustAtConditions(massFlowRate, isp, cosLoss);
+            //Debug.Log("thrust = " + thrust + " isp = " + isp + " massFlowRate = " + massFlowRate);
+        }
+
+        public static double FlowRateAtConditions(this ModuleEngines e, double throttle, double flowMultiplier)
+        {
+            double minFuelFlow = e.minFuelFlow;
+            double maxFuelFlow = e.maxFuelFlow;
+
+            // Some brilliant engine mod seems to consider that FuelFlow is not something they should properly initialize
+            if (minFuelFlow == 0 && e.minThrust > 0)
+            {
+                minFuelFlow = e.minThrust / (e.atmosphereCurve.Evaluate(0f) * e.g);
+            }
+
+            if (maxFuelFlow == 0 && e.maxThrust > 0)
+            {
+                maxFuelFlow = e.maxThrust / (e.atmosphereCurve.Evaluate(0f) * e.g);
+            }
+
+            return Mathf.Lerp(e.minFuelFlow, e.maxFuelFlow, (float)throttle * 0.01f * e.thrustPercentage) * flowMultiplier;
+        }
+
+        // for a single EngineModule, get its thrust vector (use EngineModuleFlowMultiplier and EngineModuleISP below)
+        public static Vector3d ThrustAtConditions(this ModuleEngines e, double massFlowRate, double isp, bool cosLoss = true)
+        {
+            if (massFlowRate <= 0)
+                return Vector3d.zero;
+
+            Vector3d thrustVector = Vector3d.zero;
+
+            for (int i = 0; i < e.thrustTransforms.Count; i++)
+                thrustVector -= e.thrustTransforms[i].forward * e.thrustTransformMultipliers[i];
+
+            if (cosLoss)
+            {
+                Vector3d fwd = HighLogic.LoadedScene == GameScenes.EDITOR ? EditorLogic.VesselRotation * Vector3d.up : e.part.vessel.GetTransform().up;
+                thrustVector = Vector3.Dot(fwd, thrustVector) * thrustVector.normalized;
+            }
+
+            return thrustVector * massFlowRate * e.g * e.multIsp * isp;
+        }
+
+        // for a single EngineModule, determine its flowMultiplier, subject to atmDensity + machNumber
+        public static double FlowMultiplierAtConditions(this ModuleEngines e, double atmDensity, double machNumber)
+        {
+            double flowMultiplier = 1;
+
+            if (e.atmChangeFlow)
+            {
+                if (e.useAtmCurve)
+                    flowMultiplier = e.atmCurve.Evaluate((float)atmDensity * 40 / 49);
+                else
+                    flowMultiplier = atmDensity * 40 / 49;
+            }
+
+            double ratio = 1.0f;  // FIXME: should be sum of propellant.totalAmount / sum of propellant.totalCapacity?
+                                  // (but the FuelFlowSimulation that uses this takes very large timesteps anyway)
+            if (e.useThrustCurve)
+                flowMultiplier *= e.thrustCurve.Evaluate((float)ratio);
+
+            if (e.useVelCurve)
+                flowMultiplier *= e.velCurve.Evaluate((float)machNumber);
+
+            if (flowMultiplier > e.flowMultCap)
+            {
+                double excess = flowMultiplier - e.flowMultCap;
+                flowMultiplier = e.flowMultCap + excess / (e.flowMultCapSharpness + excess / e.flowMultCap);
+            }
+
+            // some engines have e.CLAMP set to float.MaxValue so we have to have the e.CLAMP < 1 sanity check here
+            if (flowMultiplier < e.CLAMP && e.CLAMP < 1)
+                flowMultiplier = e.CLAMP;
+
+            return flowMultiplier;
+        }
+
+        // for a single EngineModule, evaluate its ISP, subject to all the different possible curves
+        public static double ISPAtConditions(this ModuleEngines e, double throttle, double atmPressure, double atmDensity, double machNumber)
+        {
+            double isp = 0;
+            isp = e.atmosphereCurve.Evaluate((float)atmPressure);
+            if (e.useThrottleIspCurve)
+                isp *= Mathf.Lerp(1f, e.throttleIspCurve.Evaluate((float)throttle), e.throttleIspCurveAtmStrength.Evaluate((float)atmPressure));
+            if (e.useAtmCurveIsp)
+                isp *= e.atmCurveIsp.Evaluate((float)atmDensity * 40 / 49);
+            if (e.useVelCurveIsp)
+                isp *= e.velCurveIsp.Evaluate((float)machNumber);
+            return isp;
+        }
+
         public static bool IsUnfiredDecoupler(this Part p, out Part decoupledPart)
         {
             for (int i = 0; i < p.Modules.Count; i++)


### PR DESCRIPTION
* supports multiple moduleengines in a part (i.e. engines with integrated verniers, particularly SSTU russian engines)
* backs out the prop.ignoreForIsp fix.  the code as it stands now is actually correct (and was correct) and given the correct thrust and the rate of propellant consumption it figures out the correct ISP (the higher mass loss from HTP means that the effective ISP will be lower).   i suspect the ignoreForIsp fix was added due to the integrated verniers throwing off the thrust calculation or something like that.
* fix for RO leaving bigger bits of residual SRB propellant in the ullage rockets tank even though the motor has flamed out (mumble mumble real thrust curve something?).

also pushes a lot of the crazier bits of logic into PartExtensions that analyze the ModuleEngine.

backs out some of the dicts and use of linq to make the code a bit clearer.  this probably makes it perform marginally worse in the short term, but i'd prefer to try to fix the perf issues higher up in the algorithm if at all possible rather than having lots of complicated hard to understand dict caches lying around.

~i think there's still a bit of a known bug here where the thrust is always the combined thrust at the start of the stage, which is not what PEG/PVG need, but does give the correct starting TWR.  the burntime of the stage should still be correct, but the ullage engines will throw off the dV and the ISP.  i believe that is a very old bug though (see the comment at the top of ComputeTimeStepDeltaV).~  nope, testing shows that merging ullage solids with an upper stage works correctly, which means there's still some voodoo in here which i don't understand (makes sense or i think people would have reported that as a bug).