### PR TITLE
Disable launch to interplanetary

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -450,6 +450,8 @@ namespace MuMech
                                 GUILayout.Label("º", GUILayout.ExpandWidth(false));
                                 GUILayout.EndHorizontal();
 
+                                launchingToInterplanetary = false
+                                /*
                                 if (core.target.TargetOrbit.referenceBody == orbit.referenceBody.referenceBody)
                                 {
                                     if (GUILayout.Button(Localizer.Format("#MechJeb_Ascent_button16")))//Launch at interplanetary window
@@ -469,6 +471,7 @@ namespace MuMech
                                         autopilot.StartCountdown(interplanetaryWindowUT);
                                     }
                                 }
+                                */
                             }
                         }
                         else
@@ -505,8 +508,7 @@ namespace MuMech
                             GUILayout.Label(message);
 
                         if (GUILayout.Button(Localizer.Format("#MechJeb_Ascent_button17")))//Abort
-                                launchingToInterplanetary =
-                                    launchingToPlane = launchingToRendezvous = autopilot.timedLaunch = false;
+                                launchingToInterplanetary = launchingToPlane = launchingToRendezvous = autopilot.timedLaunch = false;
                         }
                 }
 


### PR DESCRIPTION
I believe that all this does is confuse people.  Pretty much everyone
uses some other means (Transfer Window Planner + KAC by TriggerAu, etc)
to setup their launches to interplanetary windows.

I never hear of anyone using this feature in MJ, I doubt it works very
well, and suspect that removing it will only reduce the frequency of
questions over it, rather than impacting people.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>