### PR TITLE
PVG stabilization fixes

### DIFF
--- a/MechJeb2/MechJebModuleLogicalStageTracking.cs
+++ b/MechJeb2/MechJebModuleLogicalStageTracking.cs
@@ -51,7 +51,7 @@ namespace MuMech
             if ( !enabled || stages.Count == 0 )
                 return;
 
-            if ( stages[0].ksp_stage > ( vessel.currentStage - 1 ) )
+            while ( stages[0].ksp_stage > ( vessel.currentStage - 1 ) )
             {
                 // we did drop a relevant stage
                 stageCount += 1;
@@ -148,6 +148,9 @@ namespace MuMech
 
             public void Sync()
             {
+                if (ksp_stage > parent.core.stageStats.vacStats.Length - 1)
+                    return;
+
                 vacStats = parent.core.stageStats.vacStats[ksp_stage];
                 deltaV = vacStats.deltaV;
                 deltaTime = vacStats.deltaTime;

--- a/MechJeb2/Pontryagin/PontryaginLaunch.cs
+++ b/MechJeb2/Pontryagin/PontryaginLaunch.cs
@@ -148,7 +148,7 @@ namespace MuMech {
             {
                 //for(int k = 0; k < y0.Length; k++)
                     //Debug.Log("failed - y0[" + k + "] = " + y0[k]);
-                Fatal("failed to coverge nocoast/infinite ISP");
+                Fatal("Target is unreachable even with infinite ISP");
                 return;
             }
 
@@ -185,7 +185,7 @@ namespace MuMech {
 
             if ( !runOptimizer(arcs) )
             {
-                Fatal("failed to coverge with normal ISP");
+                Fatal("Target is unreachable");
                 //for(int k = 0; k < y0.Length; k++)
                     //Debug.Log("failed - y0[" + k + "] = " + y0[k]);
                 //Debug.Log("optimizer failed6");
@@ -203,30 +203,6 @@ namespace MuMech {
 
             if (insertedCoast)
             {
-
-                /*
-                if ( new_sol.tgo(new_sol.t0, arcs.Count-2) < 1 )
-                {
-                    // coast is less than one second, try extending it again without infinite
-                    // (FIXME: this is buggy somehow)
-                    RetryCoast(arcs, arcs.Count-2, new_sol);
-                    //Debug.Log("running optimizer4");
-
-                    if ( !runOptimizer(arcs) )
-                    {
-                        for(int k = 0; k < y0.Length; k++)
-                            Debug.Log("failed - y0[" + k + "] = " + y0[k]);
-                        Debug.Log("optimizer failed8");
-                        y0 = null;
-                        return;
-                    }
-
-                    //Debug.Log("optimizer done");
-                    new_sol = new Solution(t_scale, v_scale, r_scale, t0);
-                    multipleIntegrate(y0, new_sol, arcs, 10);
-                }
-                */
-
                 if ( new_sol.tgo(new_sol.t0, arcs.Count-2) < 1 )
                 {
                     // coast is less than one second, delete it and reconverge

--- a/MechJeb2/Pontryagin/PontryaginNode.cs
+++ b/MechJeb2/Pontryagin/PontryaginNode.cs
@@ -110,14 +110,14 @@ namespace MuMech {
             // build arcs off of ksp stages, with coasts
             List<Arc> arcs = new List<Arc>();
 
-            arcs.Add(new Arc(this));
+            arcs.Add(new Arc(this, coast: true));
 
             for(int i = 0; i < stages.Count; i++)
             {
                 arcs.Add(new Arc(this, stages[i]));
             }
 
-            arcs.Add(new Arc(this));
+            arcs.Add(new Arc(this, coast: true));
             // arcs.Add(new Arc(new Stage(this, m0: -1, isp: 0, thrust: 0, ksp_stage: stages[stages.Count-1].ksp_stage), done: true));
 
             arcs[arcs.Count-1].use_fixed_time = true;


### PR DESCRIPTION
fixes bugs introduced by the major rewriting of the stage management
code in #1119

The "array index out of bounds" on stage decoupling was ultimately caused by the "if (arcs[i].thrust == 0)" test in arcIndex which was improperly identifying the stage about to be jettisoned as a coast stage for one tick cycle when it managed to grab the stage information when the thrust was zero (MJ's pre-stage delay means that you'll have a burned out stage with zero thrust for several ticks).  This was solved by introducing a proper boolean to identify coasting stages, rather than trying to deduce if a stage was a coast based on its properties.  There's still a conditional around thrust being zero in the equations of motion because there we're just trying to prevent division by zero introduced by zero thrust stages and it doesn't matter if its a coast or one of these burned out useless stages or not.

Also the code that was responsible for marking a coasting stage as being done was formerly the responsibility of the GuidanceController module and that got deleted and dropped, so you'd "drag" a burned out coast stage "virtually" up to the insertion burn which seemed to be causing a lot of the early-termination-of-PVG-switching-to-RCS complaints.   That is now the responsibility of the main optimizer loop to drop any stages out of the prior solution that have tgo <= 0.
