### PR TITLE
Lets try altitudeTrue instead

### DIFF
--- a/MechJeb2/MechJebModuleAscentClassic.cs
+++ b/MechJeb2/MechJebModuleAscentClassic.cs
@@ -130,7 +130,7 @@ namespace MuMech
 
         void DriveVerticalAscent(FlightCtrlState s)
         {
-            if (!IsVerticalAscent(vesselState.altitudeBottom, vesselState.speedSurface)) mode = AscentMode.GRAVITY_TURN;
+            if (!IsVerticalAscent(vesselState.altitudeTrue, vesselState.speedSurface)) mode = AscentMode.GRAVITY_TURN;
             if (autopilot.autoThrottle && orbit.ApA > autopilot.desiredOrbitAltitude) mode = AscentMode.COAST_TO_APOAPSIS;
 
             //during the vertical ascent we just thrust straight up at max throttle
@@ -155,7 +155,7 @@ namespace MuMech
             }
 
             //if we've fallen below the turn start altitude, go back to vertical ascent
-            if (IsVerticalAscent(vesselState.altitudeBottom, vesselState.speedSurface))
+            if (IsVerticalAscent(vesselState.altitudeTrue, vesselState.speedSurface))
             {
                 mode = AscentMode.VERTICAL_ASCENT;
                 return;

--- a/MechJeb2/MechJebModuleAscentGT.cs
+++ b/MechJeb2/MechJebModuleAscentGT.cs
@@ -80,7 +80,7 @@ namespace MuMech
 
         void DriveVerticalAscent(FlightCtrlState s)
         {
-            if (!IsVerticalAscent(vesselState.altitudeBottom, vesselState.speedSurface)) mode = AscentMode.INITIATE_TURN;
+            if (!IsVerticalAscent(vesselState.altitudeTrue, vesselState.speedSurface)) mode = AscentMode.INITIATE_TURN;
             if (autopilot.autoThrottle && orbit.ApA > intermediateAltitude) mode = AscentMode.GRAVITY_TURN;
 
             //during the vertical ascent we just thrust straight up at max throttle
@@ -116,7 +116,7 @@ namespace MuMech
             }
 
             //if we've fallen below the turn start altitude, go back to vertical ascent
-            if (IsVerticalAscent(vesselState.altitudeBottom, vesselState.speedSurface))
+            if (IsVerticalAscent(vesselState.altitudeTrue, vesselState.speedSurface))
             {
                 mode = AscentMode.VERTICAL_ASCENT;
                 return;


### PR DESCRIPTION
Either altitudeTrue or altitudeBottom will give consistent results
across different launch sites, and the small difference between these
two is not worth walking the parts tree to compute altitudeBottom.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>