### PR TITLE
improves Autoland

### DIFF
--- a/Localization/en-us.cfg
+++ b/Localization/en-us.cfg
@@ -257,6 +257,7 @@ Localization
         #MechJeb_ApproAndLand_label12 = Target vertical speed: <<1>> m/s
         #MechJeb_ApproAndLand_label13 = Target heading: <<1>>º
         #MechJeb_ApproAndLand_label14 = Glide slope:
+        #MechJeb_ApproAndLand_MaxRateOfDescent = Max. rate of descent:
 
         #MechJeb_ApproAndLand_approachState1 = Proceeding to the initial approach point
         #MechJeb_ApproAndLand_approachState2 = Proceeding to the final approach point

--- a/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneGuidance.cs
@@ -55,6 +55,7 @@ namespace MuMech
                 GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_ApproAndLand_label14"), autoland.glideslope,"°");//Autoland glideslope:
                 GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_ApproAndLand_label4"), autoland.approachSpeed, "m/s");//Approach speed:
                 GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_ApproAndLand_label5"), autoland.touchdownSpeed, "m/s");//Touchdown speed:
+                GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_ApproAndLand_MaxRateOfDescent"), autoland.maximumSafeVerticalSpeed, "m/s");//Max rate of descent:
                 autoland.bEngageReverseIfAvailable = GUILayout.Toggle(autoland.bEngageReverseIfAvailable, Localizer.Format("#MechJeb_ApproAndLand_label6"));//Reverse thrust upon touchdown
                 autoland.bBreakAsSoonAsLanded = GUILayout.Toggle(autoland.bBreakAsSoonAsLanded, Localizer.Format("#MechJeb_ApproAndLand_label7"));//Brake as soon as landed
 


### PR DESCRIPTION
1. moves Final Approach Point further away from the runway. Realistically it should be something like 10000m but 5000m already improves things.
2. Climbing into the glideslope is really bad. We should maintain the current altitude until we intercept the glideslope. Unless we are very low of course, then we need to climb to a safe altitude (1500m should be fine for KSC).
3. 15m/s max rate of descent is kind of low. Probably okay for aircrafts but for spaceplanes it's way too low. So I turned that into an input field so the user can customize the value.