### PR TITLE
PVG core update

### DIFF
--- a/MechJeb2/Pontryagin/PontryaginBase.cs
+++ b/MechJeb2/Pontryagin/PontryaginBase.cs
@@ -435,7 +435,6 @@ namespace MuMech {
             QuaternionD rot = Quaternion.Inverse(Planetarium.fetch.rotation);
             r0 = rot * r0;
             v0 = rot * v0;
-            //Debug.Log("LAN1 = " + LAN(r0, v0) + " r = " + r0 + " v = " + v0);
             pv0 = rot * pv0;
             pr0 = rot * pr0;
             this.r0 = r0;
@@ -449,9 +448,10 @@ namespace MuMech {
             r_scale = r0m;
             v_scale = Math.Sqrt( r0m * g_bar );
             t_scale = Math.Sqrt( r0m / g_bar );
+
             r0_bar = this.r0 / r_scale;
             v0_bar = this.v0 / v_scale;
-            //Debug.Log("LAN1 = " + LAN(r0_bar, v0_bar) + " r = " + r0_bar + " v = " + v0_bar);
+
             dV_bar = dV / v_scale;
             fixed_final_time = false;
         }
@@ -462,8 +462,6 @@ namespace MuMech {
             // the current position while a guidance solution thread is currently running.
             if (thread != null && thread.IsAlive)
                 return;
-
-            //Debug.Log("r0m = " + r0.magnitude + " v0m = " + v0.magnitude);
 
             QuaternionD rot = Quaternion.Inverse(Planetarium.fetch.rotation);
             r0 = rot * r0;
@@ -518,7 +516,6 @@ namespace MuMech {
             dy[13] = At;
         }
 
-
         double ckEps = 1e-6;  /* matches Matlab's default 1e-6 ode45 reltol? */
 
         /* used to update y0 to yf without intermediate values */
@@ -527,7 +524,7 @@ namespace MuMech {
             singleIntegrate(y0: y0, yf: yf, sol: null, n: n, t: ref t, dt: dt, arcs: arcs, count: 2, dV: ref dV);
         }
 
-        /* used to pull intermediate values off to do chebyshev polynomial interpolation */
+        /* used to pull intermediate values off to do cubic spline interpolation */
         public void singleIntegrate(double[] y0, Solution sol, int n, ref double t, double dt, List<Arc> arcs, int count, ref double dV)
         {
             singleIntegrate(y0: y0, yf: null, sol: sol, n: n, t: ref t, dt: dt, arcs: arcs, count: count, dV: ref dV);
@@ -537,36 +534,38 @@ namespace MuMech {
         {
             Arc e = arcs[n];
 
+            // gotta have at least a start and an end
             if ( count < 2)
                 count = 2;
-
-            /*
-            // negative burns or coasts don't work with alglib, need to replace the rkf45 implementation
-            if ( dt < 0 )
-                dt = 0;
-
-            // zero time segments also don't work with alglib either
-            if ( dt < 1e-16 && yf != null)
-            {
-                Array.Copy(y0, arcIndex(arcs,n), yf, 13*n, 13);
-                return;
-            }
-
-            if ( dt < 1e-16 )
-                throw new Exception("dt is zero");
-                */
 
             double[] y = new double[14];
             Array.Copy(y0, arcIndex(arcs,n), y, 0, 13);
             y[13] = dV;
 
+            // fix the starting point to being r0_bar, v0_bar
+            if ( n == 0 )
+            {
+                y[0] = r0_bar[0];
+                y[1] = r0_bar[1];
+                y[2] = r0_bar[2];
+                y[3] = v0_bar[0];
+                y[4] = v0_bar[1];
+                y[5] = v0_bar[2];
+            }
 
-            /* time to burn the entire stage */
-            double tau = e.isp * g0 * y[12] / e.thrust / t_scale;
+            /*
+            if ( e.thrust > 0 )
+            {
+                // time to burn the entire stage
+                double tau = e.isp * g0 * y[12] / e.thrust / t_scale;
 
-            /* clip dt at 99.9% of tau */
-            if ( dt > 0.999 * tau && !e.infinite )
-                dt = 0.999 * tau;
+                if ( dt > tau )
+                    Debug.Log("TAU EXCEEEDED!");
+                // clip dt at 99.9% of tau
+//                if ( dt > 0.999 * tau && !e.infinite )
+//                    dt = 0.999 * tau;
+            }
+            */
 
             // XXX: remove this hack
             bool allvals;
@@ -574,7 +573,6 @@ namespace MuMech {
                 allvals = true;
             else
                 allvals = false;
-            //count = 2;
 
             double[] x = new double[count];
 
@@ -594,7 +592,7 @@ namespace MuMech {
             x[count-1] = t + dt;
             */
 
-            ODE ode = new ODE(y, 14, x, ckEps, 0, hmin: 1e-6, allvals: allvals);
+            ODE ode = new ODE(y, 14, x, ckEps, 0, hmin: 1e-15, allvals: allvals);
             ode.RKF45(centralForceThrust, e);
 
             t = t + dt;
@@ -603,10 +601,6 @@ namespace MuMech {
 
             if (sol != null)
             {
-                //Debug.Log("--------------");
-                //for(int i = 0; i < count; i++)
-                //    Debug.Log(x[i]);
-                //Debug.Log("ylist.Count = " + ode.ylist.Count);
                 sol.AddSegment(ode.xlist, ode.ylist, e);
             }
 
@@ -630,7 +624,6 @@ namespace MuMech {
         public void multipleIntegrate(double[] y0, Solution sol, List<Arc> arcs, int count)
         {
             multipleIntegrate(y0, null, sol, arcs, count: count);
-            //Debug.Log("DONE: rf = " + sol.rf().xzy.magnitude + "; vf = " + sol.vf().xzy.magnitude + " tmin = " + sol.tmin() + " tmax = " + sol.tmax() + " v_barf = " + sol.v_bar(sol.tmax()).xzy.magnitude + "; r_barf = " + sol.r_bar(sol.tmax()).xzy.magnitude + " vf2 = " + sol.v_bar(sol.tmax()).xzy.magnitude * v_scale + "; rf2 = " + sol.r_bar(sol.tmax()).xzy.magnitude * r_scale );
         }
 
         // copy the nth
@@ -667,9 +660,6 @@ namespace MuMech {
                         coast_time = arcs[i].fixed_tbar - t;
                     else
                         coast_time = y0[arcIndex(arcs, i, parameters: true)];
-
-                    //if (sol != null)
-                    //    Debug.Log("coast_time = " + coast_time + " t = " + t);
 
                     if (yf != null) {
                         // normal integration with no midpoints
@@ -733,7 +723,7 @@ namespace MuMech {
          */
         public int arcIndex(List<Arc> arcs, int n, bool parameters = false)
         {
-            int index = 2;
+            int index = 1;
             for(int i=0; i<n; i++)
             {
                 if (arcs[i].coast)
@@ -741,7 +731,7 @@ namespace MuMech {
                     if (arcs[i].use_fixed_time)
                         index += 13;
                     else
-                        index += 15;
+                        index += 14;
                 }
                 else
                 {
@@ -756,7 +746,7 @@ namespace MuMech {
                 {
                     if (!arcs[n].use_fixed_time)
                     {
-                        index += 2;
+                        index += 1;
                     }
                 }
             }
@@ -878,14 +868,9 @@ namespace MuMech {
             {
                 z[n] = 0.0;
                 for(int i = 0; i < 6; i++)
-                    z[n] = z[n] + yf[i+6+13*(arcs.Count-1)] * yf[i+6+13*(arcs.Count-1)];
+                    z[n] += yf[i+6+13*(arcs.Count-1)] * yf[i+6+13*(arcs.Count-1)];
                 z[n] = Math.Sqrt(z[n]) - 1.0;
             }
-            n++;
-
-            // positive arc time constraint
-            z[n] = y0[1];
-            // z[n] = ( y0[0] < 0 ) ? y0[0] - y0[1] * y0[1] : y0[1];
             n++;
 
             double total_bt_bar = 0;
@@ -893,68 +878,49 @@ namespace MuMech {
             {
                 if ( arcs[i].coast && !arcs[i].use_fixed_time )
                 {
-                    int index = arcIndex(arcs, i, parameters: true);
-                    if (total_bt_bar > y0[0] || (i == arcs.Count -1))
-                    {
-                        z[n] = y0[index];
-                        n++;
-                        z[n] = y0[index+1];
-                        n++;
-                    }
-                    else
-                    {
-                        Vector3d r = new Vector3d(y0[index+2], y0[index+3], y0[index+4]);
-                        //Vector3d v = new Vector3d(y0[index+5], y0[index+6], y0[index+7]);
-                        //Vector3d pv = new Vector3d(y0[index+8], y0[index+9], y0[index+10]);
-                        //Vector3d pr = new Vector3d(y0[index+11], y0[index+12], y0[index+13]);
-                        double rm = r.magnitude;
+                    int index = arcIndex(arcs, i);
 
-                        Vector3d r2 = new Vector3d(yf[i*13+0], yf[i*13+1], yf[i*13+2]);
-                        Vector3d v2 = new Vector3d(yf[i*13+3], yf[i*13+4], yf[i*13+5]);
-                        Vector3d pv2 = new Vector3d(yf[i*13+6], yf[i*13+7], yf[i*13+8]);
-                        Vector3d pr2 = new Vector3d(yf[i*13+9], yf[i*13+10], yf[i*13+11]);
-                        double r2m = r2.magnitude;
+                    Vector3d r = new Vector3d(y0[index+0], y0[index+1], y0[index+2]);
+                    Vector3d v = new Vector3d(y0[index+3], y0[index+4], y0[index+5]);
+                    Vector3d pv = new Vector3d(y0[index+6], y0[index+7], y0[index+8]);
+                    Vector3d pr = new Vector3d(y0[index+9], y0[index+10], y0[index+11]);
+                    double rm = r.magnitude;
 
-                        //double H0t1 = Vector3d.Dot(pr, v) - Vector3d.Dot(pv, r) / (rm * rm * rm);
-                        double H0t2 = Vector3d.Dot(pr2, v2) - Vector3d.Dot(pv2, r2) / (r2m * r2m * r2m);
+                    Vector3d r2 = new Vector3d(yf[i*13+0], yf[i*13+1], yf[i*13+2]);
+                    Vector3d v2 = new Vector3d(yf[i*13+3], yf[i*13+4], yf[i*13+5]);
+                    Vector3d pv2 = new Vector3d(yf[i*13+6], yf[i*13+7], yf[i*13+8]);
+                    Vector3d pr2 = new Vector3d(yf[i*13+9], yf[i*13+10], yf[i*13+11]);
+                    double r2m = r2.magnitude;
 
-                        z[n] = H0t2;
-                        n++;
-                        z[n] = y0[index+1];
-                        n++;
-                    }
+                    double H0t1 = Vector3d.Dot(pr, v) - Vector3d.Dot(pv, r) / (rm * rm * rm);
+                    double H0t2 = Vector3d.Dot(pr2, v2) - Vector3d.Dot(pv2, r2) / (r2m * r2m * r2m);
+
+                    z[n] = H0t2;
+                    n++;
                 }
                 // sum up burntime of burn arcs
                 if ( !arcs[i].coast )
                     total_bt_bar += arcs[i].max_bt_bar;
             }
 
-            /* construct sum of the squares of the residuals for levenberg marquardt */
-            /*
-            for(int i = 0; i < z.Length; i++)
-                //z[i] = z[i] * z[i];
-                z[i] = Math.Abs(z[i]);
-                */
+            double znorm = 0.0;
+            for(int i = 0; i < n; i++)
+                znorm += z[i] * z[i];
+            znorm = Math.Sqrt(znorm);
+            if (znorm < 1e-9)
+            {
+                alglib.minlmrequesttermination(state);
+            }
         }
 
-        // NOTE TO SELF:  STOP FUCKING WITH THESE NUMBERS
-        double lmEpsx = 0; // 1e-8;  // going to 1e-10 seems to cause the optimizer to flail with 1e-15 or less differences produced in the zero value
-                               // 1e-8 produces plenty accurate numbers, unless the transversality conditions are broken in some way
-        int lmIter = 0; // 20000;    // 20,000 does seem roughly appropriate -- 12,000 has been necessary to find some solutions
-        double lmDiffStep = 1e-6; // 1e-8; // this matching lmEspx probably makes sense
+        double lmEpsx =  1e-10;   // now that we request termination when the znorm gets < 1e-9 this value could be pushed up if necessary
+        int lmIter = 20000;       // should revisit this, 20,000 seems like an awful lot now that the math is more stable, but clearly this is very high
+        double lmDiffStep = 1e-9; // diffstep may be able to be pushed up to 1e-15?
+
+        alglib.minlmstate state;
 
         public bool runOptimizer(List<Arc> arcs)
         {
-            //Debug.Log("arcs in runOptimizer:");
-            //for(int i = 0; i < arcs.Count; i++)
-            //   Debug.Log(arcs[i]);
-
-            //for(int i = 0; i < stages.Count; i++)
-            //    Debug.Log(stages[i]);
-
-            //for(int i = 0; i < y0.Length; i++)
-            //    Debug.Log("runOptimizer before - y0[" + i + "] = " + y0[i]);
-
             double[] z = new double[arcIndex(arcs,arcs.Count)];
             optimizationFunction(y0, z, arcs);
 
@@ -963,14 +929,9 @@ namespace MuMech {
             for(int i = 0; i < z.Length; i++)
             {
                 znorm += z[i] * z[i];
-                //Debug.Log("zbefore[" + i + "] = " + z[i]);
             }
 
             znorm = Math.Sqrt(znorm);
-            //Debug.Log("znorm = " + znorm);
-
-            //Debug.Log("length = " + arcIndex(arcs,arcs.Count));
-            //Debug.Log("y0 length = " + y0.Length);
 
             double[] bndl = new double[arcIndex(arcs,arcs.Count)];
             double[] bndu = new double[arcIndex(arcs,arcs.Count)];
@@ -980,9 +941,16 @@ namespace MuMech {
                 bndu[i] = Double.PositiveInfinity;
             }
 
+            for(int i = 0; i < arcs.Count; i++)
+            {
+                if (arcs[i].coast_after_jettison)
+                {
+                    int index = arcIndex(arcs, i, parameters: true);
+                    bndl[index] = 0;
+                }
+            }
             bndl[0] = 0;
 
-            alglib.minlmstate state;
             alglib.minlmreport rep = new alglib.minlmreport();
             alglib.minlmcreatev(y0.Length, y0, lmDiffStep, out state);  /* y0.Length must == z.Length returned by the BC function for square problems */
             alglib.minlmsetbc(state, bndl, bndu);
@@ -1007,15 +975,9 @@ namespace MuMech {
                 if (z[i] > max_z)
                     max_z = z[i];
                 znorm += z[i] * z[i];
-                //Debug.Log("z[" + i + "] = " + z[i]);
             }
 
             last_znorm = Math.Sqrt(znorm);
-
-            //Debug.Log("znorm = " + znorm);
-
-            //for(int i = 0; i < y0.Length; i++)
-            //    Debug.Log("y0[" + i + "] = " + y0[i]);
 
             // this comes first because after max-iterations we may still have an acceptable solution.
             // we check the largest z-value rather than znorm because for a lot of dimensions several slightly
@@ -1025,8 +987,6 @@ namespace MuMech {
                 y0 = y0_new;
                 return true;
             }
-
-            //Debug.Log("runoptimizer failed!");
 
             // lol
             if ( (rep.terminationtype != 2) && (rep.terminationtype != 7) )
@@ -1066,14 +1026,12 @@ namespace MuMech {
 
             if (solution != null)
             {
-                //Debug.Log("tburn_bar = " + solution.tburn_bar(0));
                 y0[0] = solution.tburn_bar(0); // FIXME: need to pass actual t0 here
             }
             else
             {
                 y0[0] = tgo_bar;
             }
-            y0[1] = 0;
         }
 
         /* insert coast before the ith stage */
@@ -1094,8 +1052,7 @@ namespace MuMech {
             Array.Copy(y0, 0, y0_new, 0, bottom);
             // initialize the coast
             //y0_new[bottom] = Math.Asin(MuUtils.Clamp(0.5 / MAX_COAST_TAU - 1, -1, 1));
-            y0_new[bottom] = dt/2.0;
-            y0_new[bottom+1] = 0.0;
+            y0_new[bottom] = y0[0]; // dt/2.0;
             // keep the burntime of the upper stage constant
             y0_new[0] = y0[0]; // - dt/2.0;
 
@@ -1163,13 +1120,6 @@ namespace MuMech {
             }
 
             try {
-                //Debug.Log("starting optimize");
-                if (stages != null)
-                {
-                    //Debug.Log("stages: ");
-                    //for(int i = 0; i < stages.Count; i++)
-                    //    Debug.Log(stages[i]);
-                }
                 if (last_arcs != null)
                 {
                     // since we shift the zero of tbar forwards on every re-optimize we have to do this here
@@ -1180,9 +1130,6 @@ namespace MuMech {
                             last_arcs[i].fixed_tbar = ( last_arcs[i].fixed_time - t0 ) / t_scale;
                         }
                     }
-                    //Debug.Log("arcs: ");
-                    //for(int i = 0; i < last_arcs.Count; i++)
-                    //    Debug.Log(last_arcs[i]);
                 }
 
                 if (y0 == null)
@@ -1255,9 +1202,6 @@ namespace MuMech {
 
                     Solution sol = new Solution(t_scale, v_scale, r_scale, t0);
 
-                    //for(int i = 0; i < y0.Length; i++)
-                    //    Debug.Log("y0[" + i + "] = " + y0[i]);
-
                     multipleIntegrate(y0, sol, last_arcs, 10);
 
                     this.solution = sol;
@@ -1267,15 +1211,6 @@ namespace MuMech {
 
                     successful_converges += 1;
                     last_success_time = Planetarium.GetUniversalTime();
-
-                    //for(int i = 0; i < yf.Length; i++)
-                    //    Debug.Log("yf[" + i + "] = " + yf[i]);
-
-                    //Debug.Log("r_scale = " + r_scale + " v_scale = " + v_scale);
-
-
-                    //Debug.Log("Optimize done");
-
                 }
             }
             catch (alglib.alglibexception e)

--- a/MechJeb2/Pontryagin/PontryaginLaunch.cs
+++ b/MechJeb2/Pontryagin/PontryaginLaunch.cs
@@ -5,7 +5,8 @@ using UnityEngine;
 
 namespace MuMech {
     public class PontryaginLaunch : PontryaginBase {
-        public PontryaginLaunch(MechJebCore core, double mu, Vector3d r0, Vector3d v0, Vector3d pv0, Vector3d pr0, double dV) : base(core, mu, r0, v0, pv0, pr0, dV)
+        // FIXME: pr0 and pv0 need to be moved into the target constraint setting routines and need to not be the responsibility of the caller
+        public PontryaginLaunch(MechJebCore core, double mu, Vector3d r0, Vector3d v0, Vector3d pv0, double dV) : base(core, mu, r0, v0, pv0, r0.normalized * 8.0/3.0, dV)
         {
         }
 
@@ -19,17 +20,16 @@ namespace MuMech {
         double eccT;
         double LANT;
         double ArgPT;
-        Vector3d hT;
-        int numStages;
+        int numStages = 0;
 
         // 5-constraint PEG with fixed LAN
-        public void flightangle5constraint(double rTm, double vTm, double gammaT, Vector3d hT)
+        public void flightangle5constraint(double rTm, double vTm, double gammaT, double incT, double LANT)
         {
-            QuaternionD rot = Quaternion.Inverse(Planetarium.fetch.rotation);
             this.rTm = rTm / r_scale;
             this.vTm = vTm / v_scale;
             this.gammaT = gammaT;
-            this.hT = rot * hT / r_scale / v_scale;
+            this.incT = incT;
+            this.LANT = LANT;
             bcfun = flightangle5constraint;
         }
 
@@ -40,6 +40,9 @@ namespace MuMech {
             Vector3d pvf = new Vector3d(yT[6], yT[7], yT[8]);
             Vector3d prf = new Vector3d(yT[9], yT[10], yT[11]);
             Vector3d hf = Vector3d.Cross(rf, vf);
+            Vector3d hT = new Vector3d( Math.Sin(LANT) * Math.Sin(incT), -Math.Cos(LANT) * Math.Sin(incT), Math.Cos(incT) ) * rTm * vTm * Math.Cos(gammaT);
+
+            hT = -hT.xzy;
 
             Vector3d hmiss = hf - hT;
 
@@ -63,15 +66,12 @@ namespace MuMech {
         }
 
         // 4-constraint PEG with free LAN
-        public void flightangle4constraint(double rTm, double vTm, double gamma, double inc)
+        public void flightangle4constraint(double rTm, double vTm, double gammaT, double incT)
         {
-            //Debug.Log("call stack: + " + Environment.StackTrace);
             this.rTm = rTm / r_scale;
             this.vTm = vTm / v_scale;
-            //Debug.Log("4constraint vTm = " + vTm + " v_scale = " + v_scale + " vTm_bar = " + this.vTm );
-            //Debug.Log("4constraint rTm = " + rTm + " r_scale = " + r_scale + " rTm_bar = " + this.rTm );
-            this.gammaT = gamma;
-            this.incT = inc;
+            this.gammaT = gammaT;
+            this.incT = incT;
             bcfun = flightangle4constraint;
         }
 
@@ -106,17 +106,273 @@ namespace MuMech {
             }
         }
 
+        public void keplerian3constraint(double sma, double ecc, double inc)
+        {
+            this.smaT = sma / r_scale;
+            this.eccT = ecc;
+            this.incT = inc;
+            bcfun = keplerian3constraint;
+        }
+
+        // has a singularity for e == 0 which is only fixable by going to flightangle4constraint
+        // FIXME: singularity for i == 0, rot coordinates?
+        private void keplerian3constraint(double[] yT, double[] z, bool terminal)
+        {
+            Vector3d rf = new Vector3d(yT[0], yT[1], yT[2]);
+            Vector3d vf = new Vector3d(yT[3], yT[4], yT[5]);
+            Vector3d pvf = new Vector3d(yT[6], yT[7], yT[8]);
+            Vector3d prf = new Vector3d(yT[9], yT[10], yT[11]);
+
+            Vector3d hf = Vector3d.Cross(rf, vf);
+            Vector3d n = new Vector3d(0, -1, 0);  /* angular momentum vectors point south in KSP and we're in xzy coords */
+
+            double hTm = Math.Sqrt( smaT * ( 1 - eccT * eccT ) );
+
+            double smaf = 1.0 / ( 2.0 / rf.magnitude - vf.sqrMagnitude );
+            double eccf = Math.Sqrt(1.0 - hf.sqrMagnitude / smaf);
+
+            if (!terminal)
+            {
+                z[0] = smaT * ( 1 - eccT ) - ( smaf * ( 1 - eccf ) ); // PeA constraint
+                z[1] = vf.sqrMagnitude / 2.0 - 1.0 / rf.magnitude + 1.0 / ( 2.0 * smaT ); // E constraint
+                z[2] = Vector3d.Dot(n, hf.normalized) - Math.Cos(incT); // inc constraint
+                // transversality
+                z[3] = Vector3d.Dot(Vector3d.Cross(prf, rf) + Vector3d.Cross(pvf, vf), hf);
+                z[4] = Vector3d.Dot(Vector3d.Cross(prf, rf) + Vector3d.Cross(pvf, vf), n);
+                z[5] = Vector3d.Dot(prf, vf) - Vector3d.Dot(pvf, rf) / ( rf.magnitude * rf.magnitude * rf.magnitude );
+            }
+            else
+            {
+                z[0] = hf.magnitude - hTm;
+                z[1] = z[2] = z[3] = z[4] = z[5] = 0.0;
+            }
+        }
+
+        public void keplerian4constraintArgPfree(double sma, double ecc, double inc, double LAN)
+        {
+            this.smaT = sma / r_scale;
+            this.eccT = ecc;
+            this.incT = inc;
+            this.LANT = LAN;
+            bcfun = keplerian4constraintArgPfree;
+        }
+
+        private void keplerian4constraintArgPfree(double[] yT, double[] z, bool terminal)
+        {
+            Vector3d rf = new Vector3d(yT[0], yT[1], yT[2]);
+            Vector3d vf = new Vector3d(yT[3], yT[4], yT[5]);
+            Vector3d pvf = new Vector3d(yT[6], yT[7], yT[8]);
+            Vector3d prf = new Vector3d(yT[9], yT[10], yT[11]);
+
+            Vector3d hf = Vector3d.Cross(rf, vf);
+
+            Vector3d hT = new Vector3d( Math.Sin(LANT) * Math.Sin(incT), -Math.Cos(LANT) * Math.Sin(incT), Math.Cos(incT) ) * Math.Sqrt(smaT * (1 - eccT*eccT));
+            hT = -hT.xzy; // left handed coordinate system
+            Vector3d hmiss = hf - hT;
+
+            double smaf = 1.0 / ( 2.0 / rf.magnitude - vf.sqrMagnitude );
+            double eccf = Math.Sqrt(1.0 - hf.sqrMagnitude / smaf);
+
+            if (!terminal)
+            {
+                z[0] = smaT * ( 1 - eccT ) - ( smaf * ( 1 - eccf ) ); // PeA constraint
+                z[2] = hmiss[0];
+                z[2] = hmiss[1];
+                z[3] = hmiss[2];
+                // transversality
+                z[4] = Vector3d.Dot(Vector3d.Cross(prf, rf) + Vector3d.Cross(pvf, vf), hf);
+                z[5] = Vector3d.Dot(prf, vf) - Vector3d.Dot(pvf, rf) / ( rf.magnitude * rf.magnitude * rf.magnitude );
+            }
+            else
+            {
+                z[0] = hmiss.magnitude;
+                z[1] = z[2] = z[3] = z[4] = z[5] = 0.0;
+            }
+        }
+
+        public void keplerian4constraintLANfree(double sma, double ecc, double inc, double ArgP)
+        {
+            this.smaT = sma / r_scale;
+            this.eccT = ecc;
+            this.incT = inc;
+            this.ArgPT = ArgP;
+            bcfun = keplerian4constraintLANfree;
+        }
+
+        private void keplerian4constraintLANfree(double[] yT, double[] z, bool terminal)
+        {
+            Vector3d rf = new Vector3d(yT[0], yT[1], yT[2]);
+            Vector3d vf = new Vector3d(yT[3], yT[4], yT[5]);
+            Vector3d pvf = new Vector3d(yT[6], yT[7], yT[8]);
+            Vector3d prf = new Vector3d(yT[9], yT[10], yT[11]);
+
+            Vector3d hf = Vector3d.Cross(rf, vf);
+            Vector3d n = new Vector3d(0, -1, 0); // angular momentum vectors point south in KSP and we're in xzy coords
+
+            Vector3d eccf = Vector3d.Cross(vf, hf) - rf / rf.magnitude; // ecc vector
+            double smaf = 1.0 / ( 2.0 / rf.magnitude - vf.sqrMagnitude );
+            double hTm = Math.Sqrt( smaT * ( 1 - eccT * eccT ) );
+
+            if (!terminal)
+            {
+                z[0] = smaT * ( 1 - eccT ) - ( smaf * ( 1 - eccf.magnitude ) ); // PeA constraint
+                z[1] = vf.sqrMagnitude / 2.0 - 1.0 / rf.magnitude + 1.0 / ( 2.0 * smaT ); // E constraint
+                z[2] = Vector3d.Dot(n, hf) - hf.magnitude * Math.Cos(incT);
+                z[3] = Vector3d.Dot(eccf, Vector3d.Cross(n, hf)) / eccf.magnitude / hf.magnitude - Math.Sin(incT) * Math.Cos(ArgPT);
+                z[4] = Vector3d.Dot(Vector3d.Cross(prf, rf) + Vector3d.Cross(pvf, vf), n);
+                z[5] = Vector3d.Dot(prf, vf) - Vector3d.Dot(pvf, rf) / ( rf.magnitude * rf.magnitude * rf.magnitude );
+            }
+            else
+            {
+                z[0] = hf.magnitude - hTm;
+                z[1] = z[2] = z[3] = z[4] = z[5] = 0.0;
+            }
+        }
+
+        public void keplerian5constraint(double sma, double ecc, double inc, double LAN, double ArgP)
+        {
+            this.smaT = sma / r_scale;
+            this.eccT = ecc;
+            this.incT = inc;
+            this.LANT = LAN;
+            this.ArgPT = ArgP;
+            bcfun = keplerian5constraint;
+        }
+
+        private void keplerian5constraint(double[] yT, double[] z, bool terminal)
+        {
+            Vector3d rf = new Vector3d(yT[0], yT[1], yT[2]);
+            Vector3d vf = new Vector3d(yT[3], yT[4], yT[5]);
+            Vector3d pvf = new Vector3d(yT[6], yT[7], yT[8]);
+            Vector3d prf = new Vector3d(yT[9], yT[10], yT[11]);
+
+            Vector3d hT = new Vector3d( Math.Sin(LANT) * Math.Sin(incT), -Math.Cos(LANT) * Math.Sin(incT), Math.Cos(incT) ) * Math.Sqrt(smaT * (1 - eccT*eccT));
+            hT = -hT.xzy; // left handed coordinate system
+            // FIXME: Vector3d.cross(n, hf) is the node vector pointing in LAN dir, another ArgPT rot around hT would give eT direction
+            Vector3d right = new Vector3d(1, 0, 0);
+            Vector3d eT = Quaternion.Euler((float)LANT, (float)incT, (float)ArgPT) * right * (float) eccT;
+
+            if (Math.Abs(hT[1]) <= 1e-6) // handle singularity
+            {
+                rf = rf.Reorder(231);
+                vf = vf.Reorder(231);
+                prf = prf.Reorder(231);
+                pvf = pvf.Reorder(231);
+                hT = hT.Reorder(231);
+                eT = eT.Reorder(231);
+            }
+
+            Vector3d hf = Vector3d.Cross(rf, vf);
+            Vector3d ef = - ( rf.normalized + Vector3d.Cross(hf, vf) );
+            Vector3d hmiss = hf - hT;
+            Vector3d emiss = ef - eT;
+            double trans = Vector3d.Dot(prf, vf) - Vector3d.Dot(pvf, rf) / ( rf.magnitude * rf.magnitude * rf.magnitude );
+
+            if (!terminal)
+            {
+                z[0] = hmiss[0];
+                z[1] = hmiss[1];
+                z[2] = hmiss[2];
+                z[3] = emiss[0];
+                z[4] = emiss[2];
+                z[5] = trans;
+            }
+            else
+            {
+                z[0] = hmiss.magnitude;
+                z[1] = z[2] = z[3] = z[4] = z[5] = 0.0;
+            }
+        }
+
+        public void flightangle3constraintMAXE(double rTm, double gammaT, double incT, int numStages)
+        {
+            this.rTm = rTm / r_scale;
+            this.gammaT = gammaT;
+            this.numStages = numStages;
+            this.incT = incT;
+            bcfun = flightangle3constraintMAXE;
+        }
+
+        // fixed-time maximal energy from https://doi.org/10.2514/2.5045
+        private void flightangle3constraintMAXE(double[] yT, double[] z, bool terminal)
+        {
+            Vector3d rf = new Vector3d(yT[0], yT[1], yT[2]);
+            Vector3d vf = new Vector3d(yT[3], yT[4], yT[5]);
+            Vector3d pvf = new Vector3d(yT[6], yT[7], yT[8]);
+            Vector3d prf = new Vector3d(yT[9], yT[10], yT[11]);
+
+            Vector3d n = new Vector3d(0, -1, 0);  /* angular momentum vectors point south in KSP and we're in xzy coords */
+            Vector3d hf = Vector3d.Cross(rf, vf);
+
+            if (!terminal)
+            {
+                z[0] = ( rf.sqrMagnitude - rTm * rTm ) / 2.0;
+                z[1] = Vector3d.Dot(n, hf) - hf.magnitude * Math.Cos(incT);
+                z[2] = Vector3d.Dot(rf, vf) - rf.magnitude * vf.magnitude * Math.Sin(gammaT);
+
+                z[3] = Vector3d.Dot(vf, prf) * rf.sqrMagnitude - Vector3d.Dot(rf, pvf) * vf.sqrMagnitude + Vector3d.Dot(rf, vf) * (vf.sqrMagnitude - Vector3d.Dot(rf, prf));
+                z[4] = Vector3d.Dot(vf, pvf) - vf.sqrMagnitude;
+                z[5] = Vector3d.Dot(hf, prf) * Vector3d.Dot(hf, Vector3d.Cross(rf, n)) + Vector3d.Dot(hf, pvf) * Vector3d.Dot(hf, Vector3d.Cross(vf, n));
+            }
+            else
+            {
+                z[0] = z[1] = z[2] = z[3] = z[4] = z[5] = 0.0;
+            }
+        }
+
+        public void flightangle4constraintMAXE(double rTm, double gammaT, double incT, double LANT, int numStages)
+        {
+            this.rTm = rTm / r_scale;
+            this.gammaT = gammaT;
+            this.incT = incT;
+            this.LANT = LANT;
+            this.numStages = numStages;
+            bcfun = flightangle4constraintMAXE;
+        }
+
+        // fixed-time maximal energy from https://doi.org/10.2514/2.5045
+        // XXX: this may only work for gammaT of zero?
+        private void flightangle4constraintMAXE(double[] yT, double[] z, bool terminal)
+        {
+            Vector3d rf = new Vector3d(yT[0], yT[1], yT[2]);
+            Vector3d vf = new Vector3d(yT[3], yT[4], yT[5]);
+            Vector3d pvf = new Vector3d(yT[6], yT[7], yT[8]);
+            Vector3d prf = new Vector3d(yT[9], yT[10], yT[11]);
+
+            Vector3d n = new Vector3d(0, -1, 0);  /* angular momentum vectors point south in KSP and we're in xzy coords */
+            Vector3d hf = Vector3d.Cross(rf, vf);
+
+            // angular momentum direction unit vector
+            Vector3d i_hT = new Vector3d( Math.Sin(LANT) * Math.Sin(incT), -Math.Cos(LANT) * Math.Sin(incT), Math.Cos(incT) );
+
+            if (!terminal)
+            {
+                z[0] = ( rf.sqrMagnitude - rTm * rTm ) / 2.0;
+                z[1] = Vector3d.Dot(n, hf) - hf.magnitude * Math.Cos(incT);
+                z[2] = Vector3d.Dot(rf, i_hT);
+                z[3] = Vector3d.Dot(vf, i_hT);
+
+                z[4] = Vector3d.Dot(vf, prf) * rf.sqrMagnitude - Vector3d.Dot(rf, pvf) * vf.sqrMagnitude;
+                z[5] = Vector3d.Dot(vf, pvf) - vf.sqrMagnitude;
+            }
+            else
+            {
+                z[0] = z[1] = z[2] = z[3] = z[4] = z[5] = 0.0;
+            }
+        }
+
         public override void Bootstrap(double t0)
         {
+            int stageCount = numStages > 0 ? numStages : stages.Count;
+
             // build arcs off of ksp stages, with coasts
             List<Arc> arcs = new List<Arc>();
-            for(int i = 0; i < stages.Count; i++)
+            for(int i = 0; i < stageCount; i++)
             {
-                //if (i != 0)
-                    //arcs.Add(new Arc(new Stage(this, m0: stages[i].m0, isp: 0, thrust: 0)));
                 arcs.Add(new Arc(this, stage: stages[i], t0: t0));
             }
 
+            // bootstrap with infinite ISP upper stage
             arcs[arcs.Count-1].infinite = true;
 
             // allocate y0
@@ -129,7 +385,6 @@ namespace MuMech {
 
             // initialize overall burn time
             y0[0] = tgo_bar;
-            y0[1] = 0;
 
             UpdateY0(arcs);
 
@@ -137,26 +392,12 @@ namespace MuMech {
             yf = new double[arcs.Count*13];
             multipleIntegrate(y0, yf, arcs, initialize: true);
 
-            //Debug.Log("optimizer hT = " + hT.magnitude * r_scale * v_scale);
-            //Debug.Log("r_scale = " + r_scale);
-            //Debug.Log("v_scale = " + v_scale);
-            //Debug.Log("rTm = " + rTm * r_scale + " " + rTm);
-            //Debug.Log("vTm = " + vTm * v_scale + " " + vTm);
-
-            //for(int j = 0; j < y0.Length; j++)
-            //    Debug.Log("bootstrap - y0[" + j + "] = " + y0[j]);
-
-            //Debug.Log("running optimizer");
 
             if ( !runOptimizer(arcs) )
             {
-                //for(int k = 0; k < y0.Length; k++)
-                    //Debug.Log("failed - y0[" + k + "] = " + y0[k]);
                 Fatal("Target is unreachable even with infinite ISP");
                 return;
             }
-
-            //Debug.Log("optimizer done");
 
             Solution new_sol = new Solution(t_scale, v_scale, r_scale, t0);
             multipleIntegrate(y0, new_sol, arcs, 10);
@@ -165,16 +406,10 @@ namespace MuMech {
             {
                 if ( new_sol.tgo(new_sol.t0, i) < 1 )
                 {
-                    /* burn is less than one second, delete it */
+                    // burn is less than one second, delete it
                     RemoveArc(arcs, i, new_sol);
                 }
             }
-
-            //for(int k = 0; k < y0.Length; k++)
-            //   Debug.Log("y0[" + k + "] = " + y0[k]);
-
-            //Debug.Log("arcs.Count = " + arcs.Count);
-            //Debug.Log("segments.Count = " + new_sol.segments.Count);
 
             bool insertedCoast = false;
 
@@ -185,23 +420,43 @@ namespace MuMech {
             }
             arcs[arcs.Count-1].infinite = false;
 
-            //Debug.Log("running optimizer3");
+            // now that we're done with the infinite burn make sure the total burn time of the guess doesn't exceed the rocket.
+            double tot_bt_bar = 0.0;
+
+            for(int i = 0; i < arcs.Count; i++)
+            {
+                if (!arcs[i].coast)
+                {
+                    tot_bt_bar += arcs[i].max_bt_bar;
+                }
+            }
+
+            y0[0] = Math.Min(tot_bt_bar, y0[0]);
 
             if ( !runOptimizer(arcs) )
             {
-                Fatal("Target is unreachable");
-                //for(int k = 0; k < y0.Length; k++)
-                    //Debug.Log("failed - y0[" + k + "] = " + y0[k]);
-                //Debug.Log("optimizer failed6");
-                y0 = null;
-                return;
+                if ( insertedCoast )
+                {
+                    DebugLog("failed to converge with a coast, removing from the solution");
+
+                    RemoveArc(arcs, arcs.Count-2, new_sol);
+                    insertedCoast = false;
+
+                    if ( !runOptimizer(arcs) )
+                    {
+                        Fatal("Target is unreachable");
+                        y0 = null;
+                        return;
+                    }
+
+                }
+                else
+                {
+                    Fatal("Target is unreachable");
+                    y0 = null;
+                    return;
+                }
             }
-
-            //Debug.Log("optimizer done");
-
-
-            //for(int k = 0; k < y0.Length; k++)
-            //    Debug.Log("y0[" + k + "] = " + y0[k]);
 
             if (insertedCoast)
             {
@@ -228,27 +483,17 @@ namespace MuMech {
             new_sol = new Solution(t_scale, v_scale, r_scale, t0);
             multipleIntegrate(y0, new_sol, arcs, 10);
 
-            //for(int k = 0; k < y0.Length; k++)
-                //Debug.Log("new y0[" + k + "] = " + y0[k]);
-
             this.solution = new_sol;
-            //Debug.Log("done with bootstrap");
 
             yf = new double[arcs.Count*13];
             multipleIntegrate(y0, yf, arcs);
-
-            //for(int k = 0; k < yf.Length; k++)
-                //Debug.Log("new yf[" + k + "] = " + yf[k]);
-
         }
 
+        /*
         public override void Optimize(double t0)
         {
             base.Optimize(t0);
-            //Debug.Log("r_scale = " + r_scale);
-            //Debug.Log("v_scale = " + v_scale);
-            //Debug.Log("rTm = " + rTm * r_scale + " " + rTm);
-            //Debug.Log("vTm = " + vTm * v_scale + " " + vTm);
         }
+        */
     }
 }

--- a/MechJeb2/Pontryagin/TODO.md
+++ b/MechJeb2/Pontryagin/TODO.md
@@ -1,14 +1,6 @@
 
 ### TODO List
 
-# Critical bugs
-
-* UpdateY0 throwing on last staging event with Atlas V HLV
-
-# Critical items before merging to mainline MechJeb
-
-* Bring back g-limiter as a suboptimal hack
-
 # Critical node executor bugs
 
 * button to get back to old node executor behavior (plus porting old behavior on top of the refactor)
@@ -19,18 +11,18 @@
 
 # Near Term Minor Features
 
-* Luna-3's upper stage does not work well as an insertion stage (probably more dV stats issues?)
 * Fairing manager to better support auto-staging of fairings
 * Box to force the number of stages used in ascent guidance
 * Get "use RCS for ullage" and "prevent unstable ignitions" and "RSS/RO special handling" into the ascent guidance + node executor menus
 * "RSS/RO special handling" should leave the throttle on when the ascent guidance is disabled
 * Fix "launch to plane" to update the inclination field
+* wonky dV countdown
 
 # Near Term Medium Tweaks
 
-* full keplerian launch conditions including manual and target and free
-* full suborbital launch conditions maximizing velocity at a target altitude
-* RCS trim should use the optimizer starting conditions and stop the tick where the residual gets worse
+* fix bug where the solution keeps running during staging events when there's less than 2 second burn on the upper stage
+* transversality conditions maximizing velocity at a target altitude
+* optimize the time of the N-1 stage and have the Nth stage burn a fixed time and not be steerable.
 * Properly use solution to update guess for costate for the next iteration
 * Better reset behavior - copy old solution to PEG controller and use it even when the optimizer thread is hard reset
 


### PR DESCRIPTION
fixes and improvements to lots of stuff

most visible to users is all the fixes which particularly appeared with
early russian launches not coasting.

* initial guess of coast period is longer to avoid optimizer finding
negative solutions which also exist.
* when going from infinite upper stage to finite stage + coast the
overall burntime guess is clipped to the actual burntime of the rocket
to avoid starting the optimizer way past where the rocket has burned
down to zero due to exceeding the tau of the stage.
* r0 and v0 are now also hard pinned in prep for atmospheric
backpressure effects.
* the optimization function now requests the optimizer to stop when
the znorm is low enough (making it both faster and more stable and
allowing the minimum step-size to be decreased).
* a bunch of upstream code for other targeting conditions is included
here that is not yet used (but will help keep my merge conflicts down).