### PR TITLE
Avoid index error in ascent GUI

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -373,7 +373,7 @@ namespace MuMech
                             GUILayout.EndHorizontal();
                         }
 
-                        if ( vessel.situation != Vessel.Situations.LANDED && vessel.situation != Vessel.Situations.PRELAUNCH && vessel.situation != Vessel.Situations.SPLASHED )
+                        if ( vessel.situation != Vessel.Situations.LANDED && vessel.situation != Vessel.Situations.PRELAUNCH && vessel.situation != Vessel.Situations.SPLASHED && atmoStats.Length > vessel.currentStage)
                         {
                             double m0 = atmoStats[vessel.currentStage].startMass;
                             double thrust = atmoStats[vessel.currentStage].startThrust;


### PR DESCRIPTION
This fixes an index range error that occurs during certain scene loading situations. I particularly tended to encounter it if the ascent GUI was open when using the KCT SPH airlaunch feature, but also sometimes when quickloading a VAB flight.