### PR TITLE
Better PVG terminal guidance

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using KSP.UI.Screens;
 
 namespace MuMech
 {
@@ -20,6 +21,8 @@ namespace MuMech
         public MechJebModuleAscentAutopilot autopilot { get { return core.GetComputerModule<MechJebModuleAscentAutopilot>(); } }
         public MechJebModuleAscentPVG pvgascent { get { return core.GetComputerModule<MechJebModuleAscentPVG>(); } }
         public MechJebModuleAscentGT gtascent { get { return core.GetComputerModule<MechJebModuleAscentGT>(); } }
+        private MechJebModuleStageStats stats { get { return core.GetComputerModule<MechJebModuleStageStats>(); } }
+        private FuelFlowSimulation.Stats[] atmoStats { get { return stats.atmoStats; } }
 
         private ascentType ascentPathIdx { get { return autopilot.ascentPathIdxPublic; } }
 
@@ -367,6 +370,30 @@ namespace MuMech
                             GUILayout.BeginHorizontal();
                             GUILayout.Label("LAST FAILURE: " + core.guidance.last_failure_cause, s);
                             GUILayout.EndHorizontal();
+                        }
+
+                        if ( vessel.situation != Vessel.Situations.LANDED && vessel.situation != Vessel.Situations.PRELAUNCH && vessel.situation != Vessel.Situations.SPLASHED )
+                        {
+                            double m0 = atmoStats[StageManager.CurrentStage].startMass;
+                            double thrust = atmoStats[StageManager.CurrentStage].startThrust;
+
+                            if (Math.Abs(vesselState.mass - m0) / m0 > 0.01)
+                            {
+                                GUIStyle s = new GUIStyle(GUI.skin.label);
+                                s.normal.textColor = Color.yellow;
+                                GUILayout.BeginHorizontal();
+                                GUILayout.Label(String.Format("MASS IS OFF BY {0:F1}%", (vesselState.mass - m0) / m0 * 100.0 ), s);
+                                GUILayout.EndHorizontal();
+                            }
+
+                            if (Math.Abs(vesselState.thrustCurrent - thrust) / thrust > 0.01)
+                            {
+                                GUIStyle s = new GUIStyle(GUI.skin.label);
+                                s.normal.textColor = Color.yellow;
+                                GUILayout.BeginHorizontal();
+                                GUILayout.Label(String.Format("THRUST IS OFF BY {0:F1}%", (vesselState.thrustCurrent - thrust) / thrust * 100.0 ), s);
+                                GUILayout.EndHorizontal();
+                            }
                         }
                     }
                 }

--- a/MechJeb2/Pontryagin/PontryaginLaunch.cs
+++ b/MechJeb2/Pontryagin/PontryaginLaunch.cs
@@ -29,7 +29,7 @@ namespace MuMech {
             bcfun = flightangle5constraint;
         }
 
-        private void flightangle5constraint(double[] yT, double[] z)
+        private void flightangle5constraint(double[] yT, double[] z, bool terminal)
         {
             Vector3d rf = new Vector3d(yT[0], yT[1], yT[2]);
             Vector3d vf = new Vector3d(yT[3], yT[4], yT[5]);
@@ -40,14 +40,22 @@ namespace MuMech {
             Vector3d hmiss = hf - hT;
 
             // 5 constraints
-            z[0] = ( rf.magnitude * rf.magnitude - rTm * rTm ) / 2.0;
-            z[1] = Vector3d.Dot(rf, vf) - rf.magnitude * vf.magnitude * Math.Sin(gamma);
-            z[2] = hmiss[0];
-            z[3] = hmiss[1];
-            z[4] = hmiss[2];
+            if (!terminal)
+            {
+                z[0] = ( rf.magnitude * rf.magnitude - rTm * rTm ) / 2.0;
+                z[1] = Vector3d.Dot(rf, vf) - rf.magnitude * vf.magnitude * Math.Sin(gamma);
+                z[2] = hmiss[0];
+                z[3] = hmiss[1];
+                z[4] = hmiss[2];
 
-            // transversality - free argp
-            z[5] = Vector3d.Dot(Vector3d.Cross(prf, rf) + Vector3d.Cross(pvf, vf), hT);
+                // transversality - free argp
+                z[5] = Vector3d.Dot(Vector3d.Cross(prf, rf) + Vector3d.Cross(pvf, vf), hT);
+            }
+            else
+            {
+                z[0] = hmiss.magnitude;
+                z[1] = z[2] = z[3] = z[4] = z[5] = 0.0;
+            }
         }
 
         // 4-constraint PEG with free LAN
@@ -63,7 +71,7 @@ namespace MuMech {
             bcfun = flightangle4constraint;
         }
 
-        private void flightangle4constraint(double[] yT, double[] z)
+        private void flightangle4constraint(double[] yT, double[] z, bool terminal)
         {
             Vector3d rf = new Vector3d(yT[0], yT[1], yT[2]);
             Vector3d vf = new Vector3d(yT[3], yT[4], yT[5]);
@@ -75,13 +83,23 @@ namespace MuMech {
             Vector3d vn = Vector3d.Cross(vf, n);
             Vector3d hf = Vector3d.Cross(rf, vf);
 
-            z[0] = ( rf.magnitude * rf.magnitude - rTm * rTm ) / 2.0;
-            z[1] = ( vf.magnitude * vf.magnitude - vTm * vTm ) / 2.0;
-            z[2] = Vector3d.Dot(n, hf) - hf.magnitude * Math.Cos(inc);
-            z[3] = Vector3d.Dot(rf, vf) - rf.magnitude * vf.magnitude * Math.Sin(gamma);
-            z[4] = rTm * rTm * ( Vector3d.Dot(vf, prf) - vTm * Math.Sin(gamma) / rTm * Vector3d.Dot(rf, prf) ) -
-                vTm * vTm * ( Vector3d.Dot(rf, pvf) - rTm * Math.Sin(gamma) / vTm * Vector3d.Dot(vf, pvf) );
-            z[5] = Vector3d.Dot(hf, prf) * Vector3d.Dot(hf, rn) + Vector3d.Dot(hf, pvf) * Vector3d.Dot(hf, vn);
+            if (!terminal)
+            {
+                z[0] = ( rf.magnitude * rf.magnitude - rTm * rTm ) / 2.0;
+                z[1] = ( vf.magnitude * vf.magnitude - vTm * vTm ) / 2.0;
+                z[2] = Vector3d.Dot(n, hf) - hf.magnitude * Math.Cos(inc);
+                z[3] = Vector3d.Dot(rf, vf) - rf.magnitude * vf.magnitude * Math.Sin(gamma);
+                z[4] = rTm * rTm * ( Vector3d.Dot(vf, prf) - vTm * Math.Sin(gamma) / rTm * Vector3d.Dot(rf, prf) ) -
+                    vTm * vTm * ( Vector3d.Dot(rf, pvf) - rTm * Math.Sin(gamma) / vTm * Vector3d.Dot(vf, pvf) );
+                z[5] = Vector3d.Dot(hf, prf) * Vector3d.Dot(hf, rn) + Vector3d.Dot(hf, pvf) * Vector3d.Dot(hf, vn);
+            }
+            else
+            {
+                double hTm = rTm * vTm * Math.Cos(gamma);
+
+                z[0] = hf.magnitude - hTm;
+                z[1] = z[2] = z[3] = z[4] = z[5] = 0.0;
+            }
         }
 
         public override void Bootstrap(double t0)

--- a/MechJeb2/Pontryagin/PontryaginNode.cs
+++ b/MechJeb2/Pontryagin/PontryaginNode.cs
@@ -36,7 +36,7 @@ namespace MuMech {
             }
         }
 
-        private void intercept(double[] yT, double[] z)
+        private void intercept(double[] yT, double[] z, bool terminal)
         {
             z[0] = yT[0] - rT[0];
             z[1] = yT[1] - rT[1];
@@ -44,9 +44,13 @@ namespace MuMech {
             z[3] = yT[3] - vT[0];
             z[4] = yT[4] - vT[1];
             z[5] = yT[5] - vT[2];
+            if ( terminal )
+                throw new Exception("need to fix this");
+
+            // no transversality for 6-constraint intercept
         }
 
-        private void terminal5constraint(double[] yT, double[] z)
+        private void terminal5constraint(double[] yT, double[] z, bool terminal)
         {
             Vector3d rTp = rT;
             Vector3d vTp = vT;
@@ -76,12 +80,20 @@ namespace MuMech {
             Vector3d emiss = ef - eT;
             double trans = Vector3d.Dot(prf, vf) - Vector3d.Dot(pvf, rf) / ( rf.magnitude * rf.magnitude * rf.magnitude );
 
-            z[0] = hmiss[0];
-            z[1] = hmiss[1];
-            z[2] = hmiss[2];
-            z[3] = emiss[0];
-            z[4] = emiss[2];
-            z[5] = trans;
+            if (!terminal)
+            {
+                z[0] = hmiss[0];
+                z[1] = hmiss[1];
+                z[2] = hmiss[2];
+                z[3] = emiss[0];
+                z[4] = emiss[2];
+                z[5] = trans;
+            }
+            else
+            {
+                z[0] = hmiss.magnitude;
+                z[1] = z[2] = z[3] = z[4] = z[5] = 0.0;
+            }
         }
 
         public override void Bootstrap(double t0)

--- a/MechJeb2/Pontryagin/TODO.md
+++ b/MechJeb2/Pontryagin/TODO.md
@@ -1,17 +1,13 @@
 
 ### TODO List
 
-# Logging / Status fixes:
+# Critical bugs
 
-* display optimizer status
-* display optimizer runtime
-* display warning about ISP/thrust in stage stats not matching current situation
-* capture optimizer exceptions and log them from the main thread
+* UpdateY0 throwing on last staging event with Atlas V HLV
 
 # Critical items before merging to mainline MechJeb
 
-* Track dV sensed like PEG does rather than counting down tgo
-   * Bring back g-limiter as a suboptimal hack
+* Bring back g-limiter as a suboptimal hack
 
 # Critical node executor bugs
 


### PR DESCRIPTION
The condition to cut the throttle for both proper engine terminal
guidance and RCS terminal guidance is now dependent upon not
overshooting the target orbital angular momentum instead of just
count down predicted time.  This is considerably more accurate and
is accurate even in the face of bugs that screw up the mass/thrust
of stage analysis.

This also surfaces those bugs through error messages on screen
during the launch, since those also need fixing.

This change also auto-enables RCS for coast periods and for
terminal guidance.  Can still be disabled if its buggy for some
reason.

Tested with launches both to plane and not and to highly elliptical
orbits and with rockets that have screwy root parts and inaccurate
∆v stats (and which wind up with very negative tgo+vgo values once
the burn completes, but the target conditions were highly accurate).

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>