### PR TITLE
Fix wobbly dV display in the last stage

### DIFF
--- a/MechJeb2/Pontryagin/PontryaginLaunch.cs
+++ b/MechJeb2/Pontryagin/PontryaginLaunch.cs
@@ -110,7 +110,7 @@ namespace MuMech {
             {
                 //if (i != 0)
                     //arcs.Add(new Arc(new Stage(this, m0: stages[i].m0, isp: 0, thrust: 0)));
-                arcs.Add(new Arc(this, stages[i]));
+                arcs.Add(new Arc(this, stage: stages[i], t0: t0));
             }
 
             arcs[arcs.Count-1].infinite = true;

--- a/MechJeb2/Pontryagin/PontryaginNode.cs
+++ b/MechJeb2/Pontryagin/PontryaginNode.cs
@@ -110,14 +110,14 @@ namespace MuMech {
             // build arcs off of ksp stages, with coasts
             List<Arc> arcs = new List<Arc>();
 
-            arcs.Add(new Arc(this, coast: true));
+            arcs.Add(new Arc(this, t0: t0, coast: true));
 
             for(int i = 0; i < stages.Count; i++)
             {
-                arcs.Add(new Arc(this, stages[i]));
+                arcs.Add(new Arc(this, stage: stages[i], t0: t0));
             }
 
-            arcs.Add(new Arc(this, coast: true));
+            arcs.Add(new Arc(this, coast: true, t0: t0));
             // arcs.Add(new Arc(new Stage(this, m0: -1, isp: 0, thrust: 0, ksp_stage: stages[stages.Count-1].ksp_stage), done: true));
 
             arcs[arcs.Count-1].use_fixed_time = true;


### PR DESCRIPTION
We need to synchronize the stage stats into the solution, but that
synchronization only happens when kicking off an optimization.  That
means that the state that was last synchronized may have no resemblance
to the current state of the stage stats, because the user may have
arbitrarily been rearranging staging in the meantime.  So we also
need to track the time that we synchronized the stage stats.

One open question I have here is why we don't simply update the stage
stats into the solution on every tick.  I don't recall why I didn't
do that.  Might have something to do with updating information
mid-optimization and creating a race condition with the next optimizer
cycle needing a consistent view over the whole time its running?  That
seems a bit weird, but the prior solution is consumed by the running
optimizer.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>