### PR TITLE
Advanced Transfer Planner fix for coplanar transfers

### DIFF
--- a/MechJeb2/Brent.cs
+++ b/MechJeb2/Brent.cs
@@ -240,8 +240,8 @@ namespace MuMech {
         // Uses golden section search and successive parabolic interpolation.
         //
         // f - 1-dimensional BrentFun function to find the minimum of
-        // a - first guess of x value
-        // b - second guess of x value
+        // a - lower endpoint of the interval
+        // b - upper endpoint of the interval
         // rtol - tolerance to solve to (1e-4 or something like that)
         // x - output of solved value
         // y - output of the function at the solved value

--- a/MechJeb2/Maneuver/PlotArea.cs
+++ b/MechJeb2/Maneuver/PlotArea.cs
@@ -61,6 +61,7 @@ namespace MuMech
             if (Math.Abs(selectedPoint[0] - hoveredPoint[0]) > 5 &&
                     Math.Abs(selectedPoint[1] - hoveredPoint[1]) > 5)
             {
+                Debug.Log("[MechJeb] porkchop plotter, zooming plotarea");
                 callback(
                         x(Math.Min(selectedPoint[0], hoveredPoint[0])),
                         x(Math.Max(selectedPoint[0], hoveredPoint[0])),

--- a/MechJeb2/Maneuver/Porkchop.cs
+++ b/MechJeb2/Maneuver/Porkchop.cs
@@ -41,15 +41,16 @@ namespace MuMech
             {
                 for (int j = 0; j < height; j++)
                 {
-                    double DVsqr = nodes[i, j] * nodes[i, j];
-                    if (DVsqr < DVminsqr)
-                    {
-                        DVminsqr = DVsqr;
-                    }
+                    if ( !nodes[i,j].IsFinite() )
+                        continue;
 
-                    DVmaxsqr = Math.Max(DVmaxsqr, nodes[i, j] * nodes[i, j]);
+                    double DVsqr = nodes[i, j] * nodes[i, j];
+                    DVminsqr = Math.Min(DVminsqr, DVsqr);
+                    DVmaxsqr = Math.Max(DVmaxsqr, DVsqr);
                 }
             }
+
+            Debug.Log("[MechJeb] porkchop scanning found DVminsqr = " + DVminsqr + " DVmaxsqr = " + DVmaxsqr);
 
             double logDVminsqr = Math.Log(DVminsqr);
             double logDVmaxsqr = Math.Min(Math.Log(DVmaxsqr), logDVminsqr + 4);


### PR DESCRIPTION
* adds a 1-d linesearch for the correct rotation in the hyperbolic
  injection code.
* adds some defensive programming around Acos calls.
* removes some code that is no longer being used now in the
  transfer calculator.

other bits of cleanup and additional debugging here and there.

this now correctly reproduces transfers from alex moon's transfer
planner for me for circular equatorial initial conditions.
