### PR TITLE
use effective thrust of the stage

### DIFF
--- a/MechJeb2/MechJebModuleLogicalStageTracking.cs
+++ b/MechJeb2/MechJebModuleLogicalStageTracking.cs
@@ -121,14 +121,18 @@ namespace MuMech
             public double deltaV;
             // burntime left in the stage in secs
             public double deltaTime;
-            // effective isp of the stage
+            // effective isp of the stage (this is derived from the total mass loss and the total ∆v)
             public double isp;
             // effective exhaust velocity of the stage
             public double v_e { get { return isp * 9.80665; } }
             // starting thrust of the stage
             public double startThrust;
-            // starting acceleration of the stage
+            // effective thrust (the "average thrust" derived from the total mdot and the v_e)
+            public double effectiveThrust { get { return v_e * ( startMass - endMass ) / deltaTime; } }
+            // starting mass of the stage
             public double startMass;
+            // ending mass of the stage
+            public double endMass;
             // starting acceleration of the stage
             public double a0 { get { return startThrust / startMass; } }
             // ideal time to consume the rocket completely
@@ -150,6 +154,7 @@ namespace MuMech
                 isp = vacStats.isp;
                 startThrust = vacStats.startThrust * 1000;
                 startMass = vacStats.startMass * 1000;
+                endMass = vacStats.endMass * 1000;
 
                 parts.Clear();
                 for(int i = 0; i < vacStats.parts.Count; i++)

--- a/MechJeb2/Pontryagin/PontryaginBase.cs
+++ b/MechJeb2/Pontryagin/PontryaginBase.cs
@@ -55,7 +55,7 @@ namespace MuMech {
                 if (stage != null)
                 {
                     _isp = stage.isp;
-                    _thrust = stage.startThrust;
+                    _thrust = stage.effectiveThrust;
                     _m0 = stage.startMass;
                     _avail_dV = stage.deltaV;
                     _max_bt = stage.deltaTime;

--- a/MechJeb2/Pontryagin/PontryaginLaunch.cs
+++ b/MechJeb2/Pontryagin/PontryaginLaunch.cs
@@ -139,7 +139,7 @@ namespace MuMech {
             Solution new_sol = new Solution(t_scale, v_scale, r_scale, t0);
             multipleIntegrate(y0, new_sol, arcs, 10);
 
-            for(int i = 0; i < arcs.Count; i++)
+            for(int i = arcs.Count - 1; i >= 0; i--)
             {
                 if ( new_sol.tgo(new_sol.t0, i) < 1 )
                 {


### PR DESCRIPTION
the start thrust can include ullage motors which burnout and
throw off the whole ∆v calculation.  this uses an "effective
thrust" over the whole stage interval based on the mass loss and
the exhaust velocity, which itself is based on the sum of the
∆v (which is accurate and summed in 'chunks') and the total
mass loss over the interval.

so what we get that is entirely accurate is the time of the whole
burn, along with the summed up ∆v, and the mass loss.  from that
effective isps and constant thrusts are computed.

really maybe what should be done is to expose those smaller chunks
in the API so that each array item in vacStats no longer corresponded
1:1 to a KSP stage.  but this is a way, way, way easier fix.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>