### PR TITLE
PVG staging rework

### DIFF
--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -601,7 +601,7 @@ namespace MuMech
 
                 // Also if we just triggered a KSP stage separation or just started coasting, then wait for 4 seconds for
                 // stats to settle before running the optimizer again.
-                if ((vesselState.time < last_stage_time + 4) || (vesselState.time < last_coasting_time + 4))
+                if ( vesselState.time < last_stage_time + 4 )
                     return;
             }
 
@@ -617,7 +617,6 @@ namespace MuMech
 
         private int last_burning_stage;
         private bool last_burning_stage_complete;
-        private double last_coasting_time = 0.0;
 
         // if we're transitioning from a complete thrust phase to a coast, wait for staging, otherwise
         // just go off of whatever the solution says for the current time.
@@ -665,7 +664,6 @@ namespace MuMech
                 {
                     status = PVGStatus.COASTING;
                 }
-                last_coasting_time = vesselState.time;
 
                 // this turns off autostaging during the coast (which currently affects fairing separation)
                 core.staging.autostageLimitInternal = last_burning_stage - 1;
@@ -748,7 +746,6 @@ namespace MuMech
             status = PVGStatus.INITIALIZING;
             last_stage_time = 0.0;
             last_optimizer_time = 0.0;
-            last_coasting_time = 0.0;
             last_success_time = 0.0;
             last_stale_kill_time = vesselState.time;
             autowarp = false;

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace MuMech
 {
-    public enum PVGStatus { ENABLED, INITIALIZING, CONVERGED, BURNING, COASTING, BURNING_STAGING, COASTING_STAGING, TERMINAL, TERMINAL_RCS, FINISHED, FAILED };
+    public enum PVGStatus { ENABLED, INITIALIZING, CONVERGED, BURNING, COASTING, TERMINAL, TERMINAL_RCS, FINISHED, FAILED };
 
     public class MechJebModuleGuidanceController : ComputerModule
     {
@@ -183,9 +183,6 @@ namespace MuMech
             }
 
             handle_throttle();
-
-            if ( isStaging() )
-                return;
 
             core.stageTracking.Update();
 
@@ -524,22 +521,17 @@ namespace MuMech
         // not TERMINAL guidance or TERMINAL_RCS
         public bool isNormal()
         {
-            return status == PVGStatus.CONVERGED || status == PVGStatus.BURNING || status == PVGStatus.BURNING_STAGING || status == PVGStatus.COASTING || status == PVGStatus.COASTING_STAGING;
+            return status == PVGStatus.CONVERGED || status == PVGStatus.BURNING || status == PVGStatus.COASTING;
         }
 
         public bool isCoasting()
         {
-            return status == PVGStatus.COASTING || status == PVGStatus.COASTING_STAGING;
+            return status == PVGStatus.COASTING;
         }
 
         public bool isBurning()
         {
-            return status == PVGStatus.BURNING || status == PVGStatus.BURNING_STAGING;
-        }
-
-        public bool isStaging()
-        {
-            return status == PVGStatus.BURNING_STAGING || status == PVGStatus.COASTING_STAGING;
+            return status == PVGStatus.BURNING;
         }
 
         public bool isTerminalGuidance()
@@ -600,9 +592,18 @@ namespace MuMech
             if ( (vesselState.time - last_optimizer_time) < MuUtils.Clamp(pvgInterval, 1.00, 30.00) )
                 return;
 
-            // for last 10 seconds of coast phase don't recompute (FIXME: can this go lower?  it was a workaround for a bug)
-            if ( p.solution != null && p.solution.arc(vesselState.time).thrust == 0 && p.solution.current_tgo(vesselState.time) < 10 )
-                return;
+            if ( p.solution != null )
+            {
+                // The current_tgo is the "booster" stage of the solution, it is allowed to go negative, for staging freeze
+                // running the optimizer for 4 seconds on either side of staging.
+                if ( Math.Abs(p.solution.current_tgo(vesselState.time)) < 4 )
+                    return;
+
+                // Also if we just triggered a KSP stage separation or just started coasting, then wait for 4 seconds for
+                // stats to settle before running the optimizer again.
+                if ((vesselState.time < last_stage_time + 4) || (vesselState.time < last_coasting_time + 4))
+                    return;
+            }
 
             p.threadStart(vesselState.time);
             //if ( p.threadStart(vesselState.time) )
@@ -662,10 +663,7 @@ namespace MuMech
 
                 if ( !isTerminalGuidance() )
                 {
-                    if (vesselState.time < last_stage_time + 4)
-                        status = PVGStatus.COASTING_STAGING;
-                    else
-                        status = PVGStatus.COASTING;
+                    status = PVGStatus.COASTING;
                 }
                 last_coasting_time = vesselState.time;
 
@@ -680,10 +678,7 @@ namespace MuMech
 
                 if ( !isTerminalGuidance() )
                 {
-                    if ((vesselState.time < last_stage_time + 4) || (vesselState.time < last_coasting_time + 4))
-                        status = PVGStatus.BURNING_STAGING;
-                    else
-                        status = PVGStatus.BURNING;
+                    status = PVGStatus.BURNING;
                 }
 
                 core.staging.autostageLimitInternal = p.solution.terminal_burn_arc().ksp_stage;

--- a/MechJeb2/Pontryagin/PontryaginBase.cs
+++ b/MechJeb2/Pontryagin/PontryaginBase.cs
@@ -131,10 +131,13 @@ namespace MuMech {
                 return tgo_bar(tbar, n) * t_scale;
             }
 
+            // this is the tgo of the "booster" stage, this is deliberately allowed to go negative if
+            // we're staging so "current" may be a misnomer.
+            //
             public double current_tgo(double t)
             {
-                int n = segment(t);
-                return tgo(t, n);
+                double tbar = ( t - t0 ) / t_scale;
+                return ( segments[0].tmax - tbar ) * t_scale;
             }
 
             public double tgo_bar(double tbar, int n) // tgo for each segment/arc in the solution


### PR DESCRIPTION
Considerably simpler handling of staging conditions.  Optimizer is frozen from 4 seconds before and after any staging event, either planned by the optimized solution or actually initiated by KSP.