### PR TITLE
Use altitudeBottom for gravity turn start

### DIFF
--- a/MechJeb2/MechJebModuleAscentClassic.cs
+++ b/MechJeb2/MechJebModuleAscentClassic.cs
@@ -130,7 +130,7 @@ namespace MuMech
 
         void DriveVerticalAscent(FlightCtrlState s)
         {
-            if (!IsVerticalAscent(vesselState.altitudeASL, vesselState.speedSurface)) mode = AscentMode.GRAVITY_TURN;
+            if (!IsVerticalAscent(vesselState.altitudeBottom, vesselState.speedSurface)) mode = AscentMode.GRAVITY_TURN;
             if (autopilot.autoThrottle && orbit.ApA > autopilot.desiredOrbitAltitude) mode = AscentMode.COAST_TO_APOAPSIS;
 
             //during the vertical ascent we just thrust straight up at max throttle
@@ -155,7 +155,7 @@ namespace MuMech
             }
 
             //if we've fallen below the turn start altitude, go back to vertical ascent
-            if (IsVerticalAscent(vesselState.altitudeASL, vesselState.speedSurface))
+            if (IsVerticalAscent(vesselState.altitudeBottom, vesselState.speedSurface))
             {
                 mode = AscentMode.VERTICAL_ASCENT;
                 return;

--- a/MechJeb2/MechJebModuleAscentGT.cs
+++ b/MechJeb2/MechJebModuleAscentGT.cs
@@ -80,7 +80,7 @@ namespace MuMech
 
         void DriveVerticalAscent(FlightCtrlState s)
         {
-            if (!IsVerticalAscent(vesselState.altitudeASL, vesselState.speedSurface)) mode = AscentMode.INITIATE_TURN;
+            if (!IsVerticalAscent(vesselState.altitudeBottom, vesselState.speedSurface)) mode = AscentMode.INITIATE_TURN;
             if (autopilot.autoThrottle && orbit.ApA > intermediateAltitude) mode = AscentMode.GRAVITY_TURN;
 
             //during the vertical ascent we just thrust straight up at max throttle
@@ -116,7 +116,7 @@ namespace MuMech
             }
 
             //if we've fallen below the turn start altitude, go back to vertical ascent
-            if (IsVerticalAscent(vesselState.altitudeASL, vesselState.speedSurface))
+            if (IsVerticalAscent(vesselState.altitudeBottom, vesselState.speedSurface))
             {
                 mode = AscentMode.VERTICAL_ASCENT;
                 return;


### PR DESCRIPTION
Using ASL means that a 0.5km trigger for turn start altitude will always
trigger at Woomerang launch site because it is at 750m ASL.

Switch so the measurement is from terrain to bottom of rocket.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>