### PR TITLE
Update part.cfg

### DIFF
--- a/Parts/MechJeb2_Pod/part.cfg
+++ b/Parts/MechJeb2_Pod/part.cfg
@@ -50,6 +50,7 @@ PART {
 
     vesselType = Probe
     stagingIcon = COMMAND_POD
+    bulkheadProfiles = size0
     
     // --- internal setup ---
     CrewCapacity = 0


### PR DESCRIPTION
* Added missing bulkheadProfiles. (causes nullref when clicking cross sectional filter in VAB) - This has to be added for everything, including non-real parts that never show in the inventory. (i.e. category = none)