### PR TITLE
Display if avionics are disabled in Ascent Autopilot

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -509,6 +509,12 @@ namespace MuMech
                 {
                     GUILayout.Label("Autopilot status: " + autopilot.status);
                 }
+                if (core.DeactivateControl)
+                {
+                    GUIStyle s = new GUIStyle(GUI.skin.label);
+                    s.normal.textColor = Color.red;
+                    GUILayout.Label("CONTROL DISABLED (AVIONICS)", s);
+                }
             }
 
             if (!vessel.patchedConicsUnlocked() && ascentPathIdx != ascentType.PVG)


### PR DESCRIPTION
People are reporting issues with PVG which are actually that they don't
have enough avionics, so give them a big red hint something is wrong.
