### PR TITLE
Add the ability to execute Principia nodes

### DIFF
--- a/Localization/en-us.cfg
+++ b/Localization/en-us.cfg
@@ -596,6 +596,7 @@ Localization
         #MechJeb_NodeEd_button4 = Execute next node
         #MechJeb_NodeEd_button5 = Execute all nodes
         #MechJeb_NodeEd_button6 = Abort node execution
+        #MechJeb_NodeEd_button7 = Execute next Principia node
 
         #MechJeb_NodeEd_checkbox1 = Auto-warp
 

--- a/Localization/zh-cn.cfg
+++ b/Localization/zh-cn.cfg
@@ -596,6 +596,7 @@ Localization
         #MechJeb_NodeEd_button4 = 执行下一个节点
         #MechJeb_NodeEd_button5 = 执行全部节点
         #MechJeb_NodeEd_button6 = 中止节点执行
+        #MechJeb_NodeEd_button7 = 执行下一个Principia节点
 
         #MechJeb_NodeEd_checkbox1 = 自动加速
 

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -740,13 +740,13 @@ namespace MuMech
 
         static MechJebModuleGuidanceController()
         {
-            isLoadedPrincipia = ReflectionUtils.isAssemblyLoaded("ksp_plugin_adapter");
+            isLoadedPrincipia = ReflectionUtils.isAssemblyLoaded("principia.ksp_plugin_adapter");
             if (isLoadedPrincipia)
             {
-                principiaEGNPCDOF = ReflectionUtils.getMethodByReflection("ksp_plugin_adapter", "principia.ksp_plugin_adapter.Interface", "ExternalGetNearestPlannedCoastDegreesOfFreedom", BindingFlags.NonPublic | BindingFlags.Static);
+                principiaEGNPCDOF = ReflectionUtils.getMethodByReflection("principia.ksp_plugin_adapter", "principia.ksp_plugin_adapter.Interface", "ExternalGetNearestPlannedCoastDegreesOfFreedom", BindingFlags.NonPublic | BindingFlags.Static);
                 if (principiaEGNPCDOF == null)
                 {
-                    // Debug.Log("failed to find ExternalGetNearestPlannedCoastDegreesOfFreedom");
+                    Debug.Log("failed to find ExternalGetNearestPlannedCoastDegreesOfFreedom");
                     isLoadedPrincipia = false;
                     return;
                 }

--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -131,7 +131,7 @@ namespace MuMech
                         core.node.ExecuteOneNode(this);
                     }
 					
-					if (GUILayout.Button(Localizer.Format("Execute next Principia node")))
+					if (MechJebModuleGuidanceController.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
 					{
                         core.node.ExecuteOnePNode(this);
                     }

--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -131,8 +131,8 @@ namespace MuMech
                         core.node.ExecuteOneNode(this);
                     }
 					
-					if (MechJebModuleGuidanceController.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
-					{
+		    if (MechJebModuleGuidanceController.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
+		    {
                         core.node.ExecuteOnePNode(this);
                     }
 

--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -130,6 +130,11 @@ namespace MuMech
                     {
                         core.node.ExecuteOneNode(this);
                     }
+					
+					if (GUILayout.Button(Localizer.Format("Execute next Principia node")))
+					{
+                        core.node.ExecuteOnePNode(this);
+                    }
 
                     if (vessel.patchedConicSolver.maneuverNodes.Count > 1)
                     {

--- a/MechJeb2/MechJebModuleNodeEditor.cs
+++ b/MechJeb2/MechJebModuleNodeEditor.cs
@@ -230,7 +230,7 @@ namespace MuMech
                         core.node.ExecuteOneNode(this);
                     }
 					
-					if (GUILayout.Button(Localizer.Format("Execute next Principia node")))
+					if (MechJebModuleGuidanceController.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
 					{
                         core.node.ExecuteOnePNode(this);
                     }

--- a/MechJeb2/MechJebModuleNodeEditor.cs
+++ b/MechJeb2/MechJebModuleNodeEditor.cs
@@ -230,8 +230,8 @@ namespace MuMech
                         core.node.ExecuteOneNode(this);
                     }
 					
-					if (MechJebModuleGuidanceController.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
-					{
+		    if (MechJebModuleGuidanceController.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
+		    {
                         core.node.ExecuteOnePNode(this);
                     }
 

--- a/MechJeb2/MechJebModuleNodeEditor.cs
+++ b/MechJeb2/MechJebModuleNodeEditor.cs
@@ -229,6 +229,11 @@ namespace MuMech
                     {
                         core.node.ExecuteOneNode(this);
                     }
+					
+					if (GUILayout.Button(Localizer.Format("Execute next Principia node")))
+					{
+                        core.node.ExecuteOnePNode(this);
+                    }
 
                     if (vessel.patchedConicSolver.maneuverNodes.Count > 1)
                     {

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -124,7 +124,7 @@ namespace MuMech
 
             double timeToNode = node.UT - vesselState.time;
             //(!double.IsInfinity(num) && num > 0.0 && num2 < num) || num2 <= 0.0
-            if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode < halfBurnTime) || timeToNode < 0)
+            if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode <= 0) || timeToNode < 0)
             {
                 burnTriggered = true;
                 if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
@@ -137,7 +137,7 @@ namespace MuMech
                 {
                     core.warp.WarpToUT(node.UT - halfBurnTime - leadTime);
                 }
-                else if (!MuUtils.PhysicsRunning() && core.attitude.attitudeAngleFromTarget() > 10 && timeToNode < 600)
+                else if (!MuUtils.PhysicsRunning() && core.attitude.attitudeAngleFromTarget() > 10 && timeToNode < halfBurnTime + 30)
                 {
                     //realign
                     core.warp.MinimumWarp();

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -45,6 +45,14 @@ namespace MuMech
             burnTriggered = false;
             alignedForBurn = false;
         }
+		
+        public void ExecuteOnePNode(object controller)
+        {
+            mode = Mode.ONE_PNODE;
+            users.Add(controller);
+            burnTriggered = false;
+            alignedForBurn = false;
+        }		
 
         public void ExecuteAllNodes(object controller)
         {
@@ -73,7 +81,7 @@ namespace MuMech
             core.thrust.users.Remove(this);
         }
 
-        protected enum Mode { ONE_NODE, ALL_NODES };
+        protected enum Mode { ONE_NODE,ONE_PNODE, ALL_NODES };
         protected Mode mode = Mode.ONE_NODE;
 
         public bool burnTriggered = false;
@@ -124,11 +132,22 @@ namespace MuMech
 
             double timeToNode = node.UT - vesselState.time;
             //(!double.IsInfinity(num) && num > 0.0 && num2 < num) || num2 <= 0.0
-            if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode <= 0) || timeToNode < 0)
-            {
-                burnTriggered = true;
-                if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
-            }
+			if (mode == Mode.ONE_NODE)
+			{
+				if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode < halfBurnTime) || timeToNode < 0)
+				{
+					burnTriggered = true;
+					if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
+				}
+			}
+			else if (mode == Mode.ONE_PNODE)
+			{
+				if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode <= 0.0225) || timeToNode < 0)
+				{
+					burnTriggered = true;
+					if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
+				}
+			}
 
             //autowarp, but only if we're already aligned with the node
             if (autowarp && !burnTriggered)

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -46,7 +46,7 @@ namespace MuMech
             alignedForBurn = false;
         }
 		
-        public void ExecuteOnePNode(object controller)
+        public void ExecuteOnePNode(object controller) //Principia Node
         {
             mode = Mode.ONE_PNODE;
             users.Add(controller);

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -132,22 +132,22 @@ namespace MuMech
 
             double timeToNode = node.UT - vesselState.time;
             //(!double.IsInfinity(num) && num > 0.0 && num2 < num) || num2 <= 0.0
-			if (mode == Mode.ONE_NODE)
-			{
-				if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode < halfBurnTime) || timeToNode < 0)
-				{
-					burnTriggered = true;
-					if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
-				}
-			}
-			else if (mode == Mode.ONE_PNODE)
-			{
-				if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode <= 0.0225) || timeToNode < 0)
-				{
-					burnTriggered = true;
-					if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
-				}
-			}
+            if (mode == Mode.ONE_NODE)
+            {
+                if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode < halfBurnTime) || timeToNode < 0)
+                {
+                    burnTriggered = true;
+                    if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
+                }
+            }
+            else if (mode == Mode.ONE_PNODE)
+            {
+                if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode <= 0.0225) || timeToNode < 0)
+                {
+                    burnTriggered = true;
+                    if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
+                }
+            }
 
             //autowarp, but only if we're already aligned with the node
             if (autowarp && !burnTriggered)


### PR DESCRIPTION
This change adds the ability to execute Principia nodes. It adds a new "Execute next Principia node" button in the Maneuver Planner and Node Editor windows, and a new mode in the Node Executor module that executes the burn right on the burn time instead of start time minus half burn time. 

It also changes auto time warp behavior as Principia node is fixed relative to the selected coordinate system, caused it's always moving on the navball, made realign to the node 600 seconds prior to the node execution pretty unusable. So that the time of realigning to the node attitude is changed to half burn time plus 30 seconds prior to the burn time, this should work fine with both stock and Principia. 