### PR TITLE
Ullage tick fix

### DIFF
--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -1017,6 +1017,10 @@ namespace MuMech
 
         private void Drive(FlightCtrlState s)
         {
+            Profiler.BeginSample("vesselState");
+            ready = vesselState.Update(vessel);
+            Profiler.EndSample();
+
             Profiler.BeginSample("MechJebCore.Drive");
             if (this == vessel.GetMasterMechJeb())
             {

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -428,6 +428,8 @@ namespace MuMech
             }
         }
 
+        private double last_update;
+
         //public static bool SupportsGimbalExtension<T>() where T : PartModule
         //{
         //    return gimbalExtDict.ContainsKey(typeof(T));
@@ -437,9 +439,11 @@ namespace MuMech
         //{
         //    gimbalExtDict[typeof(T)] = gimbalExtension;
         //}
-
         public bool Update(Vessel vessel)
         {
+            if (last_update == Planetarium.GetUniversalTime())
+                return true;
+
             if (vessel.rootPart.rb == null) return false; //if we try to update before rigidbodies exist we spam the console with NullPointerExceptions.
 
             TestStuff(vessel);
@@ -461,6 +465,8 @@ namespace MuMech
             ToggleRCSThrust(vessel);
 
             UpdateMoIAndAngularMom(vessel);
+
+            last_update = Planetarium.GetUniversalTime();;
 
             return true;
         }


### PR DESCRIPTION
The VesselState needs to be updated before Drive() is
called (which is what MechJebModuleThrustController hooks to do
all its work).   This change makes it safe to call VesselState
multiple times (no-ops it on the second call on any
tick) and then forces it to being called before Drive().

This fixes issues where on the tick where a stage was decoupled, the old VesselState information
would reflect the prior stages ullage status (which could be fine if no engines were active that had
no ullage) and the ThrustController would allow 100% throttle.  Then VesselState would get updated
that tick to reflect possibly 'very unstable' ullage conditions, which then would waste an ignition.