### PR TITLE
Allocation Free Dormand Prince Integrator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ build: build/MechJeb2.dll
 build/%.dll: ${MECHJEBFILES}
 	mkdir -p build
 	${RESGEN2} -usesourcepath MechJeb2/Properties/Resources.resx build/Resources.resources
-	${MCS} -t:library -lib:"${MANAGED}" \
+	${MCS} -t:library -unsafe -lib:"${MANAGED}" \
 		-r:Assembly-CSharp,Assembly-CSharp-firstpass,UnityEngine,UnityEngine.UI,,UnityEngine.CoreModule,UnityEngine.IMGUIModule,UnityEngine.VehiclesModule,UnityEngine.PhysicsModule,UnityEngine.AnimationModule,UnityEngine.TextRenderingModule,UnityEngine.InputLegacyModule,UnityEngine.AssetBundleModule \
 		-out:$@ \
 		${MECHJEBFILES} \

--- a/MechJeb2/ODE.cs
+++ b/MechJeb2/ODE.cs
@@ -1,74 +1,115 @@
 using System;
 using System.Collections.Generic;
+//using UnityEngine;
 
 namespace MuMech
 {
-    public delegate void ODEFun(double[] y, double x, double[] dy, object o);
+    public delegate void ODEFun(Span<double> y, double x, Span<double> dy, int n, object o);
 
     class ODE
     {
-        public double[] y0;
-        public int n;
-        public double[] xtbl;
-        public double eps;
-        public double hstart;
-        public double hmin, hmax;
-        public int maxiter;  // since maxiter results in a throw it should be very high
-        public double[][] ytbl;
-        public List<double []> ylist;
-        public List<double> xlist;
-        public bool allvals;
 
-        // y0  - array of starting y0 values
-        // n   - dimensionality of the problem
-        // x   - array of x values to evaluate at
-        // eps - accuracy
-        // h   - starting step-size (can be zero)
-        public ODE(double[] y0, int n, double[] xtbl, double eps, double h, double hmin = 0, double hmax = 0, int maxiter = 0, bool allvals = false)
+        // constants for DP5(4)7FM
+        private const double a21 = 1.0/5.0;
+        private const double a31 = 3.0/40.0;
+        private const double a32 = 9.0/40.0;
+        private const double a41 = 44.0/45.0;
+        private const double a42 = -56.0/15.0;
+        private const double a43 = 32.0/9.0;
+        private const double a51 = 19372.0/6561.0;
+        private const double a52 = -25360.0/2187.0;
+        private const double a53 = 64448.0/6561.0;
+        private const double a54 = -212.0/729.0;
+        private const double a61 = 9017.0/3168.0;
+        private const double a62 = -355.0/33.0;
+        private const double a63 = 46732.0/5247.0;
+        private const double a64 = 49.0/176.0;
+        private const double a65 = -5103.0/18656.0;
+        private const double a71 = 35.0/384.0;
+        //private const double a72 = 0.0;
+        private const double a73 = 500.0/1113.0;
+        private const double a74 = 125.0/192.0;
+        private const double a75 = -2187.0/6784.0;
+        private const double a76 = 11.0/84.0;
+
+        private const double c2  = 1.0 / 5.0;
+        private const double c3  = 3.0 / 10.0;
+        private const double c4  = 4.0 / 5.0;
+        private const double c5  = 8.0 / 9.0;
+        private const double c6  = 1.0;
+        private const double c7  = 1.0;
+
+        private const double b1  = 35.0/384.0;
+        //private const double b2  = 0.0;
+        private const double b3  = 500.0/1113.0;
+        private const double b4  = 125.0/192.0;
+        private const double b5  = -2187.0/6784.0;
+        private const double b6  = 11.0/84.0;
+        private const double b7  = 0.0;
+
+        private const double b1p = 5179.0/57600.0;
+        //private const double b2p = 0.0;
+        private const double b3p = 7571.0/16695.0;
+        private const double b4p = 393.0/640.0;
+        private const double b5p = -92097.0/339200.0;
+        private const double b6p = 187.0/2100.0;
+        private const double b7p = 1.0/40.0;
+
+        // Dormand Prince 5(4)7FM ODE integrator (aka DOPRI5)
+        //
+        // We prefer this over Bogacki–Shampine in order to obtain the free 4th order interpolant.
+        //
+        // f       - the ODE function to integrate
+        // o       - object paramter which is passed through to the ODE function
+        // y0      - array of starting y0 values
+        // n       - dimensionality of the problem
+        // xtbl    - array of x values to evaluate at (2 minimum for start + end)
+        // ytbl    - output jagged array of y values at the x evaluation points (n x 2 minimum)
+        // eps     - accuracy
+        // h       - starting step-size (can be zero for automatic guess)
+        // xlist   - output list of all intermediate x values (user allocates, can be null or omitted)
+        // ylist   - output list of all intermediate y values (user allocates, can be null or omitted)
+        // hmin    - minimum h step (may be violated on the last step)
+        // hmax    - maximum h step
+        // maxiter - maximum number of steps
+        //
+        // ref: https://github.com/scipy/scipy/blob/master/scipy/integrate/dop/dopri5.f
+        //
+        unsafe public static void RKDP547FM(ODEFun f, object o, double[] y0, int n, Span<double> xtbl, Span<double[]> ytbl, double eps, double hstart, List<double> xlist = null, List<double []> ylist = null, double hmin = 0, double hmax = 0, int maxiter = 0)
         {
-            this.y0      = y0;
-            this.n       = n;
-            this.xtbl    = xtbl;
-            this.eps     = eps;
-            this.hstart  = h;
-            this.hmin    = hmin;
-            this.hmax    = hmax;
-            this.maxiter = maxiter;
-            this.allvals = allvals;
-            ylist = new List<double []>();
-            xlist = new List<double>();
-        }
+            // mono doesn't seem to support the `Span<double> k1 = stackalloc double[n];` C# 7.2 syntax yet, fix this when it does
+            double* k1p      = stackalloc double[n];
+            Span<double> k1  = new Span<double>(k1p, n);
+            double* k2p      = stackalloc double[n];
+            Span<double> k2  = new Span<double>(k2p, n);
+            double* k3p      = stackalloc double[n];
+            Span<double> k3  = new Span<double>(k3p, n);
+            double* k4p      = stackalloc double[n];
+            Span<double> k4  = new Span<double>(k4p, n);
+            double* k5p      = stackalloc double[n];
+            Span<double> k5  = new Span<double>(k5p, n);
+            double* k6p      = stackalloc double[n];
+            Span<double> k6  = new Span<double>(k6p, n);
+            double* k7p      = stackalloc double[n];
+            Span<double> k7  = new Span<double>(k7p, n);
+            // accumulator
+            double* ap       = stackalloc double[n];
+            Span<double> a   = new Span<double>(ap, n);
+            // error
+            double* errp     = stackalloc double[n];
+            Span<double> err = new Span<double>(errp, n);
+            double h         = hstart;
+            double x         = xtbl[0];
+            double* yp      = stackalloc double[n];
+            Span<double> y   = new Span<double>(yp, n);
 
-        // adds an array to another array, with a constant multiplier
-        private void rkadd(double[] aref, double[] ain, double c = 1.0)
-        {
-            if (aref.Length != ain.Length)
-                throw new ArgumentException("array lengths do not match");
+            if ( ylist != null && xlist != null )
+            {
+                ylist.Clear();
+                xlist.Clear();
+            }
 
-            for(int i = 0; i < aref.Length; i++)
-                aref[i] = aref[i] + c * ain[i];
-        }
-
-        public void RKF45(ODEFun f, object o)
-        {
-            double[] k1  = new double[n];
-            double[] k2  = new double[n];
-            double[] k3  = new double[n];
-            double[] k4  = new double[n];
-            double[] k5  = new double[n];
-            double[] k6  = new double[n];
-            double[] a   = new double[n]; // accumulator
-            double[] err = new double[n]; // error
-            double[] z   = new double[n]; // left as zeros
-            double h     = hstart;
-            double x     = xtbl[0];
-            double[] y   = new double[n];
-            double[] dy  = new double[n];
-            ytbl         = new double[n][]; // output
-            for(int i = 0; i < n; i++)
-                ytbl[i] = new double[xtbl.Length];
-
-            y0.CopyTo(y, 0);
+            y0.CopyTo(y);
 
             // auto-guess starting value of h based on smallest dx in xtbl
             if ( h == 0 )
@@ -84,23 +125,26 @@ namespace MuMech
             // xtbl controls the direcction of integration, the sign of h is not relevant
             h = Math.Sign(xtbl[1] - xtbl[0]) * Math.Abs(h);
 
-            bool at_hmin;
-            double niter = 0;
-
+            // copy initial conditions to ybtl output
             int j = 0;
-
-            // add the initial conditions
             for(int i = 0; i < n; i++)
             {
                 ytbl[i][j] = y[i];
             }
-
-            double[] ydup2 = new double[n];
-            y.CopyTo(ydup2, 0);
-            ylist.Add(ydup2);
-            xlist.Add(x);
-
             j++;
+
+            // copy initial conditions to full xlist/ylist output
+            if (xlist != null && ylist != null)
+            {
+                double[] ydup2 = new double[n];
+                y.CopyTo(ydup2);
+                ylist.Add(ydup2);
+                xlist.Add(x);
+            }
+
+            bool fsal = false;
+            bool at_hmin;
+            double niter = 0;
 
             while(j < xtbl.Length)
             {
@@ -121,79 +165,71 @@ namespace MuMech
                     if (Math.Abs(h) > Math.Abs(xf - x))
                         h = xf - x;
 
-                    z.CopyTo(k1, 0);
-                    f(y, x, dy, o);
-                    rkadd(k1, dy, h);
+                    if (fsal)
+                    {
+                        // FIXME: tricks to make this copy go away?
+                        for(int i = 0; i < n; i++)
+                            k1[i] = k7[i];
+                    }
+                    else
+                    {
+                        f(y, x, k1, n, o);
+                    }
 
-                    y.CopyTo(a, 0);
-                    rkadd(a, k1, 0.25);
-                    z.CopyTo(k2, 0);
-                    f(a, x+0.25*h, dy, o);
-                    rkadd(k2, dy, h);
+                    for(int i = 0; i < n; i++)
+                        a[i] = y[i] + h * ( a21 * k1[i] );
+                    f(a, x+c2*h, k2, n, o);
 
-                    y.CopyTo(a, 0);
-                    rkadd(a, k1, 3.0/32.0);
-                    rkadd(a, k2, 9.0/32.0);
-                    z.CopyTo(k3, 0);
-                    f(a, x+3*h/8, dy, o);
-                    rkadd(k3, dy, h);
+                    for(int i = 0; i < n; i++)
+                        a[i] = y[i] + h * ( a31 * k1[i] + a32 * k2[i] );
+                    f(a, x+c3*h, k3, n, o);
 
-                    y.CopyTo(a, 0);
-                    rkadd(a, k1, 1932.0/2197.0);
-                    rkadd(a, k2, -7200.0/2197.0);
-                    rkadd(a, k3, 7296.0/2197.0);
-                    z.CopyTo(k4, 0);
-                    f(a, x+12*h/13, dy, o);
-                    rkadd(k4, dy, h);
+                    for(int i = 0; i < n; i++)
+                        a[i] = y[i] + h * ( a41 * k1[i] + a42 * k2[i] + a43 * k3[i] );
+                    f(a, x+c4*h, k4, n, o);
 
-                    y.CopyTo(a, 0);
-                    rkadd(a, k1, 439.0/216.0);
-                    rkadd(a, k2, -8.0);
-                    rkadd(a, k3, 3680.0/513.0);
-                    rkadd(a, k4, -845.0/4104.0);
-                    z.CopyTo(k5, 0);
-                    f(a, x+h, dy, o);
-                    rkadd(k5, dy, h);
+                    for(int i = 0; i < n; i++)
+                        a[i] = y[i] + h * ( a51 * k1[i] + a52 * k2[i] + a53 * k3[i] + a54 * k4[i] );
+                    f(a, x+c5*h, k5, n, o);
 
-                    y.CopyTo(a, 0);
-                    rkadd(a, k1, -8.0/27.0);
-                    rkadd(a, k2, 2.0);
-                    rkadd(a, k3, -3544.0/2565.0);
-                    rkadd(a, k4, 1859.0/4104.0);
-                    rkadd(a, k5, -11.0/40.0);
-                    z.CopyTo(k6, 0);
-                    f(a, x+0.5*h, dy, o);
-                    rkadd(k6, dy, h);
+                    for(int i = 0; i < n; i++)
+                        a[i] = y[i] + h * ( a61 * k1[i] + a62 * k2[i] + a63 * k3[i] + a64 * k4[i] + a65 * k5[i] );
+                    f(a, x+c6*h, k6, n, o);
 
-                    z.CopyTo(err, 0);
-                    rkadd(err, k1, 1.0/360.0);
-                    rkadd(err, k3, -128.0/4275.0);
-                    rkadd(err, k4, -2197.0/75240.0);
-                    rkadd(err, k5, 1.0/50.0);
-                    rkadd(err, k6, 2.0/55.0);
+                    for(int i = 0; i < n; i++)
+                        a[i] = y[i] + h * ( a71 * k1[i] + a73 * k3[i] + a74 * k4[i] + a75 * k5[i] + a76 * k6[i] );
+                    f(a, x+c7*h, k7, n, o);
+
+                    for(int i = 0; i < n; i++)
+                        err[i] = k1[i] * (b1-b1p) + k3[i] * (b3-b3p) + k4[i] * (b4-b4p) + k5[i] * (b5-b5p) + k6[i] * (b6-b6p) + k7[i] * (b7-b7p);
 
                     double error = 0;
-                    for(int i = 0; i < err.Length; i++)
+                    for(int i = 0; i < n; i++)
                     {
-                        error = Math.Max(error, Math.Abs(err[i] / h));
+                        // FIXME: look at dopri fortran code to see how they generate this
+                        error = Math.Max(error, Math.Abs(err[i]));
                     }
-                    double s = Math.Pow(0.5*eps/error,0.25);
+                    double s = 0.84 * Math.Pow(eps / error, 1.0/5.0);
 
                     if (error < eps || at_hmin)
                     {
-                        rkadd(y, k1, 25.0/216.0);
-                        rkadd(y, k3, 1408.0/2565.0);
-                        rkadd(y, k4, 2197.0/4104.0);
-                        rkadd(y, k5, -0.2);
+                        fsal = true; // advancing so use k7 for k1 next time
+                        for(int i = 0; i < n; i++)
+                            y[i] = a[i]; // FSAL
                         x = x + h;
 
-                        if (allvals)
+                        if (xlist != null && ylist != null)
                         {
                             double[] ydup = new double[n];
-                            Array.Copy(y, ydup, n);
+                            for(int i = 0; i < n; i++)
+                                ydup[i] = y[i];
                             ylist.Add(ydup);
                             xlist.Add(x);
                         }
+                    }
+                    else
+                    {
+                        fsal = false; // rewinding so k7 is no longer valid
                     }
 
                     if (s < 0.1)
@@ -213,7 +249,7 @@ namespace MuMech
             }
         }
 
-        public static void centralForce(double[] y, double x, double[] dy, object o)
+        public static void centralForce(Span<double> y, double x, Span<double> dy, int n, object o)
         {
             double r2 = y[0] * y[0] + y[1] * y[1] + y[2] * y[2];
             double r1 = Math.Sqrt(r2);
@@ -231,22 +267,37 @@ namespace MuMech
 
         static void Main(string[] args)
         {
+            List<double []> ylist = new List<double []>();
+            List<double> xlist    = new List<double>();
             double[] y0 = { 1, 0, 0, 0, 1, 0 };
             double[] x = { 0 * 0.78539816339, 1 * 0.78539816339, 2 * 0.78539816339, 3 * 0.78539816339, 4 * 0.78539816339 };
-            ODE ode = new ODE(y0, 6, x, 1e-9, 0, allvals: true);
-            ode.RKF45(centralForce, null);
-            for(int i = 0; i < ode.xlist.Count; i++)
+            double[][] y = new double[][]
             {
-                Console.Write(ode.xlist[i]);
-                if (i != ode.xlist.Count - 1)
+                new double[5],
+                new double[5],
+                new double[5],
+                new double[5],
+                new double[5],
+                new double[5],
+            };
+
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            for(int i = 0; i < 100000; i++)
+                ODE.RKDP547FM(centralForce, null, y0, 6, x, y, 1e-9, 0, xlist: xlist, ylist: ylist);
+            watch.Stop();
+            Console.WriteLine("ms : {0:F6}", watch.ElapsedMilliseconds);
+            for(int i = 0; i < xlist.Count; i++)
+            {
+                Console.Write(xlist[i]);
+                if (i != xlist.Count - 1)
                     Console.Write(", ");
             }
             Console.Write("\n");
-            for(int i = 0; i < ode.ylist.Count; i++)
+            for(int i = 0; i < ylist.Count; i++)
             {
                 for(int j = 0; j < 6; j++)
                 {
-                    Console.Write(ode.ylist[i][j]);
+                    Console.Write(ylist[i][j]);
                     if (j != 5)
                         Console.Write(", ");
                 }


### PR DESCRIPTION
Replaces the RKF45 integrator I wrote with the Dormand-Prince method.

Should correctly implement FSAL.

Uses stackalloc and Span so should be entirely garbage-free (but
temporarily requires compiling with -unsafe because mono or unity
or something doesn't fully support C# 7.2 initialization of Span
structures to stackalloc regions).

Over 4x faster than the RKF45 implementation (most likely due to code
cleanup that I did, I doubt my test code exercised the garbage
collector, so those benefits are on top of this speedup)

Not using Bogacki–Shampine's method because I ultimately want the free
4th order interpolant out of this method, which BS5(4) does not offer.

TODO:

- support for events (for the ReentrySim)
- 4th order interpolant (to replace the crappy alglib interpolation
  I'm doing in PVG)

This will get it to be broadly equivalent to Matlab's ODE45.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>