### PR TITLE
fix "launch to plane" again again

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -357,6 +357,9 @@ namespace MuMech
                         GUILayout.Label("n: " + core.guidance.last_lm_iteration_count + "(" + core.guidance.max_lm_iteration_count + ")", GUILayout.Width(100));
                         GUILayout.Label("staleness: " + GuiUtils.TimeToDHMS(core.guidance.staleness));
                         GUILayout.EndHorizontal();
+                        GUILayout.BeginHorizontal();
+                        GUILayout.Label(String.Format("znorm: {0:G5}", core.guidance.last_znorm));
+                        GUILayout.EndHorizontal();
                         if ( core.guidance.last_failure_cause != null )
                         {
                             GUIStyle s = new GUIStyle(GUI.skin.label);

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -36,6 +36,7 @@ namespace MuMech
         public int max_lm_iteration_count { get { return ( p != null ) ? p.max_lm_iteration_count : 0; } }
         public int last_lm_iteration_count { get { return ( p != null ) ? p.last_lm_iteration_count : 0; } }
         public int last_lm_status { get { return ( p != null ) ? p.last_lm_status : 0; } }
+        public double last_znorm { get { return ( p != null ) ? p.last_znorm : 0; } }
         public String last_failure_cause { get { return ( p != null ) ? p.last_failure_cause : null; } }
         public double last_success_time = 0.0;
         public double staleness { get { return ( last_success_time > 0 ) ? vesselState.time - last_success_time : 0; } }

--- a/MechJeb2/Pontryagin/PontryaginBase.cs
+++ b/MechJeb2/Pontryagin/PontryaginBase.cs
@@ -389,6 +389,7 @@ namespace MuMech {
         public int max_lm_iteration_count = 0;
         public int last_lm_iteration_count = 0;
         public int last_lm_status = 0;
+        public double last_znorm = 0;
         public String last_failure_cause = null;
         public double last_success_time = 0;
 
@@ -1021,10 +1022,11 @@ namespace MuMech {
                 //Debug.Log("z[" + i + "] = " + z[i]);
             }
 
-            znorm = Math.Sqrt(znorm);
-            //Debug.Log("znorm = " + znorm);
+            last_znorm = Math.Sqrt(znorm);
 
-            // this comes first because after max-iterations we may still have an acceptable solution
+            // this comes first because after max-iterations we may still have an acceptable solution.
+            // we check the largest z-value rather than znorm because for a lot of dimensions several slightly
+            // off z values can add up to failure when they're all acceptable tolerances.
             if (max_z < 1e-5)
             {
                 y0 = y0_new;


### PR DESCRIPTION
this time with feeling.

since we want to fully match the angular momentum vector for inc, lan
and one component that sort of corresponds to half of sma/ecc or
ApR/PeR pairs fully specify that.  then fix the flight path angle.
then take only one of velocity or radius to match (the other one
is fully constrained by the magnitude of the h-vec so is not free).

then use the argp transfersality conditions.

the result is that now the optimizer stops flailing and settles down
to 8-10 iterations when converged.

also added the znorm to the status output.

i don't think this has a singularity, but we'll have to see.