### PR TITLE
limit PVG autostaging to stages in the solution

### DIFF
--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -518,6 +518,11 @@ namespace MuMech
             return status == PVGStatus.COASTING || status == PVGStatus.COASTING_STAGING;
         }
 
+        public bool isBurning()
+        {
+            return status == PVGStatus.BURNING || status == PVGStatus.BURNING_STAGING;
+        }
+
         public bool isStaging()
         {
             return status == PVGStatus.BURNING_STAGING || status == PVGStatus.COASTING_STAGING;
@@ -646,6 +651,9 @@ namespace MuMech
             }
             else
             {
+                if ( !isBurning() )
+                    ThrustOn();
+
                 if ( !isTerminalGuidance() )
                 {
                     if ((vesselState.time < last_stage_time + 4) || (vesselState.time < last_coasting_time + 4))
@@ -654,14 +662,7 @@ namespace MuMech
                         status = PVGStatus.BURNING;
                 }
 
-                if (core.staging.autostageLimitInternal > 0)
-                {
-                    core.staging.autostageLimitInternal = 0;
-                }
-                else
-                {
-                    ThrustOn();
-                }
+                core.staging.autostageLimitInternal = p.solution.terminal_burn_arc().ksp_stage;
             }
         }
 

--- a/MechJeb2/Pontryagin/PontryaginBase.cs
+++ b/MechJeb2/Pontryagin/PontryaginBase.cs
@@ -315,6 +315,21 @@ namespace MuMech {
             public List<Segment> segments = new List<Segment>();
             public List<Arc> arcs = new List<Arc>();
 
+            public Arc last_arc()
+            {
+                return arcs[arcs.Count-1];
+            }
+
+            public Arc terminal_burn_arc()
+            {
+                for(int k = arcs.Count-1; k >= 0; k--)
+                {
+                    if ( arcs[k].thrust > 0 )
+                        return arcs[k];
+                }
+                return arcs[0];
+            }
+
             // Arc from index
             public Arc arc(int n)
             {


### PR DESCRIPTION
this should prevent the edge case when doing hotstaging where
there's less than ~2 seconds or whatever in the insertion stage
left and the hotstaging code kicks in accidentally when PVG
doesn't need the next stage at all.

closes #1182 

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>