### PR TITLE
Display ScreenMessage about unstable ignitions

### DIFF
--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -268,8 +268,11 @@ namespace MuMech
             }
         }
 
+        ScreenMessage preventingUnstableIgnitionsMessage;
+
         public override void OnStart(PartModule.StartState state)
         {
+            preventingUnstableIgnitionsMessage = new ScreenMessage("<color=orange>[MechJeb]: Killing throttle to prevent unstable ignition</color>", 2f, ScreenMessageStyle.UPPER_CENTER);
             pid = new PIDController(0.05, 0.000001, 0.05);
             users.Add(this);
 
@@ -540,6 +543,7 @@ namespace MuMech
             {
                 if (vesselState.lowestUllage < VesselState.UllageState.Stable)
                 {
+                    ScreenMessages.PostScreenMessage(preventingUnstableIgnitionsMessage);
                     Debug.Log("MechJeb Unstable Ignitions: preventing ignition in state: " + vesselState.lowestUllage);
                     setTempLimit(0.0F, LimitMode.UnstableIgnition);
                 }


### PR DESCRIPTION
If "Prevent unstable ignitions" is checked this will now throw up a
message on the screen indicating what MJ is doing.

This may help players who are using sounding rockets, where this
setting may not be appropriate (since there is no way to RCS
ullage up a sounding rocket).

Generally the safe way to fly with MJ is to set "Use RCS to ullage"
and to unset "Prevent unstable ignitions".  The RCS setting will
only apply when there are active RCS modules that have the correct
directionality to ullage the stage, and should always DTRT while
not affecting sounding rockets and any other stages that do not
have any RCS.

(It should be noted that AFAIK "Prevent unstable ignitions" should be safe
to use past sounding rocket era in RP-1 and will provide additional security
against accidents -- like not having staged and activated RCS but trying to start
engines -- which will bypass the RCS auto-ullaging since there is no active RCS
and will then allow an ignition to be wasted).

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>