### PR TITLE
add LogicalStageTracking

### DIFF
--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -45,6 +45,8 @@ namespace MuMech
         public MechJebModuleLandingAutopilot landing;
         public MechJebModuleSettings settings;
         public MechJebModuleAirplaneAutopilot airplane;
+        public MechJebModuleStageStats stageStats;
+        public MechJebModuleLogicalStageTracking stageTracking;
 
         public VesselState vesselState = new VesselState();
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "MechJeb"), UI_Toggle(disabledText = "Disabled", enabledText = "Enabled")]
@@ -757,6 +759,8 @@ namespace MuMech
             settings = GetComputerModule<MechJebModuleSettings>();
             airplane = GetComputerModule<MechJebModuleAirplaneAutopilot>();
             guidance = GetComputerModule<MechJebModuleGuidanceController>();
+            stageStats = GetComputerModule<MechJebModuleStageStats>();
+            stageTracking = GetComputerModule<MechJebModuleLogicalStageTracking>();
         }
 
         public override void OnLoad(ConfigNode sfsNode)

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -365,7 +365,7 @@ namespace MuMech
                             GUIStyle s = new GUIStyle(GUI.skin.label);
                             s.normal.textColor = Color.red;
                             GUILayout.BeginHorizontal();
-                            GUILayout.Label(core.guidance.last_failure_cause, s);
+                            GUILayout.Label("LAST FAILURE: " + core.guidance.last_failure_cause, s);
                             GUILayout.EndHorizontal();
                         }
                     }

--- a/MechJeb2/MechJebModuleLogicalStageTracking.cs
+++ b/MechJeb2/MechJebModuleLogicalStageTracking.cs
@@ -1,0 +1,172 @@
+﻿using UnityEngine;
+using KSP.UI.Screens;
+using System.Collections.Generic;
+
+namespace MuMech
+{
+    // Tracking actual concrete rocket stages (like what the "main" stage is or the
+    // "booster" or "upper" stage) is really fucking annoying in KSP, but vital to do
+    // any kind of significant trajectory optimization.  The KSP stage list might have
+    // 15 stages for a 3 stage rocket, only 3 of which are "significant", while the other
+    // ones are just ullage, decouplers, fairing sep, launch tower sep, etc.  And then
+    // button mashing game players will expect to be able to rearrange their staging as their
+    // rocket is ascending and just have MJ all magically figure shit out on the fly and not
+    // give up and drive their rocket into the ground in protest.
+    //
+    // The point of this class is so that consumers (mostly PVG) can get a list of significant stages
+    // that ignores most of the pointless ones out of StageStats, but also TRACKS the significant
+    // stages.  The List<Stage> stages is designed such that PVG can hold onto one of the
+    // elements and it will update its information correctly (it becomes an intermediary between
+    // MJs StageStats and the guidance controler).  Consumers need to check the "staged" flag to
+    // determine if the stage has gone away.
+    //
+    public class MechJebModuleLogicalStageTracking : ComputerModule
+    {
+        public MechJebModuleLogicalStageTracking(MechJebCore core) : base(core) { }
+
+        public List<Stage> stages = new List<Stage>();
+
+        // this is used to track how many significant stages we've dropped
+        public int stageCount = 0;
+
+        double lastTime = 0;
+
+        public override void OnStart(PartModule.StartState state)
+        {
+            GameEvents.onStageActivate.Add(handleStageEvent);
+        }
+
+        public override void OnDestroy()
+        {
+            GameEvents.onStageActivate.Remove(handleStageEvent);
+        }
+
+        public override void OnModuleEnabled()
+        {
+            Reset();
+        }
+
+        private void handleStageEvent(int data)
+        {
+            if ( !enabled || stages.Count == 0 )
+                return;
+
+            if ( stages[0].ksp_stage > ( StageManager.CurrentStage - 1 ) )
+            {
+                // we did drop a relevant stage
+                stageCount += 1;
+                stages[0].staged = true;
+                stages.RemoveAt(0);
+                Debug.Log("[MechJebModuleLogicalStageTracking] dropping a stage");
+            }
+        }
+
+        public void Reset()
+        {
+            stages.Clear();
+        }
+
+        public void Update()
+        {
+            if ( lastTime == Planetarium.GetUniversalTime() )
+                return;
+
+            core.stageStats.RequestUpdate(this, true);
+
+            int j = 0;
+
+            for ( int i = core.stageStats.vacStats.Length - 1; i >= 0; i-- )
+            {
+                var stats = core.stageStats.vacStats[i];
+
+                // FIXME: either tweakability or identify ullage + sep motors correctly
+                if ( stats.deltaV < 20 )
+                {
+                    if ( !(j == 0 && stages.Count > 0 && stages[0].ksp_stage == i) ) // check if we're just burning down the current stage
+                        continue;
+                }
+
+                if (j >= stages.Count)
+                {
+                    Debug.Log("[MechJebModuleLogicalStageTracking] adding a new stage: " + j);
+                    stages.Add(new Stage(this));
+                }
+
+                stages[j].ksp_stage = i;
+                stages[j].rocket_stage = j + stageCount;
+                stages[j].Sync();
+
+                j++;
+            }
+
+            while( stages.Count > core.stageStats.vacStats.Length )
+            {
+                Debug.Log("[MechJebModuleLogicalStageTracking] upper stage disappeared (user reconfig most likely)");
+                stages.RemoveAt(stages.Count-1);
+            }
+
+            lastTime = Planetarium.GetUniversalTime();
+        }
+
+        public class Stage
+        {
+            private MechJebModuleLogicalStageTracking parent;
+
+            // true if the this was jettisoned normally
+            public bool staged = false;
+
+            // ksp stage from StageStats
+            public int ksp_stage;
+            // ∆v of the stage in m/s
+            public double deltaV;
+            // burntime left in the stage in secs
+            public double deltaTime;
+            // effective isp of the stage
+            public double isp;
+            // effective exhaust velocity of the stage
+            public double v_e { get { return isp * 9.80665; } }
+            // starting thrust of the stage
+            public double startThrust;
+            // starting acceleration of the stage
+            public double startMass;
+            // starting acceleration of the stage
+            public double a0 { get { return startThrust / startMass; } }
+            // ideal time to consume the rocket completely
+            public double tau { get { return v_e / a0; } }
+
+            // the stage of the rocket (0-indexed, and should track across staging events)
+            public int rocket_stage = 0;
+
+            // the last parts list
+            public List<Part> parts = new List<Part>();
+
+            private FuelFlowSimulation.Stats vacStats;
+
+            public void Sync()
+            {
+                vacStats = parent.core.stageStats.vacStats[ksp_stage];
+                deltaV = vacStats.deltaV;
+                deltaTime = vacStats.deltaTime;
+                isp = vacStats.isp;
+                startThrust = vacStats.startThrust * 1000;
+                startMass = vacStats.startMass * 1000;
+
+                parts.Clear();
+                for(int i = 0; i < vacStats.parts.Count; i++)
+                {
+                    parts.Add(vacStats.parts[i]);
+                }
+            }
+
+            public override string ToString()
+            {
+                return "ksp_stage: "+ ksp_stage + " rocket_stage: " + rocket_stage + " isp:" + isp + " thrust:" + startThrust + " m0: " + startMass + " maxt:" + deltaTime;
+            }
+
+            public Stage(MechJebModuleLogicalStageTracking parent)
+            {
+                this.parent = parent;
+            }
+        }
+    }
+}

--- a/MechJeb2/Pontryagin/PontryaginLaunch.cs
+++ b/MechJeb2/Pontryagin/PontryaginLaunch.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace MuMech {
     public class PontryaginLaunch : PontryaginBase {
-        public PontryaginLaunch(double mu, Vector3d r0, Vector3d v0, Vector3d pv0, Vector3d pr0, double dV) : base(mu, r0, v0, pv0, pr0, dV)
+        public PontryaginLaunch(MechJebCore core, double mu, Vector3d r0, Vector3d v0, Vector3d pv0, Vector3d pr0, double dV) : base(core, mu, r0, v0, pv0, pr0, dV)
         {
         }
 
@@ -92,7 +92,7 @@ namespace MuMech {
             {
                 //if (i != 0)
                     //arcs.Add(new Arc(new Stage(this, m0: stages[i].m0, isp: 0, thrust: 0)));
-                arcs.Add(new Arc(stages[i]));
+                arcs.Add(new Arc(this, stages[i]));
             }
 
             arcs[arcs.Count-1].infinite = true;
@@ -102,7 +102,7 @@ namespace MuMech {
 
             // update initial position and guess for first arc
             double ve = g0 * stages[0].isp;
-            tgo = ve * stages[0].m0 / stages[0].thrust * ( 1 - Math.Exp(-dV/ve) );
+            tgo = ve * stages[0].startMass / stages[0].startThrust * ( 1 - Math.Exp(-dV/ve) );
             tgo_bar = tgo / t_scale;
 
             // initialize overall burn time

--- a/MechJeb2/Pontryagin/PontryaginNode.cs
+++ b/MechJeb2/Pontryagin/PontryaginNode.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace MuMech {
     public class PontryaginNode : PontryaginBase {
-        public PontryaginNode(double mu, Vector3d r0, Vector3d v0, Vector3d pv0, Vector3d pr0, double dV, double bt) : base(mu, r0, v0, pv0, pr0, dV)
+        public PontryaginNode(MechJebCore core, double mu, Vector3d r0, Vector3d v0, Vector3d pv0, Vector3d pr0, double dV, double bt) : base(core, mu, r0, v0, pv0, pr0, dV)
         {
             tc1 = bt / 2.0;
             tgo = bt;
@@ -98,14 +98,14 @@ namespace MuMech {
             // build arcs off of ksp stages, with coasts
             List<Arc> arcs = new List<Arc>();
 
-            arcs.Add(new Arc(new Stage(this, m0: stages[0].m0, isp: 0, thrust: 0, ksp_stage: stages[0].ksp_stage)));
+            arcs.Add(new Arc(this));
 
             for(int i = 0; i < stages.Count; i++)
             {
-                arcs.Add(new Arc(stages[i]));
+                arcs.Add(new Arc(this, stages[i]));
             }
 
-            arcs.Add(new Arc(new Stage(this, m0: stages[stages.Count-1].m0, isp: 0, thrust: 0, ksp_stage: stages[stages.Count-1].ksp_stage), done: true));
+            arcs.Add(new Arc(this));
             // arcs.Add(new Arc(new Stage(this, m0: -1, isp: 0, thrust: 0, ksp_stage: stages[stages.Count-1].ksp_stage), done: true));
 
             arcs[arcs.Count-1].use_fixed_time = true;


### PR DESCRIPTION
this is necessary to act as an intermediary between PVG and
the delta V stats in MJ.  it offers objects which are themselves
static that correspond to logical rocket stages even though
the ksp stage and the position in the stage stats may bounce
around as the user drags the staging crap all over the place.
of course the stats referenced by the object may change, but
the first stage of the rocket is always a given object and it
gets marked as 'staged' when it gets dropped and then the
stage manager tracks how many of those significant stages have
been dropped so we always know 'which' numbered stage we are
on and a sort of trusted 'what rocket stage number is this'.

the fact that i've spent like 1.5 years working on this and
think i may have finally more or less nailed the design of what
we really need indicates how bad of a rocket simulator KSP is.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>