### PR TITLE
Fix bug where the MechJeb pod fails to show up in Pods category

### DIFF
--- a/Parts/MechJeb2_Pod/part.cfg
+++ b/Parts/MechJeb2_Pod/part.cfg
@@ -30,7 +30,7 @@ PART {
     TechRequired = automation
     entryCost = 250000
     cost = 35000
-    category = none
+    category = Pods
     subcategory = 0
     title = Mechanical Jeb - Pod version 2.0
     manufacturer = Anatid Robotics / Multiversal Mechatronics
@@ -38,7 +38,7 @@ PART {
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,0,1,1,1
-    
+
     // --- standard part parameters ---
     mass = 2
     dragModelType = default
@@ -50,17 +50,17 @@ PART {
 
     vesselType = Probe
     stagingIcon = COMMAND_POD
-    
+
     // --- internal setup ---
     CrewCapacity = 0
 
 	tags = cmg command control fly gyro moment react stab steer torque autopilot rcs sas
-	
+
     MODULE
     {
         name = ModuleCommand
         minimumCrew = 0
-        
+
         RESOURCE
         {
             name = ElectricCharge
@@ -71,11 +71,11 @@ PART {
     MODULE
     {
         name = ModuleReactionWheel
-        
+
         PitchTorque = 6
         YawTorque = 6
         RollTorque = 6
-        
+
         RESOURCE
         {
             name = ElectricCharge


### PR DESCRIPTION
This bug definitely confused me. I verified this to work patch to work with KSP.