### PR TITLE
Math cleanup

### DIFF
--- a/MechJeb2/MathExtensions.cs
+++ b/MechJeb2/MathExtensions.cs
@@ -50,27 +50,27 @@ namespace MuMech
             return new Vector3d(vector.x != 0 ? 1 / vector.x : 0, vector.y != 0 ? 1 / vector.y: 0, vector.z != 0 ? 1 / vector.z: 0);
         }
 
-        public static Vector3 ProjectIntoPlane(this Vector3 vector, Vector3 planeNormal)
+        public static Vector3d ProjectOnPlane(this Vector3d vector, Vector3d planeNormal)
         {
-            return vector - Vector3.Project(vector, planeNormal);
+            return vector - Vector3d.Project(vector, planeNormal);
         }
 
         public static Vector3d DeltaEuler(this Quaternion delta)
         {
             return new Vector3d(
-                (delta.eulerAngles.x > 180) ? (delta.eulerAngles.x - 360.0F) : delta.eulerAngles.x,
-                -((delta.eulerAngles.y > 180) ? (delta.eulerAngles.y - 360.0F) : delta.eulerAngles.y),
-                (delta.eulerAngles.z > 180) ? (delta.eulerAngles.z - 360.0F) : delta.eulerAngles.z
-                );
+                    (delta.eulerAngles.x > 180) ? (delta.eulerAngles.x - 360.0F) : delta.eulerAngles.x,
+                    -((delta.eulerAngles.y > 180) ? (delta.eulerAngles.y - 360.0F) : delta.eulerAngles.y),
+                    (delta.eulerAngles.z > 180) ? (delta.eulerAngles.z - 360.0F) : delta.eulerAngles.z
+                    );
         }
 
         public static Vector3d Clamp(this Vector3d value, double min, double max)
         {
             return new Vector3d(
-                Clamp(value.x, min, max),
-                Clamp(value.y, min, max),
-                Clamp(value.z, min, max)
-                );
+                    Clamp(value.x, min, max),
+                    Clamp(value.y, min, max),
+                    Clamp(value.z, min, max)
+                    );
         }
 
         public static double Clamp(double val, double min, double max)
@@ -82,63 +82,53 @@ namespace MuMech
             return val;
         }
 
-        public static float AngleInPlane(this Vector3 vector, Vector3 planeNormal, Vector3 other)
+        // projects the two vectors onto the normal plane and computes the 0 to 360 angle
+        public static double AngleInPlane(this Vector3d vector, Vector3d planeNormal, Vector3d other)
         {
-            Vector3 v1 = vector.ProjectIntoPlane(planeNormal);
-            Vector3 v2 = other.ProjectIntoPlane(planeNormal);
+            Vector3d v1 = vector.ProjectOnPlane(planeNormal);
+            Vector3d v2 = other.ProjectOnPlane(planeNormal);
 
             if ((v1.magnitude == 0) || (v2.magnitude == 0))
-            {
-                return float.NaN;
-            }
+                return double.NaN;
 
-            v1.Normalize();
-            v2.Normalize();
-
-            Quaternion rot = Quaternion.FromToRotation(planeNormal, new Vector3(0, 0, 1));
-
-            Vector3 r1 = rot * v1;
-            Vector3 r2 = rot * v2;
-
-            return (float)((Math.Atan2(r1.y, r1.x) - Math.Atan2(r2.y, r2.x)) * UtilMath.Rad2Deg);
+            double angle = MuUtils.ClampDegrees360(Math.Acos( Vector3d.Dot(v1.normalized, v2.normalized) ) * UtilMath.Rad2Deg);
+            if ( Vector3d.Dot(Vector3d.Cross(v1, v2), planeNormal) < 0 )
+                return -angle;
+            else
+                return angle;
         }
 
-		public static Quaternion Add(this Quaternion left, Quaternion right)
-		{
-			return new Quaternion(
-				left.x + right.x,
-				left.y + right.y,
-				left.z + right.z,
-				left.w + right.w);
-		}
+        public static Quaternion Add(this Quaternion left, Quaternion right)
+        {
+            return new Quaternion(
+                    left.x + right.x,
+                    left.y + right.y,
+                    left.z + right.z,
+                    left.w + right.w);
+        }
 
-		public static Quaternion Mult(this Quaternion left, float lambda)
-		{
-			return new Quaternion(
-				left.x * lambda,
-				left.y * lambda,
-				left.z * lambda,
-				left.w * lambda);
-		}
+        public static Quaternion Mult(this Quaternion left, float lambda)
+        {
+            return new Quaternion(
+                    left.x * lambda,
+                    left.y * lambda,
+                    left.z * lambda,
+                    left.w * lambda);
+        }
 
-		public static Quaternion Conj(this Quaternion left)
-		{
-			return new Quaternion(
-				-left.x,
-				-left.y,
-				-left.z,
-				left.w);
-		}
+        public static Quaternion Conj(this Quaternion left)
+        {
+            return new Quaternion(
+                    -left.x,
+                    -left.y,
+                    -left.z,
+                    left.w);
+        }
 
         public static Vector3d Project(this Vector3d vector, Vector3d onNormal)
         {
             Vector3d normal = onNormal.normalized;
             return normal * Vector3d.Dot(vector, normal);
-        }
-
-        public static Vector3d ProjectOnPlane(this Vector3d vector, Vector3d planeNormal)
-        {
-            return vector - Vector3d.Project(vector, planeNormal);
         }
 
         // +/- infinity is not a finite number (not finite)

--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -636,32 +636,5 @@ namespace MuMech
 
             return phaseAngleDifference / phaseAngleRate;
         }
-
-        //Computes the time required for the given launch location to rotate under the target orbital plane.
-        //If the latitude is too high for the launch location to ever actually rotate under the target plane,
-        //returns the time of closest approach to the target plane.
-        //I have a wonderful proof of this formula which this comment is too short to contain.
-        public static double TimeToPlane(double LANDifference, CelestialBody launchBody, double launchLatitude, double launchLongitude, Orbit target)
-        {
-            double inc = Math.Abs(Vector3d.Angle(-target.GetOrbitNormal().Reorder(132).normalized, launchBody.angularVelocity));
-            Vector3d b = Vector3d.Exclude(launchBody.angularVelocity, -target.GetOrbitNormal().Reorder(132).normalized).normalized; // I don't understand the sign here, but this seems to work
-            b *= launchBody.Radius * Math.Sin(UtilMath.Deg2Rad * launchLatitude) / Math.Tan(UtilMath.Deg2Rad * inc);
-            Vector3d c = Vector3d.Cross(-target.GetOrbitNormal().Reorder(132).normalized, launchBody.angularVelocity).normalized;
-            double cMagnitudeSquared = Math.Pow(launchBody.Radius * Math.Cos(UtilMath.Deg2Rad * launchLatitude), 2) - b.sqrMagnitude;
-            if (cMagnitudeSquared < 0) cMagnitudeSquared = 0;
-            c *= Math.Sqrt(cMagnitudeSquared);
-            Vector3d a1 = b + c;
-            Vector3d a2 = b - c;
-
-            Vector3d longitudeVector = launchBody.GetSurfaceNVector(0, launchLongitude);
-
-            double angle1 = Math.Abs(Vector3d.Angle(longitudeVector, a1));
-            if (Vector3d.Dot(Vector3d.Cross(longitudeVector, a1), launchBody.angularVelocity) < 0) angle1 = 360 - angle1;
-            double angle2 = Math.Abs(Vector3d.Angle(longitudeVector, a2));
-            if (Vector3d.Dot(Vector3d.Cross(longitudeVector, a2), launchBody.angularVelocity) < 0) angle2 = 360 - angle2;
-
-            double angle = Math.Min(angle1, angle2) - LANDifference;
-            return (angle / 360) * launchBody.rotationPeriod;
-        }
     }
 }

--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -95,7 +95,7 @@ namespace MuMech
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public EditableDouble launchPhaseAngle = 0;
 
-        [Persistent(pass = (int)(Pass.Type | Pass.Global))]
+        [Persistent(pass = (int)(Pass.Type))]
         public EditableDouble launchLANDifference = 0;
 
         [Persistent(pass = (int)(Pass.Global))]

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -436,7 +436,16 @@ namespace MuMech
                                 {
                                     launchingToPlane = true;
 
-                                    autopilot.StartCountdown(vesselState.time + SpaceMath.MinimumTimeToPlane(mainBody.rotationPeriod, vesselState.latitude, vesselState.longitude, vesselState.celestialLongitude, core.target.TargetOrbit.LAN - autopilot.launchLANDifference, core.target.TargetOrbit.inclination));
+                                    autopilot.StartCountdown(vesselState.time +
+                                            SpaceMath.MinimumTimeToPlane(
+                                                mainBody.rotationPeriod,
+                                                vesselState.latitude,
+                                                vesselState.longitude,
+                                                vesselState.celestialLongitude,
+                                                core.target.TargetOrbit.LAN - autopilot.launchLANDifference,
+                                                core.target.TargetOrbit.inclination
+                                                )
+                                            );
                                 }
                                 autopilot.launchLANDifference.text = GUILayout.TextField(
                                         autopilot.launchLANDifference.text, GUILayout.Width(60));

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -355,7 +355,7 @@ namespace MuMech
                         GUILayout.EndHorizontal();
                         GUILayout.BeginHorizontal();
                         GUILayout.Label(Localizer.Format("#MechJeb_Ascent_label27") + core.guidance.successful_converges, GUILayout.Width(100));//converges:
-                        GUILayout.Label(Localizer.Format("#MechJeb_Ascent_label28") + core.guidance.last_lm_status, GUILayout.Width(100));//status: 
+                        GUILayout.Label(Localizer.Format("#MechJeb_Ascent_label28") + core.guidance.last_lm_status, GUILayout.Width(100));//status:
                         GUILayout.EndHorizontal();
                         GUILayout.BeginHorizontal();
                         GUILayout.Label("n: " + core.guidance.last_lm_iteration_count + "(" + core.guidance.max_lm_iteration_count + ")", GUILayout.Width(100));
@@ -369,7 +369,7 @@ namespace MuMech
                             GUIStyle s = new GUIStyle(GUI.skin.label);
                             s.normal.textColor = Color.red;
                             GUILayout.BeginHorizontal();
-                            GUILayout.Label(Localizer.Format("#MechJeb_Ascent_label30") + core.guidance.last_failure_cause, s);//LAST FAILURE: 
+                            GUILayout.Label(Localizer.Format("#MechJeb_Ascent_label30") + core.guidance.last_failure_cause, s);//LAST FAILURE:
                             GUILayout.EndHorizontal();
                         }
 
@@ -383,7 +383,7 @@ namespace MuMech
                                 GUIStyle s = new GUIStyle(GUI.skin.label);
                                 s.normal.textColor = Color.yellow;
                                 GUILayout.BeginHorizontal();
-                                GUILayout.Label(String.Format(Localizer.Format("#MechJeb_Ascent_label31") +"{0:F1}%", (vesselState.mass - m0) / m0 * 100.0 ), s);//MASS IS OFF BY 
+                                GUILayout.Label(String.Format(Localizer.Format("#MechJeb_Ascent_label31") +"{0:F1}%", (vesselState.mass - m0) / m0 * 100.0 ), s);//MASS IS OFF BY
                                 GUILayout.EndHorizontal();
                             }
 
@@ -436,10 +436,7 @@ namespace MuMech
                                 {
                                     launchingToPlane = true;
 
-                                    autopilot.StartCountdown(vesselState.time +
-                                            LaunchTiming.TimeToPlane(autopilot.launchLANDifference,
-                                                mainBody, vesselState.latitude, vesselState.longitude,
-                                                core.target.TargetOrbit));
+                                    autopilot.StartCountdown(vesselState.time + SpaceMath.MinimumTimeToPlane(mainBody.rotationPeriod, vesselState.latitude, vesselState.longitude, vesselState.celestialLongitude, core.target.TargetOrbit.LAN - autopilot.launchLANDifference, core.target.TargetOrbit.inclination));
                                 }
                                 autopilot.launchLANDifference.text = GUILayout.TextField(
                                         autopilot.launchLANDifference.text, GUILayout.Width(60));

--- a/MechJeb2/ReentrySimulation.cs
+++ b/MechJeb2/ReentrySimulation.cs
@@ -9,16 +9,16 @@ namespace MuMech
     public class ReentrySimulation
     {
         // Input values
-         Orbit input_initialOrbit;
-         double input_UT; 
-         //double input_mass;
-         IDescentSpeedPolicy input_descentSpeedPolicy; 
-         double input_decelEndAltitudeASL; 
-         double input_maxThrustAccel; 
-         double input_parachuteSemiDeployMultiplier; 
-         double input_probableLandingSiteASL; 
-         bool input_multiplierHasError;
-         double input_dt;
+        Orbit input_initialOrbit;
+        double input_UT;
+        //double input_mass;
+        IDescentSpeedPolicy input_descentSpeedPolicy;
+        double input_decelEndAltitudeASL;
+        double input_maxThrustAccel;
+        double input_parachuteSemiDeployMultiplier;
+        double input_probableLandingSiteASL;
+        bool input_multiplierHasError;
+        double input_dt;
 
         //parameters of the problem:
         Orbit initialOrbit = new Orbit();
@@ -27,7 +27,7 @@ namespace MuMech
         //double scaleHeight;
         double bodyRadius;
         double gravParameter;
-        
+
         //double mass;
         SimulatedVessel vessel;
         Vector3d bodyAngularVelocity;
@@ -44,7 +44,7 @@ namespace MuMech
         bool orbitReenters;
 
         ReferenceFrame referenceFrame = new ReferenceFrame();
-        
+
         double dt;
         double max_dt;
         //private const double min_dt = 0.01; //in seconds
@@ -58,7 +58,7 @@ namespace MuMech
         double parachuteSemiDeployMultiplier;
         bool multiplierHasError;
 
-        //Dynamical variables 
+        //Dynamical variables
         Vector3d x; //coordinate system used is centered on main body
         Vector3d startX; //start position
         Vector3d v;
@@ -117,7 +117,7 @@ namespace MuMech
             // Store all the input values as they were given
             input_initialOrbit = _initialOrbit;
             input_UT = _UT;
-            
+
             vessel = _vessel;
             input_descentSpeedPolicy = _descentSpeedPolicy;
             input_decelEndAltitudeASL = _decelEndAltitudeASL;
@@ -152,7 +152,7 @@ namespace MuMech
 
             bodyAngularVelocity = body.angularVelocity;
             this.descentSpeedPolicy = _descentSpeedPolicy;
-            decelRadius = bodyRadius + _decelEndAltitudeASL; 
+            decelRadius = bodyRadius + _decelEndAltitudeASL;
             aerobrakedRadius = bodyRadius + body.RealMaxAtmosphereAltitude();
             mainBody = body;
             this.maxThrustAccel = _maxThrustAccel;
@@ -199,7 +199,7 @@ namespace MuMech
                 result.input_dt = this.input_dt;
 
                 //MechJebCore.print("Sim Start");
-                
+
                 if (!orbitReenters)
                 {
                     result.outcome = Outcome.NO_REENTRY;
@@ -354,8 +354,8 @@ namespace MuMech
             if (descentSpeedPolicy != null && surfaceVelocity.magnitude > descentSpeedPolicy.MaxAllowedSpeed(pos, surfaceVelocity)) return true;
             return false;
         }
-        
-        // one time step of RK4: There is logic to reduce the dt and repeat if a larger dt results in very large accelerations. Also the parachute opening logic is called from in order to allow the dt to be reduced BEFORE deploying parachutes to give more precision over the point of deployment.  
+
+        // one time step of RK4: There is logic to reduce the dt and repeat if a larger dt results in very large accelerations. Also the parachute opening logic is called from in order to allow the dt to be reduced BEFORE deploying parachutes to give more precision over the point of deployment.
         void RK4Step()
         {
             bool repeatWithSmallerStep = false;
@@ -406,7 +406,7 @@ namespace MuMech
                     double altASL = xForChuteSim.magnitude - bodyRadius;
                     double altAGL = altASL - probableLandingSiteASL;
                     double pressure = Pressure(xForChuteSim);
-                    
+
                     bool willChutesOpen = vessel.WillChutesDeploy(altAGL, altASL, probableLandingSiteASL, pressure, vForChuteSim, t, parachuteSemiDeployMultiplier);
                     maxDragGees = Math.Max(maxDragGees, lastRecordedDrag.magnitude / 9.81f);
 
@@ -427,8 +427,8 @@ namespace MuMech
             x += dx;
             v += dv;
             t += dt;
-           
-            // decide what the dt needs to be for the next iteration 
+
+            // decide what the dt needs to be for the next iteration
             // Is there a parachute in the process of opening? If so then we follow special rules - fix the dt at the physics frame rate. This is because the rate for deployment depends on the frame rate for stock parachutes.
             // If parachutes are part way through deploying then we need to use the physics frame rate for the next step of the simulation
             if (parachutesDeploying)
@@ -551,7 +551,7 @@ namespace MuMech
                     else
                     {
                         // If a parachute is opening we need to lower dt to make sure we capture the opening sequence properly
-                        dt = next_dt; 
+                        dt = next_dt;
                     }
                 }
             }
@@ -583,7 +583,7 @@ namespace MuMech
         {
             Vector3d airVel = SurfaceVelocity(pos, vel);
             double altitude = pos.magnitude - bodyRadius;
-            
+
             double airDensity = AirDensity(pos, altitude);
             double pressure = Pressure(pos);
             double speedOfSound = mainBody.GetSpeedOfSound(pressure, airDensity);
@@ -593,7 +593,7 @@ namespace MuMech
 
             double pseudoReynolds = airDensity * airVel.magnitude;
             double pseudoReDragMult = (double)simCurves.DragCurvePseudoReynolds.Evaluate((float)pseudoReynolds);
-            
+
             if (once)
             {
                 result.prediction.firstDrag = DragForce(pos, vel, dynamicPressurekPa, mach).magnitude / 9.81;
@@ -606,12 +606,12 @@ namespace MuMech
 
             if (record)
                 lastRecordedDrag = dragAccel;
-            
+
             Vector3d gravAccel = GravAccel(pos);
             Vector3d liftAccel = LiftForce(pos, vel, dynamicPressurekPa, mach) / vessel.totalMass;
 
             Vector3d totalAccel = gravAccel + dragAccel + liftAccel;
-            
+
             if (once)
                 once = false;
 
@@ -626,7 +626,7 @@ namespace MuMech
         Vector3d DragForce(Vector3d pos, Vector3d vel, float dynamicPressurekPa, float mach)
         {
             if (!bodyHasAtmosphere) return Vector3d.zero;
-            
+
             Vector3d airVel = SurfaceVelocity(pos, vel);
 
             Vector3d localVel = attitude * Vector3d.up * airVel.magnitude;
@@ -654,10 +654,10 @@ namespace MuMech
             //    msg += "\n " + temp.ToString("F3") + " " + vessel.parts[0].oPart.vessel.atmosphericTemperature.ToString("F3");
             //
             //
-            //    //this.atmosphericTemperature = 
+            //    //this.atmosphericTemperature =
             //    //    this.currentMainBody.GetTemperature(this.altitude) +
-            //    //    (double)this.currentMainBody.atmosphereTemperatureSunMultCurve.Evaluate((float)this.altitude) * 
-            //    //        ((double)this.currentMainBody.latitudeTemperatureBiasCurve.Evaluate((float)(num1 * 57.2957801818848)) + 
+            //    //    (double)this.currentMainBody.atmosphereTemperatureSunMultCurve.Evaluate((float)this.altitude) *
+            //    //        ((double)this.currentMainBody.latitudeTemperatureBiasCurve.Evaluate((float)(num1 * 57.2957801818848)) +
             //    //         (double)this.currentMainBody.latitudeTemperatureSunMultCurve.Evaluate((float)(num1 * 57.2957801818848)) * (1 + this.sunDot) * 0.5
             //    //          + (double)this.currentMainBody.axialTemperatureSunMultCurve.Evaluate(this.sunAxialDot));
             //    //
@@ -674,7 +674,7 @@ namespace MuMech
         private Vector3d LiftForce(Vector3d pos, Vector3d vel, float dynamicPressurekPa, float mach)
         {
             if (!bodyHasAtmosphere) return Vector3d.zero;
-            
+
             Vector3d airVel = SurfaceVelocity(pos, vel);
 
             Vector3d localVel = attitude * Vector3d.up * airVel.magnitude;
@@ -685,7 +685,7 @@ namespace MuMech
 
             return vesselToWorld * localLift;
         }
-        
+
         double Pressure(Vector3d pos)
         {
             double altitude = pos.magnitude - bodyRadius;
@@ -702,7 +702,7 @@ namespace MuMech
         {
             double pressure = StaticPressure(altitude);
             double temp = GetTemperature(pos, altitude);
-               
+
             return FlightGlobals.getAtmDensity(pressure, temp, mainBody);
         }
 
@@ -727,7 +727,7 @@ namespace MuMech
             }
             return Mathf.Lerp(0f, (float)mainBody.atmospherePressureSeaLevel, simCurves.AtmospherePressureCurve.Evaluate((float)(altitude / mainBody.atmosphereDepth)));
         }
-        
+
         // Lifted from the Trajectories mod.
         private double GetTemperature(Vector3d position, double altitude)
         {
@@ -754,7 +754,7 @@ namespace MuMech
             float sunDotCorrected = (1.0f + Vector3.Dot(sunVector, Quaternion.AngleAxis(45f * Mathf.Sign((float)mainBody.rotationPeriod), mainBody.bodyTransform.up) * up)) * 0.5f;
             float sunDotNormalized = (sunDotCorrected - sunBodyMinDot) / (sunBodyMaxDot - sunBodyMinDot);
             double atmosphereTemperatureOffset = (double)simCurves.LatitudeTemperatureBiasCurve.Evaluate(time) + (double)simCurves.LatitudeTemperatureSunMultCurve.Evaluate(time) * sunDotNormalized + (double)simCurves.AxialTemperatureSunMultCurve.Evaluate(sunAxialDot);
-            
+
             double temperature;
             if (!mainBody.atmosphereUseTemperatureCurve)
             {
@@ -766,12 +766,12 @@ namespace MuMech
                     simCurves.AtmosphereTemperatureCurve.Evaluate((float)altitude) :
                     UtilMath.Lerp(simCurves.SpaceTemperature, mainBody.atmosphereTemperatureSeaLevel, simCurves.AtmosphereTemperatureCurve.Evaluate((float)(altitude / mainBody.atmosphereDepth)));
             }
-            
+
             temperature += (double)simCurves.AtmosphereTemperatureSunMultCurve.Evaluate((float)altitude) * atmosphereTemperatureOffset;
 
             return temperature;
         }
-        
+
         private double ShockTemperature(double velocity, double mach)
         {
             double newtonianTemperatureFactor = velocity * PhysicsGlobals.NewtonianTemperatureFactor;
@@ -805,15 +805,15 @@ namespace MuMech
 
 
                 result.debugLog += "\n "
-                                   + (t - startUT).ToString("F2").PadLeft(8)
-                                   + " Alt:" + altitude.ToString("F0").PadLeft(6)
-                                   + " Vel:" + vel.magnitude.ToString("F2").PadLeft(8)
-                                   + " AirVel:" + airVel.magnitude.ToString("F2").PadLeft(8)
-                                   + " SoS:" + speedOfSound.ToString("F2").PadLeft(6)
-                                   + " mach:" + mach.ToString("F2").PadLeft(6)
-                                   + " dynP:" + dynamicPressurekPa.ToString("F5").PadLeft(9)
-                                   + " Temp:" + atmosphericTemperature.ToString("F2").PadLeft(8)
-                                   + " Lat:" + referenceFrame.Latitude(pos).ToString("F2").PadLeft(6);
+                    + (t - startUT).ToString("F2").PadLeft(8)
+                    + " Alt:" + altitude.ToString("F0").PadLeft(6)
+                    + " Vel:" + vel.magnitude.ToString("F2").PadLeft(8)
+                    + " AirVel:" + airVel.magnitude.ToString("F2").PadLeft(8)
+                    + " SoS:" + speedOfSound.ToString("F2").PadLeft(6)
+                    + " mach:" + mach.ToString("F2").PadLeft(6)
+                    + " dynP:" + dynamicPressurekPa.ToString("F5").PadLeft(9)
+                    + " Temp:" + atmosphericTemperature.ToString("F2").PadLeft(8)
+                    + " Lat:" + referenceFrame.Latitude(pos).ToString("F2").PadLeft(6);
             }
         }
 
@@ -916,11 +916,11 @@ namespace MuMech
             private FloatCurve axialTemperatureSunMultCurve;
 
             private FloatCurve atmosphereTemperatureCurve;
-            
+
             private FloatCurve dragCurvePseudoReynolds;
 
             private double spaceTemperature;
-            
+
             public FloatCurve LiftCurve
             {
                 get { return liftCurve; }
@@ -1071,7 +1071,7 @@ namespace MuMech
             public double input_probableLandingSiteASL;
             public bool input_multiplierHasError;
             public double input_dt;
-            
+
             public string debugLog;
 
             private static readonly Pool<Result> pool = new Pool<Result>(Create, Reset);
@@ -1173,24 +1173,24 @@ namespace MuMech
             public double GetOvershoot(EditableAngle targetLatitude,EditableAngle targetLongitude)
             {
                 // Get the start, end and target positions as a set of 3d vectors that we can work with
-                Vector3 end = this.body.GetWorldSurfacePosition(endPosition.latitude, endPosition.longitude, 0) - body.position;
-                Vector3 target = this.body.GetWorldSurfacePosition(targetLatitude, targetLongitude, 0) - body.position; 
-                Vector3 start = this.body.GetWorldSurfacePosition(startPosition.latitude, startPosition.longitude, 0) - body.position;
+                Vector3d end = this.body.GetWorldSurfacePosition(endPosition.latitude, endPosition.longitude, 0) - body.position;
+                Vector3d target = this.body.GetWorldSurfacePosition(targetLatitude, targetLongitude, 0) - body.position;
+                Vector3d start = this.body.GetWorldSurfacePosition(startPosition.latitude, startPosition.longitude, 0) - body.position;
 
-                // First we need to get two vectors that are non orthogonal to each other and to the vector from the start to the target. TODO can we simplify this code by using Vector3.Exclude?
-                Vector3 start2Target = target - start;
-                Vector3 orthog1 = Vector3.Cross(start2Target,Vector3.up);
+                // First we need to get two vectors that are non orthogonal to each other and to the vector from the start to the target. TODO can we simplify this code by using Vector3d.Exclude?
+                Vector3d start2Target = target - start;
+                Vector3d orthog1 = Vector3d.Cross(start2Target,Vector3d.up);
                 // check for the spaecial case where start2target is parrallel to up. If it is then the result will be zero,and we need to try again
-                if(orthog1 == Vector3.up)
+                if(orthog1 == Vector3d.up)
                 {
-                    orthog1 = Vector3.Cross(start2Target,Vector3.forward);
+                    orthog1 = Vector3d.Cross(start2Target,Vector3d.forward);
                 }
-                Vector3 orthog2 = Vector3.Cross(start2Target,orthog1);
+                Vector3d orthog2 = Vector3d.Cross(start2Target,orthog1);
 
                 // Now that we have those two orthogonal vectors, we can project any vector onto the two planes defined by them to give us the vector component that is parallel to start2Target.
-                Vector3 target2end = end - target;
+                Vector3d target2end = end - target;
 
-                Vector3 overshoot = target2end.ProjectIntoPlane(orthog1).ProjectIntoPlane(orthog2);
+                Vector3d overshoot = target2end.ProjectOnPlane(orthog1).ProjectOnPlane(orthog2);
 
                 // finally how long is it? We know it is parrallel to start2target, so if we add it to start2target, and then get the difference of the lengths, that should give us a positive or negative
                 double overshootLength = (start2Target+overshoot).magnitude - start2Target.magnitude;
@@ -1216,14 +1216,14 @@ namespace MuMech
                 resultText += "\n input_dt: " + input_dt;
                 resultText += "\n}";
                 resultText += "\nid: " + id;
-                resultText += "\noutcome: " + outcome; 
+                resultText += "\noutcome: " + outcome;
                 resultText += "\nmaxdt: " + maxdt;
                 resultText += "\ntimeToComplete: " + timeToComplete;
                 resultText += "\nendUT: " + endUT;
                 if (null != referenceFrame) { resultText += "\nstartPosition: " + referenceFrame.WorldPositionAtCurrentTime(startPosition); }
                 if (null != referenceFrame) { resultText += "\nendPosition: " + referenceFrame.WorldPositionAtCurrentTime(endPosition); }
                 resultText += "\nendASL: " + endASL;
-                resultText += "\nendVelocity: " + endVelocity.longitude + "," + endVelocity.latitude + "," + endVelocity.radius; 
+                resultText += "\nendVelocity: " + endVelocity.longitude + "," + endVelocity.latitude + "," + endVelocity.radius;
                 resultText += "\nmaxDragGees: " + maxDragGees;
                 resultText += "\ndeltaVExpended: " + deltaVExpended;
                 resultText += "\nmultiplierHasError: " + multiplierHasError;
@@ -1238,7 +1238,7 @@ namespace MuMech
 
     //An IDescentSpeedPolicy describes a strategy for doing the braking burn.
     //while landing. The function MaxAllowedSpeed is supposed to compute the maximum allowed speed
-    //as a function of body-relative position and rotating frame, surface-relative velocity. 
+    //as a function of body-relative position and rotating frame, surface-relative velocity.
     //This lets the ReentrySimulator simulate the descent of a vessel following this policy.
     //
     //Note: the IDescentSpeedPolicy object passed into the simulation will be used in the separate simulation
@@ -1271,7 +1271,7 @@ namespace MuMech
     //be provided in some unambiguous format, so that we can interpret these positions and velocities correctly at a later
     //time, regardless of what sort of origin shifts and axis rotations have occurred.
     //
-    //Now, it doesn't particularly matter what unambiguous format we use, as long as it is in fact unambiguous. We choose to 
+    //Now, it doesn't particularly matter what unambiguous format we use, as long as it is in fact unambiguous. We choose to
     //represent positions unambiguously via a latitude, a longitude, a radius, and a time. If we record these four data points
     //for an event, we can unambiguously reconstruct the position of the event at a later time. We just have to account for the
     //fact that the rotation of the planet means that the same position will have a different longitude.
@@ -1351,5 +1351,5 @@ namespace MuMech
 
     }
 
-    
+
 }

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -136,6 +136,8 @@ namespace MuMech
         public MovingAverage orbitEccentricity = new MovingAverage();
         [ValueInfoItem("#MechJeb_SemiMajorAxis", InfoItem.Category.Orbit, format = ValueInfoItem.SI, siSigFigs = 6, siMaxPrecision = 0, units = "m")]//Semi-major axis
         public MovingAverage orbitSemiMajorAxis = new MovingAverage();
+        [ValueInfoItem("Celestial Longitude", InfoItem.Category.Orbit, format = "F3")]
+        public MovingAverage celestialLongitude = new MovingAverage();
         [ValueInfoItem("#MechJeb_Latitude", InfoItem.Category.Surface, format = ValueInfoItem.ANGLE_NS)]//Latitude
         public MovingAverage latitude = new MovingAverage();
         [ValueInfoItem("#MechJeb_Longitude", InfoItem.Category.Surface, format = ValueInfoItem.ANGLE_EW)]//Longitude
@@ -702,28 +704,21 @@ namespace MuMech
             orbitTimeToAp.value = vessel.orbit.timeToAp;
             orbitTimeToPe.value = vessel.orbit.timeToPe;
 
-            if (!vessel.LandedOrSplashed)
-            {
-                orbitLAN.value = vessel.orbit.LAN;
-            }
-            else
-            {
-                orbitLAN.value = -(vessel.transform.position - vessel.mainBody.transform.position).AngleInPlane(Planetarium.Zup.Z, Planetarium.Zup.X);
-                orbitTimeToAp.value = 0;
-            }
+            orbitLAN.value = vessel.orbit.LAN;
 
             orbitArgumentOfPeriapsis.value = vessel.orbit.argumentOfPeriapsis;
             orbitInclination.value = vessel.orbit.inclination;
             orbitEccentricity.value = vessel.orbit.eccentricity;
             orbitSemiMajorAxis.value = vessel.orbit.semiMajorAxis;
+            celestialLongitude.value = Planetarium.right.AngleInPlane(-Planetarium.up, orbitalPosition);
             latitude.value = vessel.mainBody.GetLatitude(CoM);
             longitude.value = MuUtils.ClampDegrees180(vessel.mainBody.GetLongitude(CoM));
 
             if (vessel.mainBody != Planetarium.fetch.Sun)
             {
-                Vector3d delta = vessel.mainBody.getPositionAtUT(Planetarium.GetUniversalTime() + 1) - vessel.mainBody.getPositionAtUT(Planetarium.GetUniversalTime() - 1);
-                Vector3d plUp = Vector3d.Cross(vessel.mainBody.getPositionAtUT(Planetarium.GetUniversalTime()) - vessel.mainBody.referenceBody.getPositionAtUT(Planetarium.GetUniversalTime()), vessel.mainBody.getPositionAtUT(Planetarium.GetUniversalTime() + vessel.mainBody.orbit.period / 4) - vessel.mainBody.referenceBody.getPositionAtUT(Planetarium.GetUniversalTime() + vessel.mainBody.orbit.period / 4)).normalized;
-                angleToPrograde = MuUtils.ClampDegrees360((((vessel.orbit.inclination > 90) || (vessel.orbit.inclination < -90)) ? 1 : -1) * ((Vector3)up).AngleInPlane(plUp, delta));
+                Vector3d prograde = vessel.mainBody.orbit.getOrbitalVelocityAtUT(time).xzy;
+                Vector3d normal = vessel.mainBody.orbit.GetOrbitNormal().xzy;
+                angleToPrograde = MuUtils.ClampDegrees360( (((vessel.orbit.inclination > 90) || (vessel.orbit.inclination < -90)) ? 1 : -1) * orbitalPosition.AngleInPlane(normal, prograde) );
             }
             else
             {


### PR DESCRIPTION
- Cleans up and extracts the TimeToPlane algorithm using clearer spherical trig computation
- Cleans up the angleToPrograde calculation
- The orbitLAN value is now always the orbitalLAN, even when landed
- The celestialLongitude value is the celestial longitude of the current vessel position (formerly what orbitLAN was when landed)
- The Vector3 ProjectIntoPlane and Vector3d ProjectOnPlane methods have been consolidated into one Vector3d ProjectOnPlane method