### PR TITLE
fix hohmann transfers again

### DIFF
--- a/MechJeb2/Maneuver/OperationTransfer.cs
+++ b/MechJeb2/Maneuver/OperationTransfer.cs
@@ -50,10 +50,7 @@ namespace MuMech
 
             Vector3d dV;
 
-            // for some reason the Orbit constructor that takes an Orbit argument doesn't dup the Orbit correctly
-            // so we have to do this instead...
-            Orbit targetOrbit = new Orbit();
-            targetOrbit.UpdateFromOrbitAtUT(target.TargetOrbit, UT, target.TargetOrbit.referenceBody);
+            Orbit targetOrbit = target.TargetOrbit.Clone();
 
             if ( periodOffset != 0 )
             {

--- a/MechJeb2/OrbitExtensions.cs
+++ b/MechJeb2/OrbitExtensions.cs
@@ -95,6 +95,23 @@ namespace MuMech
             return MuUtils.OrbitFromStateVectors(o.SwappedAbsolutePositionAtUT(UT), o.SwappedOrbitalVelocityAtUT(UT) + dV, o.referenceBody, UT);
         }
 
+        // returns a new orbit that is identical to the current one (although the epoch will change)
+        // (i tried many different APIs in the orbit class, but the GetOrbitalStateVectors/UpdateFromStateVectors route was the only one that worked)
+        public static Orbit Clone(this Orbit o, double UT = Double.NegativeInfinity)
+        {
+            Vector3d pos, vel;
+
+            // hack up a dynamic default value to the current time
+            if ( UT == Double.NegativeInfinity )
+                UT = Planetarium.GetUniversalTime();
+
+            Orbit newOrbit = new Orbit();
+            o.GetOrbitalStateVectorsAtUT(UT, out pos, out vel);
+            newOrbit.UpdateFromStateVectors(pos, vel, o.referenceBody, UT);
+
+            return newOrbit;
+        }
+
         // This does not allocate a new orbit object and the caller should call new Orbit if/when required
         public static void MutatedOrbit(this Orbit o, double periodOffset = Double.NegativeInfinity)
         {


### PR DESCRIPTION
Introduces `Orbit.Clone()` which should work as long as the Orbit is defined for 'now', and if it isn't it is up to the caller to pass in a UT where GetOrbitalStateVectorsAtUT() is sane (I tried using o.epoch under the assumption that the epoch of the source orbit would always be valid to use as an argument there, but that failed for some bizarre reason...   🔪  KSP...)
