### PR TITLE
Incorporate "MechJebAndEngineerForAll" style functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ package: build ${MECHJEBFILES}
 	cp -r Icons package/MechJeb2/
 	cp build/MechJeb2.dll package/MechJeb2/Plugins/
 	cp LICENSE.md README.md package/MechJeb2/
+	cp MechJebNoCommandPod.cfg package/MechJeb2/
 
 %.tar.gz:
 	${TAR} zcf $@ package/MechJeb2
@@ -90,6 +91,7 @@ install: build
 	cp -r Parts "${KSPDIR}"/GameData/MechJeb2/
 	cp -r Icons "${KSPDIR}"/GameData/MechJeb2/
 	cp build/MechJeb2.dll "${KSPDIR}"/GameData/MechJeb2/Plugins/
+	cp MechJebNoCommandPod.cfg "${KSPDIR}"/GameData/MechJeb2/
 
 uninstall: info
 	rm -rf "${KSPDIR}"/GameData/MechJeb2/Plugins

--- a/MechJebNoCommandPod.cfg
+++ b/MechJebNoCommandPod.cfg
@@ -1,0 +1,25 @@
+@PART[*]:HAS[@MODULE[ModuleCommand]]:NEEDS[!MechJebUseCommandPod,!RP-0,!RealismOverhaul]
+{
+  %MODULE[MechJebCore]
+  {
+    MechJebLocalSettings
+    {
+      MechJebModuleCustomWindowEditor { unlockTechs = flightControl }
+      MechJebModuleSmartASS { unlockTechs = flightControl }
+      MechJebModuleManeuverPlanner { unlockTechs = advFlightControl }
+      MechJebModuleNodeEditor { unlockTechs = advFlightControl }
+      MechJebModuleTranslatron { unlockTechs = advFlightControl }
+      MechJebModuleWarpHelper { unlockTechs = advFlightControl }
+      MechJebModuleAttitudeAdjustment { unlockTechs = advFlightControl }
+      MechJebModuleThrustWindow { unlockTechs = advFlightControl }
+      MechJebModuleRCSBalancerWindow { unlockTechs = advFlightControl }
+      MechJebModuleRoverWindow { unlockTechs = fieldScience }
+      MechJebModuleAscentGuidance { unlockTechs = unmannedTech }
+      MechJebModuleLandingGuidance { unlockTechs = unmannedTech }
+      MechJebModuleSpaceplaneGuidance { unlockTechs = unmannedTech }
+      MechJebModuleDockingGuidance { unlockTechs = advUnmanned }
+      MechJebModuleRendezvousAutopilotWindow { unlockTechs = advUnmanned }
+      MechJebModuleRendezvousGuidance { unlockTechs = advUnmanned }
+    }
+  }
+}


### PR DESCRIPTION
This adds MJ to all command pods by default.

It is opt-out, similar to the NoNonRP0 trick in RP-0 but requires
creating the empty folder GameData/MechJebUseCommandPod.

It also disables itself if RealismOverhaul or RP-0 are present since
those handle their own setup, and also override when techs are
unlocked.

I think this will address the incessant fly-bys in the forum thread
by people who install MJ and then see no display and bash out a one
sentence bug report stating that MJ is broken, because they've forgotten
that the install they've been playing for the past X months had
MechJebAndEngineerForAll in it.

I suspect 90% of players don't use the command pod, or wouldn't use
the command pods if they knew about MechJebAndEngineerForAll.

I think this may mean that MJ needs to pick up a dep on ModuleManager
in CKAN.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>