### PR TITLE
remove the persistence of the launchLANDifference

### DIFF
--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -95,7 +95,6 @@ namespace MuMech
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public EditableDouble launchPhaseAngle = 0;
 
-        [Persistent(pass = (int)(Pass.Type))]
         public EditableDouble launchLANDifference = 0;
 
         [Persistent(pass = (int)(Pass.Global))]


### PR DESCRIPTION
this should hopefully greatly reduce the number of false bug reports
against launch-to-plane.

it means users who actually want to use this feature need to always
set it up before every launch, but those would necessarily be high
information experienced users vs the naive users who constantly
slam their heads against this feature and can't figure it out.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>