### PR TITLE
Fix disabling autostaging in flight

### DIFF
--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -459,7 +459,6 @@ namespace MuMech
         {
             core.attitude.users.Add(this);
             core.thrust.users.Add(this);
-            if (autopilot.autostage) core.staging.users.Add(this);
         }
 
         public override void OnModuleDisabled()
@@ -468,7 +467,6 @@ namespace MuMech
             if (!core.rssMode)
                 core.thrust.ThrustOff();
             core.thrust.users.Remove(this);
-            core.staging.users.Remove(this);
         }
 
         //gives a throttle setting that reduces as we approach the desired apoapsis


### PR DESCRIPTION
If the "sub" ascent modules (Classic, GT, PVG) are enabled they are
currently registering themselves with autostaging if autostaging is
enabled on the autopilot.  That means that in flight if autostaging
is disabled that only the code runs in the main Autopilot class
to try to disable it, but the sub-module is still registered.

This should always just have been left the responsibility of the main
autopilot class itself and not in the base class of the sub controllers.
