### PR TITLE
Advanced Transfer Planner Upgrade

### DIFF
--- a/Localization/en-us.cfg
+++ b/Localization/en-us.cfg
@@ -98,7 +98,8 @@ Localization
         #MechJeb_adv_computing = Computing:
 
         #MechJeb_adv_reset_button = Reset
-        #MechJeb_adv_captureburn = include capture burn
+        #MechJeb_adv_captureburn = Include capture burn
+        #MechJeb_adv_periapsis = Periapsis
         #MechJeb_adv_label1 = any time now
         #MechJeb_adv_label2 = Select:
         #MechJeb_adv_label3 = Departure in

--- a/Localization/zh-cn.cfg
+++ b/Localization/zh-cn.cfg
@@ -99,6 +99,7 @@ Localization
 
         #MechJeb_adv_reset_button = 重置
         #MechJeb_adv_captureburn = 计算捕获燃烧值
+        #MechJeb_adv_periapsis = Periapsis
         #MechJeb_adv_label1 = 现在任意时间
         #MechJeb_adv_label2 = 选择:
         #MechJeb_adv_label3 = 出发日期\u0020

--- a/MechJeb2/Brent.cs
+++ b/MechJeb2/Brent.cs
@@ -4,23 +4,24 @@ namespace MuMech {
     public delegate double BrentFun(double x, object o);
     public delegate double BrentFun2(double x, ReadOnlySpan<double> k1, ReadOnlySpan<double> k2, ReadOnlySpan<double> k3, ReadOnlySpan<double> k4, object o);
 
-    // Brent's rootfinding method
-    //
-    // Uses secant or inverse quadratic interpolation as appropriate, with a fallback to bisection if necessary.
-    //
-    // f - 1-dimensional BrentFun function to find the root on
-    // a - first guess of x value
-    // b - second guess of x value
-    // rtol - tolerance to solve to (1e-4 or something like that)
-    // x - output of solved value
-    // y - output of the function at the solved value (should be zero to rtol)
-    // o - object to be passed to BrentFun for extra data (may be null)
-    // maxiter - cap on iterations (will throw TimeoutException if exceeded)
-    // sign - select the positive or negative side of the root for return value
-    //
     public class Brent {
+        // Brent's rootfinding method
+        //
+        // Uses secant or inverse quadratic interpolation as appropriate, with a fallback to bisection if necessary.
+        //
+        // f - 1-dimensional BrentFun function to find the root on
+        // a - first guess of x value
+        // b - second guess of x value
+        // rtol - tolerance to solve to (1e-4 or something like that)
+        // x - output of solved value
+        // y - output of the function at the solved value (should be zero to rtol)
+        // o - object to be passed to BrentFun for extra data (may be null)
+        // maxiter - cap on iterations (will throw TimeoutException if exceeded)
+        // sign - select the positive or negative side of the root for return value
+        //
         // NOTE: please make any fixes to both versions of this routine
-        public static void Solve(BrentFun f, double a, double b, double rtol, out double x, out double y, object o, int maxiter = 50, int sign=0)
+        //
+        public static void Root(BrentFun f, double a, double b, double rtol, out double x, out double y, object o, int maxiter = 50, int sign=0)
         {
             double c = 0;
             double d = Double.MaxValue;
@@ -116,10 +117,12 @@ namespace MuMech {
             y = fb;
         }
 
-        // This is necessary due to the fact that we can't create closures over Span<T>'s in C# 7.2, if this gets fixed or
+        // This is necessary due to the fact that we can't create closures over Span<T>'s in C# 8.0, if this gets fixed or
         // someone can find a workaround then we could eliminate this unfortunate copypasta.
         //
-        public static void Solve(BrentFun2 f, double a, double b, double rtol, out double x, out double y, object o, ReadOnlySpan<double> k1, ReadOnlySpan<double> k2, ReadOnlySpan<double> k3, ReadOnlySpan<double> k4, int maxiter = 50, int sign = 0)
+        // (see my question at https://stackoverflow.com/questions/59605908/what-is-a-working-alternative-to-being-unable-to-pass-a-spant-into-lambda-expr )
+        //
+        public static void Root(BrentFun2 f, double a, double b, double rtol, out double x, out double y, object o, ReadOnlySpan<double> k1, ReadOnlySpan<double> k2, ReadOnlySpan<double> k3, ReadOnlySpan<double> k4, int maxiter = 50, int sign = 0)
         {
             double c = 0;
             double d = Double.MaxValue;
@@ -213,6 +216,199 @@ namespace MuMech {
 
             x = b;
             y = fb;
+        }
+
+        // Brent's 1-dimensional derivative-free local minimization method
+        //
+        // Uses golden section search and successive parabolic interpolation.
+        //
+        // f - 1-dimensional BrentFun function to find the minimum of
+        // a - first guess of x value
+        // b - second guess of x value
+        // rtol - tolerance to solve to (1e-4 or something like that)
+        // x - output of solved value
+        // y - output of the function at the solved value
+        // o - object to be passed to BrentFun for extra data (may be null)
+        // maxiter - cap on iterations (will throw TimeoutException if exceeded)
+        //
+        public static void Minimize(BrentFun f, double a, double b, double tol, out double x, out double y, object o, int maxiter = 50)
+        {
+            double c;
+            double d = 0;
+            double e;
+            double eps;
+            double fu;
+            double fv;
+            double fw;
+            double fx;
+            double m;
+            double p;
+            double q;
+            double r;
+            double sa;
+            double sb;
+            double t2;
+            double t;
+            double u;
+            double v;
+            double w;
+            int i = 0;
+
+            //
+            //  C is the square of the inverse of the golden ratio.
+            //
+            c = 0.5 * ( 3.0 - Math.Sqrt ( 5.0 ) );
+
+            eps = Math.Sqrt ( MuUtils.DBL_EPSILON );
+
+            sa = a;
+            sb = b;
+            x = sa + c * ( b - a );
+            w = x;
+            v = w;
+            e = 0.0;
+            fx = f(x, o);
+            fw = fx;
+            fv = fw;
+
+            while(true)
+            {
+                m = 0.5 * ( sa + sb ) ;
+                t = eps * Math.Abs ( x ) + tol;
+                t2 = 2.0 * t;
+                //
+                //  Check the stopping criterion.
+                //
+                if ( Math.Abs ( x - m ) <= t2 - 0.5 * ( sb - sa ) )
+                {
+                    break;
+                }
+                //
+                //  Fit a parabola.
+                //
+                r = 0.0;
+                q = r;
+                p = q;
+
+                if ( t < Math.Abs ( e ) )
+                {
+                    r = ( x - w ) * ( fx - fv );
+                    q = ( x - v ) * ( fx - fw );
+                    p = ( x - v ) * q - ( x - w ) * r;
+                    q = 2.0 * ( q - r );
+                    if ( 0.0 < q )
+                    {
+                        p = - p;
+                    }
+                    q = Math.Abs ( q );
+                    r = e;
+                    e = d;
+                }
+
+                if ( Math.Abs ( p ) < Math.Abs ( 0.5 * q * r ) &&
+                        q * ( sa - x ) < p &&
+                        p < q * ( sb - x ) )
+                {
+                    //
+                    //  Take the parabolic interpolation step.
+                    //
+                    d = p / q;
+                    u = x + d;
+                    //
+                    //  F must not be evaluated too close to A or B.
+                    //
+                    if ( ( u - sa ) < t2 || ( sb - u ) < t2 )
+                    {
+                        if ( x < m )
+                        {
+                            d = t;
+                        }
+                        else
+                        {
+                            d = - t;
+                        }
+                    }
+                }
+                //
+                //  A golden-section step.
+                //
+                else
+                {
+                    if ( x < m )
+                    {
+                        e = sb - x;
+                    }
+                    else
+                    {
+                        e = sa - x;
+                    }
+                    d = c * e;
+                }
+                //
+                //  F must not be evaluated too close to X.
+                //
+                if ( t <= Math.Abs ( d ) )
+                {
+                    u = x + d;
+                }
+                else if ( 0.0 < d )
+                {
+                    u = x + t;
+                }
+                else
+                {
+                    u = x - t;
+                }
+
+                fu = f(u, o);
+                //
+                //  Update A, B, V, W, and X.
+                //
+                if ( fu <= fx )
+                {
+                    if ( u < x )
+                    {
+                        sb = x;
+                    }
+                    else
+                    {
+                        sa = x;
+                    }
+                    v = w;
+                    fv = fw;
+                    w = x;
+                    fw = fx;
+                    x = u;
+                    fx = fu;
+                }
+                else
+                {
+                    if ( u < x )
+                    {
+                        sa = u;
+                    }
+                    else
+                    {
+                        sb = u;
+                    }
+
+                    if ( fu <= fw || w == x )
+                    {
+                        v = w;
+                        fv = fw;
+                        w = u;
+                        fw = fu;
+                    }
+                    else if ( fu <= fv || v == x || v == w )
+                    {
+                        v = u;
+                        fv = fu;
+                    }
+                }
+                if (i++ >= maxiter)
+                    throw new TimeoutException("Brent's minimization method: maximum iterations exceeded");
+            }
+            y = fx;
         }
     }
 }

--- a/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
+++ b/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
@@ -234,8 +234,8 @@ namespace MuMech
             }
             GUILayout.EndHorizontal();
 
-            GUILayout.Label(Localizer.Format("#MechJeb_adv_label3") + departure);//Departure in
-            GUILayout.Label(Localizer.Format("#MechJeb_adv_label4") + duration);//Transit duration
+            GUILayout.Label(Localizer.Format("#MechJeb_adv_label3") + " " + departure);//Departure in
+            GUILayout.Label(Localizer.Format("#MechJeb_adv_label4") + " " + duration);//Transit duration
         }
 
         public override void DoParametersGUI(Orbit o, double universalTime, MechJebModuleTargetController target)

--- a/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
+++ b/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
@@ -25,10 +25,14 @@ namespace MuMech
 
         bool includeCaptureBurn = false;
 
+        EditableDouble periapsisHeight = new EditableDouble(0);
+
         const double minSamplingStep = 12 * 3600;
 
         private Mode selectionMode = Mode.Porkchop;
         int windowWidth;
+
+        private CelestialBody lastTargetCelestial;
 
         TransferCalculator worker;
         private PlotArea plot;
@@ -113,14 +117,16 @@ namespace MuMech
             minTransferTime = 3600;
 
             maxDepartureTime = minDepartureTime + synodic_period * 1.5;
-            maxTransferTime = hohmann_transfer_time * 1.5;
-            maxArrivalTime.val = (synodic_period + hohmann_transfer_time) * 1.5;
+            maxTransferTime = hohmann_transfer_time * 2.0;
+            maxArrivalTime.val = synodic_period * 1.5 + hohmann_transfer_time * 2.0;
         }
 
         private bool layoutSkipped = false;
 
         private void DoPorkchopGui(Orbit o, double universalTime, MechJebModuleTargetController target)
         {
+            CelestialBody targetCelestial = target.Target as CelestialBody;
+
             // That mess is why you should not compute anything inside a GUI call
             // TODO : rewrite all that...
             if (worker == null)
@@ -212,6 +218,21 @@ namespace MuMech
 
             includeCaptureBurn = GUILayout.Toggle(includeCaptureBurn, Localizer.Format("#MechJeb_adv_captureburn"));//"include capture burn"
 
+            // fixup the default value of the periapsis if the target changes
+            if (targetCelestial != null && lastTargetCelestial != targetCelestial)
+            {
+                if (targetCelestial.atmosphere)
+                {
+                    periapsisHeight = targetCelestial.atmosphereDepth/1000 + 10;
+                }
+                else
+                {
+                    periapsisHeight = 100;
+                }
+            }
+
+            GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_adv_periapsis"), periapsisHeight, "km");
+
             GUILayout.BeginHorizontal();
             GUILayout.Label(Localizer.Format("#MechJeb_adv_label2"));//"Select: "
             GUILayout.FlexibleSpace();
@@ -236,6 +257,8 @@ namespace MuMech
 
             GUILayout.Label(Localizer.Format("#MechJeb_adv_label3") + " " + departure);//Departure in
             GUILayout.Label(Localizer.Format("#MechJeb_adv_label4") + " " + duration);//Transit duration
+
+            lastTargetCelestial = targetCelestial;
         }
 
         public override void DoParametersGUI(Orbit o, double universalTime, MechJebModuleTargetController target)
@@ -287,32 +310,29 @@ namespace MuMech
                 throw new OperationException(Localizer.Format("#MechJeb_adv_Exception2"));//Started computation
             }
 
-            List<ManeuverParameters> NodeList = new List<ManeuverParameters>();
-
             if (worker.arrivalDate < 0 )
             {
                 throw new OperationException(Localizer.Format("#MechJeb_adv_Exception3"));//Computation failed
             }
+
+            double target_PeR = lastTargetCelestial.Radius + periapsisHeight * 1000;
+
             if (selectionMode == Mode.Porkchop)
             {
                 if (plot == null || plot.selectedPoint == null)
                     throw new OperationException(Localizer.Format("#MechJeb_adv_Exception4"));//Invalid point selected.
-                NodeList.Add( worker.OptimizeEjection(
+                return worker.OptimizeEjection(
                     worker.DateFromIndex(plot.selectedPoint[0]),
                     o, worker.destinationOrbit, target.Target as CelestialBody,
                     worker.DateFromIndex(plot.selectedPoint[0]) + worker.DurationFromIndex(plot.selectedPoint[1]),
-                    UT)
-                        );
-                return NodeList;
+                    UT, target_PeR, includeCaptureBurn);
             }
 
-            NodeList.Add( worker.OptimizeEjection(
+            return worker.OptimizeEjection(
                     worker.DateFromIndex(worker.bestDate),
                     o, worker.destinationOrbit, target.Target as CelestialBody,
                     worker.DateFromIndex(worker.bestDate) + worker.DurationFromIndex(worker.bestDuration),
-                    UT)
-                    );
-            return NodeList;
+                    UT, target_PeR, includeCaptureBurn);
         }
     }
 }

--- a/MechJeb2/Maneuver/PlotArea.cs
+++ b/MechJeb2/Maneuver/PlotArea.cs
@@ -3,171 +3,181 @@ using UnityEngine;
 
 namespace MuMech
 {
-	public class PlotArea
-	{
-		public delegate void AreaChanged(double minx, double maxx, double miny, double maxy);
+    public class PlotArea
+    {
+        public delegate void AreaChanged(double minx, double maxx, double miny, double maxy);
 
-		static GUIStyle selectionStyle;
+        static GUIStyle selectionStyle;
 
-		public bool draggable = true;
+        public bool draggable = true;
 
-		public int[] hoveredPoint;
-		public int[] selectedPoint;
+        public int[] hoveredPoint;
+        public int[] selectedPoint;
 
-		private bool mouseDown;
+        private bool mouseDown;
 
-		private double minx;
-		private double maxx;
-		private double miny;
-		private double maxy;
+        private double minx;
+        private double maxx;
+        private double miny;
+        private double maxy;
 
-		private Texture2D texture;
+        private Texture2D texture;
 
-		private AreaChanged callback;
+        private AreaChanged callback;
 
-		public PlotArea (double minx, double maxx, double miny, double maxy, Texture2D texture, AreaChanged callback)
-		{
-			this.minx = minx;
-			this.maxx = maxx;
-			this.miny = miny;
-			this.maxy = maxy;
-			this.texture = texture;
-			this.callback = callback;
-		}
+        public PlotArea (double minx, double maxx, double miny, double maxy, Texture2D texture, AreaChanged callback)
+        {
+            this.minx = minx;
+            this.maxx = maxx;
+            this.miny = miny;
+            this.maxy = maxy;
+            this.texture = texture;
+            this.callback = callback;
+        }
 
+        static PlotArea()
+        {
+            selectionStyle = new GUIStyle();
+            Texture2D background = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            background.SetPixel(0,0, new Color(0, 0, 1, 0.3f));
+            background.Apply();
+            selectionStyle.normal.background = background;
+        }
 
-		static PlotArea()
-		{
-			selectionStyle = new GUIStyle();
-			Texture2D background = new Texture2D(1, 1, TextureFormat.RGBA32, false);
-			background.SetPixel(0,0, new Color(0, 0, 1, 0.3f));
-			background.Apply();
-			selectionStyle.normal.background = background;
-		}
-		
+        public double x(int index)
+        {
+            return minx + index * (maxx - minx) / texture.width;
+        }
+        public double y(int index)
+        {
+            return miny + index * (maxy - miny) / texture.height;
+        }
 
-		public double x(int index)
-		{
-			return minx + index * (maxx - minx) / texture.width;
-		}
-		public double y(int index)
-		{
-			return miny + index * (maxy - miny) / texture.height;
-		}
+        public int[] lastHoveredPoint = null;
 
-		public void DoGUI()
-		{
-			GUILayout.Box(texture, GUIStyle.none, new GUILayoutOption[] { GUILayout.Width(texture.width), GUILayout.Height(texture.height)});
-			if (Event.current.type == EventType.Repaint)
-			{
-				hoveredPoint = null;
-				var rect = GUILayoutUtility.GetLastRect(); rect.x +=1; rect.y += 2;
-				Vector2 mouse = Event.current.mousePosition;
-				if (rect.Contains(mouse))
-				{
-					var pos = (mouse - rect.position);
-					hoveredPoint = new int[]{(int) pos.x, (int)(rect.height - pos.y - 1)};
-				}
-				else
-				{
-					mouseDown = false;
-				}
-				if (mouseDown)
-				{
-					GUI.Box(new Rect(rect.x + Math.Min(selectedPoint[0], hoveredPoint[0]),
-						rect.y + rect.height - Math.Max(selectedPoint[1], hoveredPoint[1]),
-						Math.Abs(selectedPoint[0] - hoveredPoint[0]),
-						Math.Abs(selectedPoint[1] - hoveredPoint[1])), "", selectionStyle);
-				}
-			}
+        private void zoomSelectionBox(int[] hoveredPoint)
+        {
+            mouseDown = false;
+            if (Math.Abs(selectedPoint[0] - hoveredPoint[0]) > 5 &&
+                    Math.Abs(selectedPoint[1] - hoveredPoint[1]) > 5)
+            {
+                callback(
+                        x(Math.Min(selectedPoint[0], hoveredPoint[0])),
+                        x(Math.Max(selectedPoint[0], hoveredPoint[0])),
+                        y(Math.Min(selectedPoint[1], hoveredPoint[1])),
+                        y(Math.Max(selectedPoint[1], hoveredPoint[1]))
+                        );
+            }
+        }
 
-			draggable = hoveredPoint == null;
-			if (hoveredPoint != null)
-			{
-				switch (Event.current.type)
-				{
-				case EventType.MouseDown:
-					if (Event.current.button == 0)
-					{
-						mouseDown = true;
-						selectedPoint = hoveredPoint;
-					}
-					break;
-				case EventType.MouseUp:
-					if (Event.current.button == 0 && mouseDown)
-					{
-						mouseDown = false;
-						if (Math.Abs(selectedPoint[0] - hoveredPoint[0]) > 5 &&
-							Math.Abs(selectedPoint[1] - hoveredPoint[1]) > 5)
-						{
-							callback(
-								x(Math.Min(selectedPoint[0], hoveredPoint[0])),
-								x(Math.Max(selectedPoint[0], hoveredPoint[0])),
-								y(Math.Min(selectedPoint[1], hoveredPoint[1])),
-								y(Math.Max(selectedPoint[1], hoveredPoint[1]))
-							);
-						}
-					}
-					break;
-				case EventType.ScrollWheel:
-					if (Event.current.delta.y == 0)
-						break;
-					double lambda = Event.current.delta.y < 0 ? 0.7 : 1/0.7;
-					double deltax = maxx - minx;
-					double deltay = maxy - miny;
+        public void DoGUI()
+        {
+            GUILayout.Box(texture, GUIStyle.none, new GUILayoutOption[] { GUILayout.Width(texture.width), GUILayout.Height(texture.height)});
+            if (Event.current.type == EventType.Repaint)
+            {
+                hoveredPoint = null;
+                var rect = GUILayoutUtility.GetLastRect(); rect.x +=1; rect.y += 2;
+                Vector2 mouse = Event.current.mousePosition;
+                if (rect.Contains(mouse))
+                {
+                    var pos = (mouse - rect.position);
+                    hoveredPoint = new int[]{(int) pos.x, (int)(rect.height - pos.y - 1)};
+                }
+                else
+                {
+                    if (mouseDown && lastHoveredPoint != null)
+                    {
+                        // zoom the selection box if we leave the area when mouse is down
+                        zoomSelectionBox(lastHoveredPoint);
+                    }
+                }
+                if (mouseDown)
+                {
+                    GUI.Box(new Rect(rect.x + Math.Min(selectedPoint[0], hoveredPoint[0]),
+                                rect.y + rect.height - Math.Max(selectedPoint[1], hoveredPoint[1]),
+                                Math.Abs(selectedPoint[0] - hoveredPoint[0]),
+                                Math.Abs(selectedPoint[1] - hoveredPoint[1])), "", selectionStyle);
+                }
+            }
 
-					double newminx = x(hoveredPoint[0]) - hoveredPoint[0] * lambda * deltax / texture.width;
-					double newminy = y(hoveredPoint[1]) - hoveredPoint[1] * lambda * deltay / texture.height;
-					callback(
-						newminx,
-						newminx + lambda * deltax,
-						newminy,
-						newminy + lambda * deltay
-					);
-						
-					break;
-					case EventType.KeyUp:
-						ProcessKeys();
-						break;
-				}
-			}
-		}
+            draggable = hoveredPoint == null;
+            if (hoveredPoint != null)
+            {
+                switch (Event.current.type)
+                {
+                    case EventType.MouseDown:
+                        if (Event.current.button == 0)
+                        {
+                            mouseDown = true;
+                            selectedPoint = hoveredPoint;
+                        }
+                        break;
+                    case EventType.MouseUp:
+                        if (Event.current.button == 0 && mouseDown)
+                        {
+                            // zoom the selection box on mouseup
+                            zoomSelectionBox(hoveredPoint);
+                        }
+                        break;
+                    case EventType.ScrollWheel:
+                        if (Event.current.delta.y == 0)
+                            break;
+                        double lambda = Event.current.delta.y < 0 ? 0.7 : 1/0.7;
+                        double deltax = maxx - minx;
+                        double deltay = maxy - miny;
 
-		private void ProcessKeys()
-		{
-			KeyCode code = Event.current.keyCode;
-			int dirX = 0, dirY = 0;
+                        double newminx = x(hoveredPoint[0]) - hoveredPoint[0] * lambda * deltax / texture.width;
+                        double newminy = y(hoveredPoint[1]) - hoveredPoint[1] * lambda * deltay / texture.height;
+                        callback(
+                                newminx,
+                                newminx + lambda * deltax,
+                                newminy,
+                                newminy + lambda * deltay
+                                );
 
-			if (code == KeyCode.W || code == KeyCode.S ||
-				code == KeyCode.UpArrow || code == KeyCode.DownArrow)
-			{
-				dirY = code == KeyCode.W || code == KeyCode.UpArrow ? 1 : -1;
-			}
-			else if (code == KeyCode.A || code == KeyCode.D ||
-					 code == KeyCode.LeftArrow || code == KeyCode.RightArrow)
-			{
-				dirX = code == KeyCode.D || code == KeyCode.RightArrow ? 1 : -1;
-			}
+                        break;
+                    case EventType.KeyUp:
+                        ProcessKeys();
+                        break;
+                }
+            }
+            lastHoveredPoint = hoveredPoint;
+        }
 
-			if (dirX != 0 || dirY != 0)
-			{
-				double dx = maxx - minx;
-				double dy = maxy - miny;
+        private void ProcessKeys()
+        {
+            KeyCode code = Event.current.keyCode;
+            int dirX = 0, dirY = 0;
 
-				double moveDx = dx * 0.25 * dirX;
-				double moveDy = dy * 0.25 * dirY;
+            if (code == KeyCode.W || code == KeyCode.S ||
+                    code == KeyCode.UpArrow || code == KeyCode.DownArrow)
+            {
+                dirY = code == KeyCode.W || code == KeyCode.UpArrow ? 1 : -1;
+            }
+            else if (code == KeyCode.A || code == KeyCode.D ||
+                    code == KeyCode.LeftArrow || code == KeyCode.RightArrow)
+            {
+                dirX = code == KeyCode.D || code == KeyCode.RightArrow ? 1 : -1;
+            }
 
-				double newMinX = minx + moveDx;
-				double newMinY = miny + moveDy;
+            if (dirX != 0 || dirY != 0)
+            {
+                double dx = maxx - minx;
+                double dy = maxy - miny;
 
-				callback(
-					newMinX,
-					newMinX + dx,
-					newMinY,
-					newMinY + dy
-				);
-			}
-		}
-	}
+                double moveDx = dx * 0.25 * dirX;
+                double moveDy = dy * 0.25 * dirY;
+
+                double newMinX = minx + moveDx;
+                double newMinY = miny + moveDy;
+
+                callback(
+                        newMinX,
+                        newMinX + dx,
+                        newMinY,
+                        newMinY + dy
+                        );
+            }
+        }
+    }
 }
-

--- a/MechJeb2/Maneuver/Porkchop.cs
+++ b/MechJeb2/Maneuver/Porkchop.cs
@@ -5,42 +5,42 @@ using UnityEngine;
 
 namespace MuMech
 {
-	public class Porkchop
-	{
-		public static void RefreshTexture(double[,] nodes, Texture2D texture)
-		{
-			Gradient colours = new Gradient();
-			var colourKeys = new GradientColorKey[6];
-			colourKeys[0].color = new Color(0.25f, 0.25f, 1.0f);
-			colourKeys[0].time = 0.0f;
-			colourKeys[1].color = new Color(0.5f, 0.5f, 1.0f);
-			colourKeys[1].time = 0.01f;
-			colourKeys[2].color = new Color(0.5f, 1.0f, 1.0f);
-			colourKeys[2].time = 0.25f;
-			colourKeys[3].color = new Color(0.5f, 1.0f, 0.5f);
-			colourKeys[3].time = 0.5f;
-			colourKeys[4].color = new Color(1.0f, 1.0f, 0.5f);
-			colourKeys[4].time = 0.75f;
-			colourKeys[5].color = new Color(1.0f, 0.5f, 0.5f);
-			colourKeys[5].time = 1.0f;
+    public class Porkchop
+    {
+        public static void RefreshTexture(double[,] nodes, Texture2D texture)
+        {
+            Gradient colours = new Gradient();
+            var colourKeys = new GradientColorKey[6];
+            colourKeys[0].color = new Color(0.25f, 0.25f, 1.0f);
+            colourKeys[0].time = 0.0f;
+            colourKeys[1].color = new Color(0.5f, 0.5f, 1.0f);
+            colourKeys[1].time = 0.01f;
+            colourKeys[2].color = new Color(0.5f, 1.0f, 1.0f);
+            colourKeys[2].time = 0.25f;
+            colourKeys[3].color = new Color(0.5f, 1.0f, 0.5f);
+            colourKeys[3].time = 0.5f;
+            colourKeys[4].color = new Color(1.0f, 1.0f, 0.5f);
+            colourKeys[4].time = 0.75f;
+            colourKeys[5].color = new Color(1.0f, 0.5f, 0.5f);
+            colourKeys[5].time = 1.0f;
 
-			var alphaKeys = new GradientAlphaKey[2];
-			alphaKeys[0].alpha = 1.0f;
-			alphaKeys[0].time = 0.0f;
-			alphaKeys[1].alpha = 1.0f;
-			alphaKeys[1].time = 1.0f;
+            var alphaKeys = new GradientAlphaKey[2];
+            alphaKeys[0].alpha = 1.0f;
+            alphaKeys[0].time = 0.0f;
+            alphaKeys[1].alpha = 1.0f;
+            alphaKeys[1].time = 1.0f;
 
-			colours.SetKeys(colourKeys, alphaKeys);
+            colours.SetKeys(colourKeys, alphaKeys);
 
             int width = nodes.GetLength(0);
             int height = nodes.GetLength(1);
 
             double DVminsqr = double.MaxValue;
-			double DVmaxsqr = double.MinValue;
-			for (int i = 0; i < width; i++)
-			{
-				for (int j = 0; j < height; j++)
-				{
+            double DVmaxsqr = double.MinValue;
+            for (int i = 0; i < width; i++)
+            {
+                for (int j = 0; j < height; j++)
+                {
                     double DVsqr = nodes[i, j] * nodes[i, j];
                     if (DVsqr < DVminsqr)
                     {
@@ -48,27 +48,27 @@ namespace MuMech
                     }
 
                     DVmaxsqr = Math.Max(DVmaxsqr, nodes[i, j] * nodes[i, j]);
-				}
-			}
+                }
+            }
 
-			double logDVminsqr = Math.Log(DVminsqr);
-			double logDVmaxsqr = Math.Min(Math.Log(DVmaxsqr), logDVminsqr + 4);
+            double logDVminsqr = Math.Log(DVminsqr);
+            double logDVmaxsqr = Math.Min(Math.Log(DVmaxsqr), logDVminsqr + 4);
 
-			for (int i = 0; i < width; i++)
-			{
-				for (int j = 0; j < height; j++)
-				{
+            for (int i = 0; i < width; i++)
+            {
+                for (int j = 0; j < height; j++)
+                {
                     double lambda = (Math.Log(nodes[i, j] * nodes[i, j]) - logDVminsqr) / (logDVmaxsqr - logDVminsqr);
                     texture.SetPixel(i, j, colours.Evaluate((float)lambda));
-				}
-			}
+                }
+            }
 
-			texture.Apply();
+            texture.Apply();
 
 #if DEBUG
-			string dir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-			System.IO.File.WriteAllBytes(dir + "/Porkchop.png", texture.EncodeToPNG());
+            string dir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            System.IO.File.WriteAllBytes(dir + "/Porkchop.png", texture.EncodeToPNG());
 #endif
-		}
-	}
+        }
+    }
 }

--- a/MechJeb2/Maneuver/TransferCalculator.cs
+++ b/MechJeb2/Maneuver/TransferCalculator.cs
@@ -39,8 +39,6 @@ namespace MuMech
 
         public double minDV;
 
-        private static readonly PatchedConics.SolverParameters solverParameters = new PatchedConics.SolverParameters();
-
         public TransferCalculator(
                 Orbit o, Orbit target,
                 double min_departure_time,
@@ -125,7 +123,7 @@ namespace MuMech
 
             exitDV = V1 - V1_0;
             captureDV = V2_1 - V2;
-       }
+        }
 
         void ComputeDeltaV(object args)
         {
@@ -275,7 +273,7 @@ namespace MuMech
         }
 
         double AngleAboutAxis(Vector3d v1, Vector3d v2, Vector3d axis)
-        {
+                    {
             axis.Normalize();
 
             v1 = (v1 - Vector3d.Dot(axis, v1) * axis).normalized;
@@ -286,164 +284,56 @@ namespace MuMech
 
         public ManeuverParameters ComputeEjectionManeuver(Vector3d exit_velocity, Orbit initial_orbit, double UT_0)
         {
-            double GM = initial_orbit.referenceBody.gravParameter;
-            double C3 = exit_velocity.sqrMagnitude;
-            double Mh = initial_orbit.referenceBody.sphereOfInfluence;
-            double Rpe = initial_orbit.semiMajorAxis;
+                Vector3d r0;
+                Vector3d v0;
+                Vector3d vneg = new Vector3d();
+                Vector3d vpos = new Vector3d();
+                Vector3d r = new Vector3d();
+                double dt = 0;
 
-            double isma = 2 / Mh - C3 / GM; //inverted Semi-major Axis, will work for parabolic orbit
-            double ecc = 1.0 - Rpe * isma;
+                // get our reference position on the orbit
+                initial_orbit.GetOrbitalStateVectorsAtUT(UT_0, out r0, out v0);
 
-            //double vstart = Math.Sqrt(GM * (2 / Rpe - isma)); //{ total start boost}
-            //double slat = Rpe * Rpe * vstart * vstart / GM;
+                // analytic solution for paring orbit ejection to hyperbolic v-infinity
+                SpaceMath.singleImpulseHyperbolicBurn(initial_orbit.referenceBody.gravParameter, r0, v0, exit_velocity, ref vneg, ref vpos, ref r, ref dt);
 
-            //the problem here should be R for circular orbit instead of Rpe
-            double slat = 2 * Rpe - isma * Rpe * Rpe; //but we don't know start point (yet) in elliptic orbit
-
-            double theta = Math.Acos((slat / Mh - 1) / ecc);
-
-
-            /*
-            //old way infinity hyperbolic:
-            //problems: it's not necessary hyperbolic (in case of low speed exit_velocity),
-            //and exit_velocity appears not infinite far from celestial body, but only sphereOfInfluence far
-            //i.e. Mh in previous statements(theta, isma) is not infinity!
-
-            double sma = -GM / C3;
-
-            double ecc = 1 - Rpe / sma;
-            double theta = Math.Acos(-1 / ecc);
-
-*/
-            Vector3d intersect_1;
-            Vector3d intersect_2;
-
-            // intersect_1 is the optimal position on the orbit assuming the orbit is circular and the sphere of influence is infinite
-            IntersectConePlane(exit_velocity, theta, initial_orbit.h, out intersect_1, out intersect_2);
-
-            Vector3d eccvec = initial_orbit.GetEccVector();
-
-            double true_anomaly = AngleAboutAxis(eccvec, intersect_1, initial_orbit.h);
-            // GetMeanAnomalyAtTrueAnomaly expects degrees and returns radians
-            double mean_anomaly = initial_orbit.GetMeanAnomalyAtTrueAnomaly(true_anomaly * UtilMath.Rad2Deg);
-
-            double delta_mean_anomaly = MuUtils.ClampRadiansPi(mean_anomaly - initial_orbit.MeanAnomalyAtUT(UT_0));
-
-            double UT = UT_0 + delta_mean_anomaly / initial_orbit.MeanMotion();
-
-            Vector3d V_0 = initial_orbit.getOrbitalVelocityAtUT(UT);
-            Vector3d pos = initial_orbit.getRelativePositionAtUT(UT);
-
-            double final_vel = Math.Sqrt(C3 + 2 * GM / pos.magnitude);
-
-            Vector3d x = pos.normalized;
-            Vector3d z = Vector3d.Cross(x, exit_velocity).normalized;
-            Vector3d y = Vector3d.Cross(z, x);
-
-            theta = Math.PI / 2;
-            double dtheta = 0.001;
-            Orbit sample = new Orbit();
-
-            double theta_err = double.MaxValue;
-
-            for (int iteration = 0 ; iteration < 50 ; ++iteration)
-            {
-                Vector3d V_1 = final_vel * (Math.Cos(theta) * x + Math.Sin(theta) * y);
-                sample.UpdateFromStateVectors(pos, V_1, initial_orbit.referenceBody, UT);
-                theta_err = AngleAboutAxis(exit_velocity, sample.getOrbitalVelocityAtUT(OrbitExtensions.NextTimeOfRadius(sample, UT, sample.referenceBody.sphereOfInfluence)), z);
-                if (double.IsNaN(theta_err))
-                    return null;
-                if (Math.Abs(theta_err) <= 0.1 * UtilMath.Deg2Rad)
-                    return new ManeuverParameters((V_1 - V_0).xzy, UT);
-
-                V_1 = final_vel * (Math.Cos(theta + dtheta) * x + Math.Sin(theta + dtheta) * y);
-                sample.UpdateFromStateVectors(pos, V_1, initial_orbit.referenceBody, UT);
-                double theta_err_2 = AngleAboutAxis(exit_velocity, sample.getOrbitalVelocityAtUT(OrbitExtensions.NextTimeOfRadius(sample, UT, sample.referenceBody.sphereOfInfluence)), z);
-
-                V_1 = final_vel * (Math.Cos(theta - dtheta) * x + Math.Sin(theta - dtheta) * y);
-                sample.UpdateFromStateVectors(pos, V_1, initial_orbit.referenceBody, UT);
-                double theta_err_3 = AngleAboutAxis(exit_velocity, sample.getOrbitalVelocityAtUT(OrbitExtensions.NextTimeOfRadius(sample, UT, sample.referenceBody.sphereOfInfluence)), z);
-
-                double derr = MuUtils.ClampRadiansPi(theta_err_2 - theta_err_3) / (2 * dtheta);
-
-                theta = MuUtils.ClampRadiansTwoPi(theta - theta_err / derr);
-
-                // if theta > pi, replace with 2pi - theta, the function ejection_angle=f(theta) is symmetrc wrt theta=pi
-                if (theta > Math.PI)
-                    theta = 2 * Math.PI - theta;
-            }
-
-            return null;
+                return new ManeuverParameters((vpos - vneg).xzy, UT_0 + dt);
         }
 
-        class OptimizerData
+        void TargetObjectiveFunction(double[] x, double[] fi, object obj, Orbit initial_orbit, CelestialBody target, double UT_arrival, double target_PeR, ref bool failed, ref double PeR)
         {
-            public CelestialBody target_body;
-            public Orbit initial_orbit;
-            public Orbit target_orbit;
-            public double UT_arrival;
-            public bool failed;
-        }
-
-        void DistanceToTarget(double[] x, double[] fi, object obj)
-        {
-            OptimizerData data = (OptimizerData)obj;
-
             double t = x[3];
             Vector3d DV = new Vector3d(x[0], x[1], x[2]);
 
-            Orbit orbit = new Orbit();
-            orbit.UpdateFromStateVectors(data.initial_orbit.getRelativePositionAtUT(t), data.initial_orbit.getOrbitalVelocityAtUT(t) + DV.xzy, data.initial_orbit.referenceBody, t);
-            orbit.StartUT = t;
-            orbit.EndUT = orbit.eccentricity >= 1.0 ? orbit.period : t + orbit.period;
-            Orbit next_orbit = new Orbit();
-            PatchedConics.CalculatePatch(orbit, next_orbit, t, solverParameters, null);
+            Orbit orbit;
+            OrbitalManeuverCalculator.PatchedConicInterceptBody(initial_orbit, target, DV, t, UT_arrival, out orbit);
 
-            while(true)
+            Vector3d err = orbit.getTruePositionAtUT(UT_arrival) - target.orbit.getTruePositionAtUT(UT_arrival);
+
+            fi[0] = err.x;
+            fi[1] = err.y;
+            fi[2] = err.z;
+
+            /*
+            fi[0] = 0.0;
+
+            if (orbit.referenceBody == target)
             {
-                if (orbit.referenceBody == data.target_body)
-                {
-                    if ( orbit.PeR < 100000 )
-                    {
-                        fi[0] = DV.x;
-                        fi[1] = DV.y;
-                        fi[2] = DV.z;
-                    }
-                    else
-                    {
-                        Vector3d err = orbit.getRelativePositionFromTrueAnomaly(0);
-                        fi[0] = err.x;
-                        fi[1] = err.y;
-                        fi[2] = err.z;
-                    }
-                    data.failed = false;  /* we intersected at some point with the target body SOI */
-
-                    return;
-                }
-                else if (orbit.EndUT > data.UT_arrival)
-                {
-                    Vector3d err;
-                    if ( orbit.referenceBody == data.target_orbit.referenceBody )
-                    {
-                        err = orbit.getRelativePositionAtUT(data.UT_arrival) - data.target_orbit.getRelativePositionAtUT(data.UT_arrival);
-                    }
-                    else
-                    {
-                        err = orbit.getTruePositionAtUT(data.UT_arrival) - data.target_orbit.getTruePositionAtUT(data.UT_arrival);
-                    }
-
-                    fi[0] = err.x;
-                    fi[1] = err.y;
-                    fi[2] = err.z;
-
-                    return;
-                }
-
-                Orbit temp = orbit;
-                orbit = next_orbit;
-                next_orbit = temp;
-                PatchedConics.CalculatePatch(orbit, next_orbit, orbit.StartUT, solverParameters, null);
+                double miss = ( orbit.PeR - target_PeR );
+                fi[0] += miss * miss;
+                failed = false;  // we intersected at some point with the target body SOI
+                PeR = orbit.PeR;
             }
+            else
+            {
+                double err = ( orbit.getTruePositionAtUT(UT_arrival) - target.orbit.getTruePositionAtUT(UT_arrival) ).magnitude;
+                fi[0] += err * err;
+                failed = true;  // we did not intersect the target body SOI
+                PeR = ( orbit.getTruePositionAtUT(UT_arrival) - target.orbit.getTruePositionAtUT(UT_arrival) ).magnitude;
+            }
+            Debug.Log("  PeR = " + PeR);
+            fi[0] += DV.sqrMagnitude / 1000;
+            */
         }
 
         public ManeuverParameters OptimizeEjection(double UT_transfer, Orbit initial_orbit, Orbit target, CelestialBody target_body, double UT_arrival, double earliest_UT)
@@ -452,49 +342,70 @@ namespace MuMech
 
             while(true)
             {
+                const double DIFFSTEP = 1e-6;
+                const double EPSX = 1e-9;
+                const int MAXITS = 1000;
+
                 alglib.minlmstate state;
                 alglib.minlmreport rep;
 
-                double[] x = new double[5];
-                double[] scale = new double[5];
+                double[] x = new double[4];
+                double[] scale = new double[4];
 
                 Vector3d exitDV, captureDV;
                 CalcLambertDVs(UT_transfer, UT_arrival - UT_transfer, out exitDV, out captureDV);
 
-                var maneuver = ComputeEjectionManeuver(exitDV, origin, UT_transfer);
+                Orbit source = initial_orbit.referenceBody.orbit; // helicentric orbit of the source planet
+
+                // helicentric transfer orbit
+                Orbit transfer_orbit = new Orbit();
+                transfer_orbit.UpdateFromStateVectors(source.getRelativePositionAtUT(UT_transfer), source.getOrbitalVelocityAtUT(UT_transfer) + exitDV, source.referenceBody, UT_transfer);
+
+                double UT_SOI_exit;
+                OrbitalManeuverCalculator.SOI_intercept(transfer_orbit, initial_orbit.referenceBody, UT_transfer, UT_arrival, out UT_SOI_exit);
+
+                // convert from heliocentric to body centered velocity
+                Vector3d Vsoi = transfer_orbit.getOrbitalVelocityAtUT(UT_SOI_exit) - initial_orbit.referenceBody.orbit.getOrbitalVelocityAtUT(UT_SOI_exit);
+
+                // using Vsoi works a better here than the Vinf from the heliocentric computation at UT_Transfer
+                ManeuverParameters maneuver = ComputeEjectionManeuver(Vsoi, initial_orbit, UT_transfer);
 
                 x[0] = maneuver.dV.x;
                 x[1] = maneuver.dV.y;
                 x[2] = maneuver.dV.z;
-                x[3] = maneuver.UT + N * initial_orbit.period;
+                x[3] = maneuver.UT;
 
-                scale[0] = scale[1] = scale[2] = maneuver.dV.magnitude;
+                scale[0] = scale[1] = scale[2] = 1000.0f;
                 scale[3] = initial_orbit.period;
 
-                OptimizerData data = new OptimizerData();
-                data.initial_orbit = initial_orbit;
-                data.target_orbit = target;
-                data.target_body = target_body;
-                data.UT_arrival = UT_arrival;
-                data.failed = true;
+                const int NCONSTRAINT = 3;
 
-                alglib.minlmcreatev(4, 3, x, 0.001, out state);
-                alglib.minlmsetcond(state, 0, 0);
+                double[] fi = new double[NCONSTRAINT];
+                bool failed = false;
+                double PeR = 0.0;
+
+                TargetObjectiveFunction(x, fi, null, initial_orbit, target_body, UT_arrival, 100000 + target_body.Radius, ref failed, ref PeR);
+                Debug.Log("failed = " + failed);
+                Debug.Log("PeR = " + PeR);
+
+                // now do the patched conic shooting
+                alglib.minlmcreatev(4, NCONSTRAINT, x, DIFFSTEP, out state);
+                alglib.minlmsetcond(state, EPSX, MAXITS);
                 alglib.minlmsetscale(state, scale);
-                alglib.minlmoptimize(state, DistanceToTarget, null, data);
+                alglib.minlmoptimize(state, (x, fi, obj) => TargetObjectiveFunction(x, fi, obj, initial_orbit, target_body, UT_arrival, 100000 + target_body.Radius, ref failed, ref PeR), null, null);
                 alglib.minlmresults(state, out x, out rep);
 
                 Debug.Log("Transfer calculator: termination type=" + rep.terminationtype);
                 Debug.Log("Transfer calculator: iteration count=" + rep.iterationscount);
 
                 // try again if we failed to intersect the target orbit
-                if ( data.failed )
+                if ( failed )
                 {
                     Debug.Log("Failed to intersect target orbit");
                     N++;
                 }
                 // try again in one orbit if the maneuver node is in the past
-                else if (x[3] < earliest_UT || data.failed)
+                else if (x[3] < earliest_UT || failed)
                 {
                     Debug.Log("Transfer calculator: maneuver is " + (earliest_UT - x[3]) + " s too early, trying again in " + initial_orbit.period + " s");
                     N++;
@@ -507,6 +418,7 @@ namespace MuMech
                 {
                     throw new OperationException("Ejection Optimization failed; try manual selection");
                 }
+                UT_transfer += initial_orbit.period;
             }
         }
     }

--- a/MechJeb2/MechJeb2.csproj
+++ b/MechJeb2/MechJeb2.csproj
@@ -208,6 +208,7 @@
     <Compile Include="ScriptsModule\MechJebModuleScriptActionsList.cs" />
     <Compile Include="ScriptsModule\MechJebModuleScriptCondition.cs" />
     <Compile Include="Shepperd.cs" />
+    <Compile Include="SpaceMath.cs" />
     <Compile Include="ToolbarWrapper.cs" />
     <Compile Include="UnityToolbag\Dispatcher\Dispatcher.cs" />
     <Compile Include="UnityToolbag\Future\Future.cs" />

--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -101,7 +101,9 @@ namespace MuMech
                     if (!createNode)
                         maneuverNodes.Last().RemoveSelf();
                     for (var i = 0; i < nodeList.Count; i++)
+                    {
                         vessel.PlaceManeuverNode(o, nodeList[i].dV, nodeList[i].UT);
+                    }
                 }
 
                 if (executingNode && core.node != null)

--- a/MechJeb2/MuUtils.cs
+++ b/MechJeb2/MuUtils.cs
@@ -10,7 +10,7 @@ namespace MuMech
 
         public const double DBL_EPSILON = 2.2204460492503131e-16;
 
-		public static float ResourceDensity(int type)
+        public static float ResourceDensity(int type)
         {
             return PartResourceLibrary.Instance.GetDefinition(type).density;
         }
@@ -187,12 +187,12 @@ namespace MuMech
             }
         }
 
-		public static IList<T> Swap<T>(this IList<T> list, int indexA, int indexB)
-		{
-			T tmp = list[indexA];
-			list[indexA] = list[indexB];
-			list[indexB] = tmp;
-			return list;
+        public static IList<T> Swap<T>(this IList<T> list, int indexA, int indexB)
+        {
+            T tmp = list[indexA];
+            list[indexA] = list[indexB];
+            list[indexB] = tmp;
+            return list;
         }
 
         public static void DrawLine(Texture2D tex, int x1, int y1, int x2, int y2, Color col)
@@ -536,17 +536,17 @@ namespace MuMech
         }
 
         public Matrix3x3f transpose()
-		{
-			Matrix3x3f ret = new Matrix3x3f();
-			for (int i = 0; i < 3; i++)
-			{
-				for (int j = 0; j < 3; j++)
-				{
-					ret.e[i, j] = e[j, i];
-				}
-			}
-			return ret;
-		}
+        {
+            Matrix3x3f ret = new Matrix3x3f();
+            for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; j < 3; j++)
+                {
+                    ret.e[i, j] = e[j, i];
+                }
+            }
+            return ret;
+        }
 
         public static Vector3d operator *(Matrix3x3f M, Vector3 v)
         {

--- a/MechJeb2/ODE.cs
+++ b/MechJeb2/ODE.cs
@@ -252,7 +252,7 @@ namespace MuMech
                             s = 1;
                             if (h_restart == 0)
                                 h_restart = h;
-                            Brent.Solve((newh, a1, a2, a3, a4, o2) => EvtWrapper(EvtFuns[evt], newh, x, a1, a2, x+h, a3, a4, n, o2), 0, h, 1e-15, out h, out _, o, y, k1, a, k7, sign: sign);
+                            Brent.Root((newh, a1, a2, a3, a4, o2) => EvtWrapper(EvtFuns[evt], newh, x, a1, a2, x+h, a3, a4, n, o2), 0, h, 1e-15, out h, out _, o, y, k1, a, k7, sign: sign);
                         }
                     }
                     else

--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using Smooth.Pools;
 
 namespace MuMech
 {
@@ -80,7 +81,7 @@ namespace MuMech
 
             BrentFun f = delegate(double testDeltaV, object ign) { return o.PerturbedOrbit(UT, testDeltaV * burnDirection).PeR - newPeR;  };
             double dV;
-            Brent.Solve(f, minDeltaV, maxDeltaV, 1e-8, out dV, out _, null);
+            Brent.Root(f, minDeltaV, maxDeltaV, 1e-8, out dV, out _, null);
 
             return dV * burnDirection;
         }
@@ -115,7 +116,7 @@ namespace MuMech
             // change of sign for hyperbolic orbits.
             BrentFun f = delegate(double testDeltaV, object ign) { return 1.0/o.PerturbedOrbit(UT, testDeltaV * burnDirection).ApR - 1.0/newApR;  };
             double dV;
-            Brent.Solve(f, minDeltaV, maxDeltaV, 1e-8, out dV, out _, null);
+            Brent.Root(f, minDeltaV, maxDeltaV, 1e-8, out dV, out _, null);
 
             return dV * burnDirection;
         }
@@ -182,23 +183,23 @@ namespace MuMech
             Vector3d deltaHorizontalVelocity;
 
             if ( vesselState.speedSurfaceHorizontal < 200 ) {
-              // at initial launch we have to head the direction the user specifies (90 north instead of -90 south).
-              // 200 m/s of surface velocity also defines a 'grace period' where someone can catch a rocket that they meant
-              // to launch at -90 and typed 90 into the inclination box fast after it started to initiate the turn.
-              // if the rocket gets outside of the 200 m/s surface velocity envelope, then there is no way to tell MJ to
-              // take a south travelling rocket and turn north or vice versa.
-              desiredHorizontalVelocity = desiredHorizontalVelocityOne;
-              deltaHorizontalVelocity = deltaHorizontalVelocityOne;
-            } else {
-              // now in order to get great circle tracks correct we pick the side which gives the lowest delta-V, which will get
-              // ground tracks that cross the maximum (or minimum) latitude of a great circle correct.
-              if ( deltaHorizontalVelocityOne.magnitude < deltaHorizontalVelocityTwo.magnitude ) {
+                // at initial launch we have to head the direction the user specifies (90 north instead of -90 south).
+                // 200 m/s of surface velocity also defines a 'grace period' where someone can catch a rocket that they meant
+                // to launch at -90 and typed 90 into the inclination box fast after it started to initiate the turn.
+                // if the rocket gets outside of the 200 m/s surface velocity envelope, then there is no way to tell MJ to
+                // take a south travelling rocket and turn north or vice versa.
                 desiredHorizontalVelocity = desiredHorizontalVelocityOne;
                 deltaHorizontalVelocity = deltaHorizontalVelocityOne;
-              }  else {
-                desiredHorizontalVelocity = desiredHorizontalVelocityTwo;
-                deltaHorizontalVelocity = deltaHorizontalVelocityTwo;
-              }
+            } else {
+                // now in order to get great circle tracks correct we pick the side which gives the lowest delta-V, which will get
+                // ground tracks that cross the maximum (or minimum) latitude of a great circle correct.
+                if ( deltaHorizontalVelocityOne.magnitude < deltaHorizontalVelocityTwo.magnitude ) {
+                    desiredHorizontalVelocity = desiredHorizontalVelocityOne;
+                    deltaHorizontalVelocity = deltaHorizontalVelocityOne;
+                }  else {
+                    desiredHorizontalVelocity = desiredHorizontalVelocityTwo;
+                    deltaHorizontalVelocity = deltaHorizontalVelocityTwo;
+                }
             }
 
             // if you circularize in one burn, towards the end deltaHorizontalVelocity will whip around, but we want to
@@ -351,7 +352,7 @@ namespace MuMech
                 DeltaVAndApsisPhaseAngleOfHohmannTransfer(o, target, testTime, out testApsisPhaseAngle);
                 return testApsisPhaseAngle;
             };
-            Brent.Solve(f, maxTime, minTime, 1e-8, out burnUT, out _, null);
+            Brent.Root(f, maxTime, minTime, 1e-8, out burnUT, out _, null);
 
             Vector3d burnDV = DeltaVAndApsisPhaseAngleOfHohmannTransfer(o, target, burnUT, out _);
 
@@ -1038,8 +1039,8 @@ namespace MuMech
             double long_diff_rad = UtilMath.Deg2Rad * (long_b - long_a);
 
             return UtilMath.Rad2Deg * Math.Atan2(Math.Sqrt(Math.Pow(Math.Cos(lat_b_rad) * Math.Sin(long_diff_rad), 2) +
-                Math.Pow(Math.Cos(lat_a_rad) * Math.Sin(lat_b_rad) - Math.Sin(lat_a_rad) * Math.Cos(lat_b_rad) * Math.Cos(long_diff_rad), 2)),
-                Math.Sin(lat_a_rad) * Math.Sin(lat_b_rad) + Math.Cos(lat_a_rad) * Math.Cos(lat_b_rad) * Math.Cos(long_diff_rad));
+                        Math.Pow(Math.Cos(lat_a_rad) * Math.Sin(lat_b_rad) - Math.Sin(lat_a_rad) * Math.Cos(lat_b_rad) * Math.Cos(long_diff_rad), 2)),
+                    Math.Sin(lat_a_rad) * Math.Sin(lat_b_rad) + Math.Cos(lat_a_rad) * Math.Cos(lat_b_rad) * Math.Cos(long_diff_rad));
         }
 
         // Compute an angular heading from point a to point b on a unit sphere
@@ -1053,8 +1054,8 @@ namespace MuMech
             double long_diff_rad = UtilMath.Deg2Rad * (long_b - long_a);
 
             return MuUtils.ClampDegrees360(180.0 / Math.PI * Math.Atan2(
-                Math.Sin(long_diff_rad),
-                Math.Cos(lat_a_rad) * Math.Tan(lat_b_rad) - Math.Sin(lat_a_rad) * Math.Cos(long_diff_rad)));
+                        Math.Sin(long_diff_rad),
+                        Math.Cos(lat_a_rad) * Math.Tan(lat_b_rad) - Math.Sin(lat_a_rad) * Math.Cos(long_diff_rad)));
         }
 
         //Computes the deltaV of the burn needed to set a given LAN at a given UT.
@@ -1120,7 +1121,7 @@ namespace MuMech
             // change of sign for hyperbolic orbits.
             BrentFun f = delegate(double testDeltaV, object ign) { return 1.0/o.PerturbedOrbit(UT, testDeltaV * burnDirection).semiMajorAxis - 1.0/newSMA;  };
             double dV;
-            Brent.Solve(f, minDeltaV, maxDeltaV, 1e-4, out dV, out _, null);
+            Brent.Root(f, minDeltaV, maxDeltaV, 1e-4, out dV, out _, null);
 
             return dV * burnDirection;
         }
@@ -1153,12 +1154,71 @@ namespace MuMech
             double target_sma = 0;
 
             while (oppositeRadius-o.referenceBody.Radius < o.referenceBody.timeWarpAltitudeLimits [4] && N < 20) {
-                    N++;
-                    double target_period = o.referenceBody.rotationPeriod * (LongitudeOffset / 360 + N);
-                    target_sma = Math.Pow ((o.referenceBody.gravParameter * target_period * target_period) / (4 * Math.PI * Math.PI), 1.0 / 3.0); // cube roo
-                    oppositeRadius = 2 * (target_sma) - burnRadius;
-                }
+                N++;
+                double target_period = o.referenceBody.rotationPeriod * (LongitudeOffset / 360 + N);
+                target_sma = Math.Pow ((o.referenceBody.gravParameter * target_period * target_period) / (4 * Math.PI * Math.PI), 1.0 / 3.0); // cube roo
+                oppositeRadius = 2 * (target_sma) - burnRadius;
+            }
             return DeltaVForSemiMajorAxis (o, UT, target_sma);
+        }
+
+        //
+        // Global OrbitPool for re-using Orbit objects
+        //
+
+        private static readonly Pool<Orbit> OrbitPool = new Pool<Orbit>(createOrbit, resetOrbit);
+        private static Orbit createOrbit() { return new Orbit(); }
+        private static void resetOrbit(Orbit o) { }
+
+        private static readonly PatchedConics.SolverParameters solverParameters = new PatchedConics.SolverParameters();
+
+        // Runs the PatchedConicSolver to do initial value "shooting" given an initial orbit, a maneuver dV and UT to execute, to a target Celestial's SOI
+        //
+        // initial   : initial parkig orbit
+        // target    : the Body whose SOI we are shooting towards
+        // dV        : the dV of the manuever off of the parking orbit
+        // burnUT    : the time of the maneuver off of the parking orbit
+        // arrivalUT : this is really more of an upper clamp on the simulation so that if we miss and never hit the body SOI it stops
+        // intercept : this is the final computed intercept orbit, it should be in the SOI of the target body, but if it never hits it then the
+        //             e.g. heliocentric orbit is returned instead, so the caller needs to check.
+        //
+        // FIXME: NREs when there's no next patch
+        // FIXME: duplicates code with OrbitExtensions.CalculateNextOrbit()
+        //
+        public static void PatchedConicInterceptBody(Orbit initial, CelestialBody target, Vector3d dV, double burnUT, double arrivalUT, out Orbit intercept)
+        {
+            Orbit orbit = OrbitPool.Borrow();
+            orbit.UpdateFromStateVectors(initial.getRelativePositionAtUT(burnUT), initial.getOrbitalVelocityAtUT(burnUT) + dV.xzy, initial.referenceBody, burnUT);
+            orbit.StartUT = burnUT;
+            orbit.EndUT = orbit.eccentricity >= 1.0 ? orbit.period : burnUT + orbit.period;
+            Orbit next_orbit = OrbitPool.Borrow();
+
+            PatchedConics.CalculatePatch(orbit, next_orbit, burnUT, solverParameters, null);
+
+            while( (orbit.referenceBody!=target) && (orbit.EndUT < arrivalUT) )
+            {
+                OrbitPool.Release(orbit);
+                orbit = next_orbit;
+                next_orbit = OrbitPool.Borrow();
+
+                PatchedConics.CalculatePatch(orbit, next_orbit, orbit.StartUT, solverParameters, null);
+            }
+            intercept = orbit;
+            intercept.UpdateFromOrbitAtUT(orbit, arrivalUT, orbit.referenceBody);
+            OrbitPool.Release(orbit);
+            OrbitPool.Release(next_orbit);
+        }
+
+        // Takes an e.g. heliocentric orbit and a target planet celestial and finds the time of the SOI intercept.
+        //
+        //
+        //
+        public static void SOI_intercept(Orbit transfer, CelestialBody target, double UT1, double UT2, out double UT)
+        {
+            if ( transfer.referenceBody != target.orbit.referenceBody )
+                throw new ArgumentException("[MechJeb] SOI_intercept: transfer orbit must be in the same SOI as the target celestial");
+            BrentFun f = delegate(double UT, object ign) { return ( transfer.getRelativePositionAtUT(UT) - target.orbit.getRelativePositionAtUT(UT) ).magnitude - target.sphereOfInfluence;  };
+            Brent.Root(f, UT1, UT2, 1e-4, out UT, out _, null);
         }
     }
 }

--- a/MechJeb2/SpaceMath.cs
+++ b/MechJeb2/SpaceMath.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace MuMech
+{
+    public static class SpaceMath
+    {
+        /// <summary>
+        /// Single impulse transfer from an ellipitical, non-coplanar parking orbit to an arbitrary hyperbolic v-infinity target.
+        ///
+        /// Ocampo, C., & Saudemont, R. R. (2010). Initial Trajectory Model for a Multi-Maneuver Moon-to-Earth Abort Sequence.
+        /// Journal of Guidance, Control, and Dynamics, 33(4), 1184–1194.
+        /// </summary>
+        ///
+        /// <param name="mu">Gravitational parameter of central body.</param>
+        /// <param name="r0">Reference position on the parking orbit.</param>
+        /// <param name="v0">Reference velocity on the parking orbit.</param>
+        /// <param name="v_inf">Target hyperbolic v-infinity vector.</param>
+        /// <param name="vneg">Velocity on the parking orbit before the burn.</param>
+        /// <param name="vpos">Velocity on the hyperboliic ejection orbit after the burn.</param>
+        /// <param name="r">Position of the burn.</param>
+        /// <param name="dt">Coasting time on the parking orbit from the reference to the burn.</param>
+        ///
+        public static void singleImpulseHyperbolicBurn(double mu, Vector3d r0, Vector3d v0, Vector3d v_inf,
+                ref Vector3d vneg, ref Vector3d vpos, ref Vector3d r, ref double dt)
+        {
+            // angular momentum of the parking orbit
+            Vector3d h0 = Vector3d.Cross(r0, v0);
+
+            // semi major axis of parking orbit
+            double a0 = 1.0 / (2.0 / r0.magnitude - v0.sqrMagnitude / mu);
+
+            // sma of hyperbolic ejection orbit
+            double af = - mu / v_inf.sqrMagnitude;
+
+            // parking orbit angular momentum unit
+            Vector3d h0_hat = h0/h0.magnitude;
+
+            // eccentricity vector of the parking orbit
+            Vector3d ecc = Vector3d.Cross(v0,h0)/mu - r0/r0.magnitude;
+
+            // eccentricity of the parking orbit.
+            double e0 = ecc.magnitude;
+
+            // semilatus rectum of parking orbit
+            double p0 = a0 * ( 1 - e0 * e0 );
+
+            // parking orbit periapsis position unit vector
+            Vector3d rp0_hat;
+            if ( Math.Abs(e0) > 1e-14 )
+                rp0_hat = ecc/e0;
+            else
+                rp0_hat = r0/r0.magnitude;
+
+            // parking orbit periapsis velocity unit vector
+            Vector3d vp0_hat = Vector3d.Cross(h0, rp0_hat);
+            vp0_hat = vp0_hat/vp0_hat.magnitude;
+
+            // direction of hyperbolic v-infinity vector
+            Vector3d v_inf_hat = v_inf/v_inf.magnitude;
+
+            // 3 cases for finding hf_hat
+            double dotp = Vector3d.Dot(h0_hat, v_inf_hat);
+            Vector3d hf_hat;
+            if ( dotp == 0 )
+            {
+                // zero plane change case
+                hf_hat = h0_hat;
+            }
+            else if ( Math.Abs(dotp) == 1 )
+            {
+                // 90 degree plane change case
+                hf_hat = Vector3d.Cross(rp0_hat, v_inf_hat);
+                hf_hat = hf_hat / hf_hat.magnitude;
+            }
+            else
+            {
+                // general case (also works for dotp = 0)
+                hf_hat = Vector3d.Cross(v_inf_hat, Vector3d.Cross(h0_hat, v_inf_hat));
+                hf_hat = hf_hat / hf_hat.magnitude;
+            }
+
+            // unit vector pointing at the position of the burn on the parking orbit
+            Vector3d r1_hat = Vector3d.Cross(v_inf_hat, hf_hat);
+            r1_hat = r1_hat/r1_hat.magnitude;
+
+            // true anomaly of r1 on the parking orbit
+            double nu_10 = Math.Sign(Vector3d.Dot(h0_hat, Vector3d.Cross(rp0_hat, r1_hat))) * Math.Acos(Vector3d.Dot(rp0_hat,r1_hat));
+
+            // length of the position vector of the burn on the parking orbit
+            double r1 = p0 / ( 1 + e0 * Math.Cos(nu_10) );
+
+            // position of the burn
+            r = r1 * r1_hat;
+
+            // constant
+            double k = - af / r1;
+
+            // eccentricity of the hyperbolic ejection orbit
+            double ef = Math.Sqrt(1 + 2*k*k + 2*k + Math.Sqrt(1 + 4*k))/(Math.Sqrt(2)*k);
+
+            // semilatus rectum of hyperbolic ejection orbit
+            double pf = af * ( 1 - ef*ef );
+
+            // true anomaly of the v_inf on the hyperbolic ejection orbit
+            double nu_inf = Math.Acos(-1/ef);
+
+            // true anomaly of the burn on the hyperbolic ejection orbit
+            double nu_1f = nu_inf - Math.PI/2;
+
+            // turning angle of the hyperbolic orbit
+            double delta = 2 * Math.Asin(1/ef);
+
+            // incoming hyperbolic velocity unit vector
+            Vector3d v_inf_minus_hat = Math.Cos(delta) * v_inf_hat + Math.Sin(delta) * Vector3d.Cross(v_inf_hat, hf_hat);
+
+            // periapsis position and velocity vectors of the hyperbolic ejection orbit
+            Vector3d rpf_hat = v_inf_minus_hat - v_inf_hat;
+            rpf_hat = rpf_hat / rpf_hat.magnitude;
+            Vector3d vpf_hat = v_inf_minus_hat + v_inf_hat;
+            vpf_hat = vpf_hat / vpf_hat.magnitude;
+
+            // compute the velocity on the hyperbola and the parking orbit
+            vpos = Math.Sqrt(mu/pf) * ( -Math.Sin(nu_1f) * rpf_hat + ( ef + Math.Cos(nu_1f) ) * vpf_hat );
+            vneg = Math.Sqrt(mu/p0) * ( -Math.Sin(nu_10) * rp0_hat + ( e0 + Math.Cos(nu_10) ) * vp0_hat );
+
+            // compute nu of the reference position on the parking orbit
+            Vector3d r0_hat = r0/r0.magnitude;
+            double nu0 = Math.Sign(Vector3d.Dot(h0_hat, Vector3d.Cross(rp0_hat, r0_hat))) * Math.Acos(Vector3d.Dot(rp0_hat,r0_hat));
+
+            // mean angular motion of the parking orbit
+            double n = 1/Math.Sqrt( a0*a0*a0 / mu );
+
+            // eccentric anomalies of reference position and r1 on the parking orbit
+            double E0 = Math.Atan2(Math.Sqrt(1 - e0*e0) * Math.Sin(nu0), e0 + Math.Cos(nu0));
+            double E1 = Math.Atan2(Math.Sqrt(1 - e0*e0) * Math.Sin(nu_10), e0 + Math.Cos(nu_10));
+
+            // mean anomalies of reference position and r1 on the parking orbit
+            double M0 = E0 - e0 * Math.Sin( E0 );
+            double M1 = E1 - e0 * Math.Sin( E1 );
+
+            // coast time on the parking orbit
+            dt = ( M1 - M0 ) / n;
+            if ( dt < 0 )
+            {
+                dt += 2 * Math.PI / n;
+            }
+        }
+    }
+}

--- a/MechJeb2/VesselExtensions.cs
+++ b/MechJeb2/VesselExtensions.cs
@@ -44,7 +44,7 @@ namespace MuMech
                 for (int m = 0; m < count; m++)
                 {
                     if (part.Modules[m] is T mod)
-                    {  
+                    {
                         list.Add(mod);;
                     }
                 }
@@ -266,8 +266,11 @@ namespace MuMech
 
 
         //input dV should be in world coordinates
-        public static ManeuverNode PlaceManeuverNode(this Vessel vessel, Orbit patch, Vector3d dV, double UT)
+        public static ManeuverNode PlaceManeuverNode(this Vessel vessel, Orbit ignoredParameterThatNeedsDeleting, Vector3d dV, double UT)
         {
+            // get the right for the time
+            Orbit patch = vessel.GetPatchAtUT(UT);
+
             //placing a maneuver node with bad dV values can really mess up the game, so try to protect against that
             //and log an exception if we get a bad dV vector:
             for (int i = 0; i < 3; i++)


### PR DESCRIPTION
![Screen Shot 2020-02-15 at 6 58 06 PM](https://user-images.githubusercontent.com/454857/74600321-b1d8e000-5044-11ea-93ce-cedb5a430615.png)

* The advanced transfer planner now has precise periapsis control at the target
* If the box is checked to include the capture burn, the second circularization node is placed
* A routine has been added which computes analytical near-optimal single impulse ejection burns from elliptical non-coplanar parking orbits.  This replaces the old circular parking orbit approximation.  This will:
   - Improve the accuracy of porkchop plots
   - Fix problems where the ejection optimizer never converged because the initial guess was too poor
* When drawing a box on the porkchop plot, if the mouse goes off the screen the last box drawn is used to zoom (still mildly frustrating behavior, but not incredibly frustrating behavior).
* The periapsis target is hardcoded to default to 100 km around airless bodies and atmdepth + 10 km around bodies with an atmosphere.
* Brent's 1-d local minimization solver has been added.
