### PR TITLE
set unstable ignitions to false by default

### DIFF
--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -89,7 +89,7 @@ namespace MuMech
         }
 
         [Persistent(pass = (int)Pass.Global)]
-        public bool limitToPreventUnstableIgnition = true;
+        public bool limitToPreventUnstableIgnition = false;
 
         [GeneralInfoItem("Prevent unstable ignition", InfoItem.Category.Thrust)]
         public void LimitToPreventUnstableIgnitionInfoItem()
@@ -102,7 +102,7 @@ namespace MuMech
         [Persistent(pass = (int)Pass.Global)]
         public bool autoRCSUllaging = true;
 
-        [GeneralInfoItem("Prevent unstable ignition", InfoItem.Category.Thrust)]
+        [GeneralInfoItem("Use RCS to ulllage", InfoItem.Category.Thrust)]
         public void AutoRCsUllageInfoItem()
         {
             GUIStyle s = new GUIStyle(GUI.skin.toggle);


### PR DESCRIPTION
The banner message has shown that people do leave this set and
are now surprised that their sounding rocket launches have been
getting killed by MJ, and that people largely don't understand
the feature.

So disabling this by default, leaving RCS ullaging on, which is
the safest config.

Also caught some bad copypasta in the info item for RCS ullaging
here.