### PR TITLE
Added missing bulkheadProfiles

### DIFF
--- a/Parts/MechJeb2_AR202/part.cfg
+++ b/Parts/MechJeb2_AR202/part.cfg
@@ -38,8 +38,11 @@ PART {
     CrewCapacity = 0
 
     vesselType = Probe
+    bulkheadProfiles = srf
+
 	
 	tags = command control autopilot
+
 
     MODULE
     {
@@ -121,6 +124,7 @@ PART {
     CrewCapacity = 0
 
     vesselType = Probe
+    bulkheadProfiles = srf
 }
 
 PART {
@@ -155,6 +159,7 @@ PART {
     CrewCapacity = 0
 
     vesselType = Probe
+    bulkheadProfiles = srf
 }
 
 PART {
@@ -189,6 +194,7 @@ PART {
     CrewCapacity = 0
 
     vesselType = Probe
+    bulkheadProfiles = srf
 }
 
 PART {
@@ -223,4 +229,5 @@ PART {
     CrewCapacity = 0
 
     vesselType = Probe
+    bulkheadProfiles = srf
 }


### PR DESCRIPTION
* Added missing bulkheadProfiles. (causes nullref when clicking cross sectional filter in VAB) - This has to be added for everything, including non-real parts that never show in the inventory. (i.e. category = none)