### PR TITLE
stop updating gravity loss under zero thrust

### DIFF
--- a/MechJeb2/MechJebModuleFlightRecorder.cs
+++ b/MechJeb2/MechJebModuleFlightRecorder.cs
@@ -122,7 +122,7 @@ namespace MuMech
 
         public double[] maximums;
         public double[] minimums;
-        
+
         private bool paused = false;
 
         [Persistent(pass = (int)Pass.Local)]
@@ -243,7 +243,8 @@ namespace MuMech
                 return;
             }
 
-            gravityLosses += vesselState.deltaT * Vector3d.Dot(-vesselState.orbitalVelocity.normalized, vesselState.gravityForce);
+            if ( vesselState.currentThrustAccel > 0 )
+                gravityLosses += vesselState.deltaT * Vector3d.Dot(-vesselState.orbitalVelocity.normalized, vesselState.gravityForce);
             dragLosses += vesselState.deltaT * vesselState.drag;
             deltaVExpended += vesselState.deltaT * vesselState.currentThrustAccel;
             steeringLosses += vesselState.deltaT * vesselState.currentThrustAccel * (1 - Vector3d.Dot(vesselState.orbitalVelocity.normalized, vesselState.forward));


### PR DESCRIPTION
we should now match the definitions in:

https://books.google.com/books?id=C70gQI5ayEAC&lpg=PA119&ots=eZHeW0KJWU&dq=rockets%20steering%20losses&pg=PA119#v=onepage&q=rockets%20steering%20losses&f=false

lots of steering losses on initial launch is normal -- launching
vertically against 400 m/s of horizontal velocity incurs a lot of
steering losses.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>