### PR TITLE
Autopilot overhaul

### DIFF
--- a/Localization/en-us.cfg
+++ b/Localization/en-us.cfg
@@ -314,7 +314,11 @@ Localization
 
         #MechJeb_Aircraftauto_Label10 = Roll
 
-        #MechJeb_Aircraftauto_Label11 = Yaw Control Limit
+        #MechJeb_Aircraftauto_Limits = Limits:
+        #MechJeb_Aircraftauto_RollLimit = Roll
+        #MechJeb_Aircraftauto_YawLimit = Yaw
+        #MechJeb_Aircraftauto_PitchUpLimit = Pitch up
+        #MechJeb_Aircraftauto_PitchDownLimit = Pitch down
 
     //Ascent Guidance
         #MechJeb_Ascent_title = Ascent Guidance

--- a/Localization/en-us.cfg
+++ b/Localization/en-us.cfg
@@ -284,6 +284,8 @@ Localization
 
         #MechJeb_Aircraftauto_btnset2 = Set
 
+        #MechJeb_Aircraftauto_VS =    V/S ±
+
         #MechJeb_Aircraftauto_Label3 = Vertical Speed Limit
 
         #MechJeb_Aircraftauto_btnset3 = Set
@@ -296,7 +298,7 @@ Localization
 
         #MechJeb_Aircraftauto_btnset5 = Set
 
-        #MechJeb_Aircraftauto_Label6 =     Roll Limit ±
+        #MechJeb_Aircraftauto_Label6 =     Bank angle ±
 
         #MechJeb_Aircraftauto_btnset6 = Set
 
@@ -306,13 +308,11 @@ Localization
 
         #MechJeb_Aircraftauto_Label8 = Accceleration
 
-        #MecgJeb_Aircraftauto_error1 = error:<<1>> Target:<<2>> Cur:<<3>>
-
-        #MechJeb_Aircraftauto_Label9 = VertSpeed
-
-        #MecgJeb_Aircraftauto_error2 = error:<<1>> Target:<<2>> Cur:<<3>>
+        #MecgJeb_Aircraftauto_error1 = Error:<<1>> Target:<<2>> Cur:<<3>>
+        #MecgJeb_Aircraftauto_error2 = Error:<<1>> Target:<<2>> Cur:<<3>> PID: <<4>>
 
         #MechJeb_Aircraftauto_Label10 = Roll
+        #MechJeb_Aircraftauto_Pitch = Pitch
 
         #MechJeb_Aircraftauto_Limits = Limits:
         #MechJeb_Aircraftauto_RollLimit = Roll

--- a/Localization/es-es.cfg
+++ b/Localization/es-es.cfg
@@ -283,6 +283,8 @@ Localization
 
         #MechJeb_Aircraftauto_btnset2 = Fijar
 
+        #MechJeb_Aircraftauto_VS =    V/S ±
+
         #MechJeb_Aircraftauto_Label3 = Límite de velocidad vertical
 
         #MechJeb_Aircraftauto_btnset3 = Fijar
@@ -305,15 +307,18 @@ Localization
 
         #MechJeb_Aircraftauto_Label8 = Aceleración
 
-        #MecgJeb_Aircraftauto_error1 = error:<<1>> Objetivo:<<2>> Cur:<<3>>
+        #MecgJeb_Aircraftauto_error1 = Error:<<1>> Objetivo:<<2>> Cur:<<3>>
 
-        #MechJeb_Aircraftauto_Label9 = Velocidad vert
-
-        #MecgJeb_Aircraftauto_error2 = error:<<1>> Objetivo:<<2>> Cur:<<3>>
+        #MecgJeb_Aircraftauto_error2 = Error:<<1>> Objetivo:<<2>> Cur:<<3>> PID: <<4>>
 
         #MechJeb_Aircraftauto_Label10 = Balanceo
+        #MechJeb_Aircraftauto_Pitch = Pitch
 
-        #MechJeb_Aircraftauto_Label11 = Límite de control de guiñada
+        #MechJeb_Aircraftauto_Limits = Limits:
+        #MechJeb_Aircraftauto_RollLimit = Roll
+        #MechJeb_Aircraftauto_YawLimit = Yaw
+        #MechJeb_Aircraftauto_PitchUpLimit = Pitch up
+        #MechJeb_Aircraftauto_PitchDownLimit = Pitch down
 
     //Ascent Guidance
         #MechJeb_Ascent_title = Guía de ascenso

--- a/Localization/ru.cfg
+++ b/Localization/ru.cfg
@@ -287,6 +287,8 @@ Localization
 
         #MechJeb_Aircraftauto_btnset2 = ЗДТ
 
+        #MechJeb_Aircraftauto_VS =    V/S ±
+
         #MechJeb_Aircraftauto_Label3 = Ограничение вертикальной скорости
 
         #MechJeb_Aircraftauto_btnset3 = ЗДТ
@@ -310,14 +312,16 @@ Localization
         #MechJeb_Aircraftauto_Label8 = Ускорение
 
         #MecgJeb_Aircraftauto_error1 = Ошибка:<<1>> Цель:<<2>> Тек.:<<3>>
-
-        #MechJeb_Aircraftauto_Label9 = ВертСкор
-
-        #MecgJeb_Aircraftauto_error2 = Ошибка:<<1>> Цель:<<2>> Тек.:<<3>>
+        #MecgJeb_Aircraftauto_error2 = Ошибка:<<1>> Цель:<<2>> Тек.:<<3>> PID: <<4>>
 
         #MechJeb_Aircraftauto_Label10 = Крен
+        #MechJeb_Aircraftauto_Pitch = Pitch
 
-        #MechJeb_Aircraftauto_Label11 = Лимит управления рысканьем
+        #MechJeb_Aircraftauto_Limits = Limits:
+        #MechJeb_Aircraftauto_RollLimit = Roll
+        #MechJeb_Aircraftauto_YawLimit = Yaw
+        #MechJeb_Aircraftauto_PitchUpLimit = Pitch up
+        #MechJeb_Aircraftauto_PitchDownLimit = Pitch down
 
     //Ascent Guidance
         #MechJeb_Ascent_title = Помощник подъема

--- a/Localization/zh-cn.cfg
+++ b/Localization/zh-cn.cfg
@@ -283,6 +283,8 @@ Localization
 
         #MechJeb_Aircraftauto_btnset2 = 设置
 
+        #MechJeb_Aircraftauto_VS =    V/S ±
+
         #MechJeb_Aircraftauto_Label3 = 垂直速度限制
 
         #MechJeb_Aircraftauto_btnset3 = 设置
@@ -306,14 +308,16 @@ Localization
         #MechJeb_Aircraftauto_Label8 = 加速度
 
         #MecgJeb_Aircraftauto_error1 = 错误:<<1>> 目标:<<2>> 当前:<<3>>
-
-        #MechJeb_Aircraftauto_Label9 = 垂直速度
-
-        #MecgJeb_Aircraftauto_error2 = 错误:<<1>> 目标:<<2>> 当前:<<3>>
+        #MecgJeb_Aircraftauto_error2 = 错误:<<1>> 目标:<<2>> 当前:<<3>> PID: <<4>>
 
         #MechJeb_Aircraftauto_Label10 = 滚转角
+        #MechJeb_Aircraftauto_Pitch = Pitch
 
-        #MechJeb_Aircraftauto_Label11 = 偏航控制限制
+        #MechJeb_Aircraftauto_Limits = Limits:
+        #MechJeb_Aircraftauto_RollLimit = Roll
+        #MechJeb_Aircraftauto_YawLimit = Yaw
+        #MechJeb_Aircraftauto_PitchUpLimit = Pitch up
+        #MechJeb_Aircraftauto_PitchDownLimit = Pitch down
 
     //Ascent Guidance
         #MechJeb_Ascent_title = 自动发射

--- a/MechJeb2/MechJebModuleAirplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleAirplaneAutopilot.cs
@@ -20,13 +20,13 @@ namespace MuMech
         public EditableDouble AccKp = 0.5, AccKi = 0.5, AccKd = 0.005;
 
         [Persistent(pass = (int)Pass.Global)]
-        public EditableDouble PitKp = 2, PitKi = 0.5, PitKd = 0.001;
+        public EditableDouble PitKp = 2.0, PitKi = 0.5, PitKd = 0.5;
 
         [Persistent (pass = (int)Pass.Global)]
-        public EditableDouble RolKp = 0.5, RolKi = 0.08, RolKd = 0.75;
+        public EditableDouble RolKp = 0.5, RolKi = 0.02, RolKd = 0.5;
 
         [Persistent (pass = (int)Pass.Global)]
-        public EditableDouble YawKp = 0.25, YawKi = 0.3, YawKd = 0.75;
+        public EditableDouble YawKp = 4.0, YawKi = 0.01, YawKd = 0.02;
 
         [Persistent (pass = (int)Pass.Local)]
         public EditableDouble YawLimit = 10, RollLimit = 45, PitchDownLimit = 15, PitchUpLimit = 25;

--- a/MechJeb2/MechJebModuleAirplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleAirplaneAutopilot.cs
@@ -7,33 +7,37 @@ namespace MuMech
 {
     public class MechJebModuleAirplaneAutopilot : ComputerModule
     {
+        [Persistent(pass = (int)Pass.Local)]
         public bool HeadingHoldEnabled = false, AltitudeHoldEnabled = false, VertSpeedHoldEnabled = false, RollHoldEnabled = false, SpeedHoldEnabled = false;
 
-        [Persistent (pass = (int)Pass.Global)]
+        [Persistent (pass = (int)Pass.Local)]
         public double AltitudeTarget = 0, HeadingTarget = 90, RollTarget = 0, SpeedTarget = 0, VertSpeedTarget = 0;
+
+        [Persistent(pass = (int)Pass.Local)]
+        public double BankAngle = 30;
 
         [Persistent (pass = (int)Pass.Global)]
         public EditableDouble AccKp = 0.5, AccKi = 0.5, AccKd = 0.005;
 
-        [Persistent (pass = (int)Pass.Global)]
-        public EditableDouble VerKp = 1, VerKi = 0.1, VerKd = 0.01;
-
         [Persistent(pass = (int)Pass.Global)]
         public EditableDouble PitKp = 2, PitKi = 0.5, PitKd = 0.001;
 
-        private double VerPIDScale = 1;
-
+        [Persistent (pass = (int)Pass.Global)]
+        public EditableDouble RolKp = 0.5, RolKi = 0.08, RolKd = 0.75;
 
         [Persistent (pass = (int)Pass.Global)]
-        public EditableDouble RolKp = 0.2, RolKi = 0.01, RolKd = 0.001;
+        public EditableDouble YawKp = 0.25, YawKi = 0.3, YawKd = 0.75;
 
-        [Persistent (pass = (int)Pass.Global)]
-        public EditableDouble YawKp = 2, YawKi = 0.01, YawKd = 0.001;
+        [Persistent (pass = (int)Pass.Local)]
+        public EditableDouble YawLimit = 10, RollLimit = 45, PitchDownLimit = 15, PitchUpLimit = 25;
 
-        [Persistent (pass = (int)Pass.Global)]
-        public EditableDouble YawLimit = 45, RollLimit = 5, PitchDownLimit = 10, PitchUpLimit = 25;
+        public PIDController AccelerationPIDController, PitchPIDController, RollPIDController, YawPIDController;
 
-        public PIDController AccelerationPIDController, VertSpeedPIDController, PitchPIDController, RollPIDController, YawPIDController;
+        public double a_err, cur_acc, _spd;
+        public double curr_yaw;
+        public double pitch_err, roll_err, yaw_err;
+        public double pitch_act, roll_act, yaw_act;
+        public double RealVertSpeedTarget, RealPitchTarget, RealRollTarget, RealYawTarget, RealAccelerationTarget;
 
         public MechJebModuleAirplaneAutopilot (MechJebCore core) : base (core)
         {
@@ -43,7 +47,6 @@ namespace MuMech
         public override void OnStart (PartModule.StartState state)
         {
             AccelerationPIDController = new PIDController (AccKp, AccKi, AccKd);
-            VertSpeedPIDController = new PIDController (VerKp, VerKi, VerKd);
             PitchPIDController = new PIDController(PitKp, PitKi, PitKd);
             RollPIDController = new PIDController (RolKp, RolKi, RolKd);
             YawPIDController = new PIDController (YawKp, YawKi, YawKd);
@@ -102,7 +105,6 @@ namespace MuMech
             if (!enabled)
                 return;
             VertSpeedHoldEnabled = true;
-            VertSpeedPIDController.Reset ();
             PitchPIDController.Reset();
         }
 
@@ -119,7 +121,6 @@ namespace MuMech
                 return;
             AltitudeHoldEnabled = true;
             if (VertSpeedHoldEnabled) {
-                VertSpeedPIDController.Reset ();
                 PitchPIDController.Reset();
             } else {
                 EnableVertSpeedHold ();
@@ -134,7 +135,7 @@ namespace MuMech
             DisableVertSpeedHold ();
         }
 
-        double fixVertSpeed (double deltaAltitude)
+        private double convertAltitudeToVerticalSpeed (double deltaAltitude)
         {
             double reference = 5;
             if (reference < 2)
@@ -159,10 +160,6 @@ namespace MuMech
 
         void UpdatePID ()
         {
-            VerPIDScale = (0.0015885994 * vessel.totalMass + 0.0031753299) * fixPIDfromSpeed (vesselState.speedSurface);
-            VertSpeedPIDController.Kp = VerKp * VerPIDScale;
-            VertSpeedPIDController.Ki = VerKi * VerPIDScale;
-            VertSpeedPIDController.Kd = VerKd * VerPIDScale;
             AccelerationPIDController.Kp = AccKp;
             AccelerationPIDController.Ki = AccKi;
             AccelerationPIDController.Kd = AccKd;
@@ -176,9 +173,6 @@ namespace MuMech
             YawPIDController.Ki = YawKi;
             YawPIDController.Kd = YawKd;
         }
-
-        public double a_err, cur_acc, _spd;
-        public double RealVertSpeedTarget, RealRollTarget, RealAccelerationTarget;
 
         public override void Drive (FlightCtrlState s)
         {
@@ -202,109 +196,90 @@ namespace MuMech
             }
 
             //AltitudeHold (set VertSpeed automatically to hold altitude)
-            if (AltitudeHoldEnabled)
-                RealVertSpeedTarget = fixVertSpeed(AltitudeTarget - vesselState.altitudeASL);
+            if (AltitudeHoldEnabled) {
+                RealVertSpeedTarget = convertAltitudeToVerticalSpeed(AltitudeTarget - vesselState.altitudeASL);
+                RealVertSpeedTarget = UtilMath.Clamp(RealVertSpeedTarget, -VertSpeedTarget, VertSpeedTarget);
+            }
             else
                 RealVertSpeedTarget = VertSpeedTarget;
 
+            pitch_err = roll_err = yaw_err = 0;
+            pitch_act = roll_act = yaw_act = 0;
+
             //VertSpeedHold
             if (VertSpeedHoldEnabled) {
-                double pitch_err = 0;
+                // NOTE: 60-to-1 rule:
+                // deltaAltitude = 2 * PI * r * deltaPitch / 360
+                // Vvertical = 2 * PI * TAS * deltaPitch / 360
+                // deltaPitch = Vvertical / Vhorizontal * 180 / PI
                 double deltaVertSpeed = RealVertSpeedTarget - vesselState.speedVertical;
+                double adjustment = 180 / vesselState.speedSurface * deltaVertSpeed / Math.PI;
+                RealPitchTarget = vesselState.vesselPitch + adjustment;
 
-                if (deltaVertSpeed > 0)
-                {
-                    double remainingPitchRange = (PitchUpLimit - vesselState.vesselPitch) * .9;
+                RealPitchTarget = UtilMath.Clamp(RealPitchTarget, -PitchDownLimit, PitchUpLimit);
+                pitch_err = MuUtils.ClampDegrees180(RealPitchTarget - vesselState.vesselPitch);
 
-                    if (remainingPitchRange > 0)
-                    {
-                        double sc = UtilMath.Clamp(Math.Abs(deltaVertSpeed / RealVertSpeedTarget), 0, 1);
-                        double exp = (Math.Log(remainingPitchRange + 1) - Math.Log(1)) * sc;
-                        pitch_err = Math.Exp(exp) - 1;
-                    }
-                }
-                else
-                {
-                    double remainingPitchRange = (vesselState.vesselPitch - -PitchDownLimit) * .9;
-
-                    if (remainingPitchRange > 0)
-                    {
-                        double sc = UtilMath.Clamp(Math.Abs(deltaVertSpeed / RealVertSpeedTarget), 0, 1);
-                        double exp = (Math.Log(remainingPitchRange + 1) - Math.Log(1)) * sc;
-                        pitch_err = -(Math.Exp(exp) - 1);
-                    }
-                }
-
-                // above pitch up limit
-                if (PitchUpLimit < vesselState.vesselPitch)
-                    pitch_err = UtilMath.Min(pitch_err, PitchUpLimit - vesselState.vesselPitch);
-                // below pitch down limit
-                else if (-PitchDownLimit > vesselState.vesselPitch)
-                    pitch_err = UtilMath.Max(pitch_err, -PitchDownLimit - vesselState.vesselPitch);
-
-                //PitchPIDController.intAccum = MuUtils.Clamp (PitchPIDController.intAccum, -1 / (VerKi * VerPIDScale), 1 / (VerKi * VerPIDScale));
                 PitchPIDController.intAccum = UtilMath.Clamp(PitchPIDController.intAccum, -100 / PitKi , 100 / PitKi);
-                double p_act = PitchPIDController.Compute (pitch_err);
+                pitch_act = PitchPIDController.Compute (pitch_err) / 100;
 
-                print("init: " + PitchPIDController.intAccum + " err: " + pitch_err + " act: " + p_act / 100);
                 //Debug.Log (p_act);
-                if (double.IsNaN (p_act)) {
+                if (double.IsNaN (pitch_act)) {
                     PitchPIDController.Reset ();
                 } else {
-                    s.pitch = Mathf.Clamp ((float)p_act / 100, -1, 1);
+                    s.pitch = Mathf.Clamp ((float)pitch_act, -1, 1);
                 }
             }
 
             //HeadingHold
-            double curHeading = vesselState.HeadingFromDirection (vesselState.forward);
+            double curFlightPath = vesselState.HeadingFromDirection (vesselState.forward);
+            // NOTE: we can not use vesselState.vesselHeading here because it interpolates headings internally
+            //       i.e. turning from 1° to 359° will end up as (1+359)/2 = 180°
+            //       see class MovingAverage for more details
+            curr_yaw = vesselState.currentHeading - curFlightPath;
+
             if (HeadingHoldEnabled) {
-                double toturn = MuUtils.ClampDegrees180 (HeadingTarget - curHeading);
-                RealRollTarget = MuUtils.Clamp (toturn * 2, -RollLimit, RollLimit);
+                double toturn = MuUtils.ClampDegrees180 (HeadingTarget - curFlightPath);
+
+                if (Math.Abs(toturn) < 0.2) {
+                    // yaw for small adjustments
+                    RealYawTarget = MuUtils.Clamp(toturn * 2, -YawLimit, YawLimit);
+                    RealRollTarget = 0;
+                } else {
+                    // roll for large adjustments
+                    RealYawTarget = 0;
+                    RealRollTarget = MuUtils.Clamp (toturn * 2, -RollLimit, RollLimit);
+                }
             } else {
                 RealRollTarget = RollTarget;
+                RealYawTarget = 0;
             }
 
             if (RollHoldEnabled) {
-                double roll_err = MuUtils.ClampDegrees180 (vesselState.vesselRoll + RealRollTarget);
+                RealRollTarget = UtilMath.Clamp(RealRollTarget, -BankAngle, BankAngle);
+                RealRollTarget = UtilMath.Clamp(RealRollTarget, -RollLimit, RollLimit);
+                roll_err = MuUtils.ClampDegrees180(RealRollTarget - -vesselState.currentRoll);
+
                 RollPIDController.intAccum = MuUtils.Clamp (RollPIDController.intAccum, -100 / RolKi, 100 / RolKi);
-                double roll_act = RollPIDController.Compute (roll_err);
-                s.roll = Mathf.Clamp ((float)roll_act / 100, -1, 1);
+                roll_act = RollPIDController.Compute (roll_err) / 100;
+
+                if (double.IsNaN(roll_act))
+                    RollPIDController.Reset();
+                else
+                    s.roll = Mathf.Clamp((float)roll_act, -1, 1);
             }
 
             if (HeadingHoldEnabled) {
-                float YawActLimit = 0.5f;
-                double yaw_err = MuUtils.ClampDegrees180 (HeadingTarget - curHeading);
-                yaw_err = UtilMath.Clamp(yaw_err, -YawLimit, YawLimit);
-                YawPIDController.intAccum = MuUtils.Clamp (YawPIDController.intAccum, -YawActLimit * 100 / YawKi, YawActLimit * 100 / YawKi);
-                double yaw_act = YawPIDController.Compute (yaw_err);
-                s.yaw = Mathf.Clamp((float)yaw_act / 100, -YawActLimit, +YawActLimit);
+                RealYawTarget = UtilMath.Clamp(RealYawTarget, -YawLimit, YawLimit);
+                yaw_err = MuUtils.ClampDegrees180 (RealYawTarget - curr_yaw);
+                
+                YawPIDController.intAccum = MuUtils.Clamp (YawPIDController.intAccum, -100 / YawKi, 100 / YawKi);
+                yaw_act = YawPIDController.Compute (yaw_err) / 100;
+
+                if (double.IsNaN(yaw_act))
+                    YawPIDController.Reset();
+                else
+                    s.yaw = Mathf.Clamp((float)yaw_act, -1, 1);
             }
-        }
-
-        private double calculateSteeringError(double current, double target, double minLimit, double maxLimit)
-        {
-            double margin = 0.1;
-            double error = 0;
-            double delta = target - current;
-            double remainingRange = delta > 0 ? (maxLimit - current) * (1 - margin) : (current - minLimit) * (1 - margin);
-
-            if (remainingRange > 0)
-            {
-                double sc = UtilMath.Clamp(Math.Abs(delta / target), 0, 1);
-                double exp = (Math.Log(remainingRange + 1) - Math.Log(1)) * sc;
-                error = Math.Exp(exp) - 1;
-
-                if (delta < 0)
-                    error = -error;
-            }
-
-            // corrective steering back into operational limits [minLimit, maxLimit]
-            if (current > maxLimit)
-                error = UtilMath.Min(error, (maxLimit - current) * (1 + margin));
-            else if (current < minLimit)
-                error = UtilMath.Max(error, minLimit - current);
-
-            return error;
         }
     }
 }

--- a/MechJeb2/MechJebModuleAirplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleAirplaneGuidance.cs
@@ -18,7 +18,7 @@ namespace MuMech
         bool showpid = false;
 
         [Persistent (pass = (int)Pass.Global)]
-        EditableDouble AltitudeTargettmp = 0, HeadingTargettmp = 90, RollTargettmp = 0, SpeedTargettmp = 0, VertSpeedTargettmp = 0, VertSpeedMaxtmp = 10, RollMaxtmp = 30;
+        EditableDouble AltitudeTargettmp = 0, HeadingTargettmp = 90, RollTargettmp = 0, SpeedTargettmp = 0, VertSpeedTargettmp = 0, RollMaxtmp = 30;
 
         protected override void WindowGUI (int windowID)
         {
@@ -104,20 +104,6 @@ namespace MuMech
                     autopilot.VertSpeedTarget = VertSpeedTargettmp;
                 }
                 GUILayout.EndHorizontal ();
-            } else {
-                GUILayout.BeginHorizontal ();
-                GUILayout.Label (Localizer.Format("#MechJeb_Aircraftauto_Label3"), GUILayout.Width (140));//Vertical Speed Limit
-                change = false;
-                if (GUILayout.Button("-", GUILayout.Width(18))) { VertSpeedMaxtmp.val -= (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); change = true; }
-                VertSpeedMaxtmp.text = GUILayout.TextField (VertSpeedMaxtmp.text, GUILayout.ExpandWidth (true), GUILayout.Width (60));
-                if (GUILayout.Button("+", GUILayout.Width(18))) { VertSpeedMaxtmp.val += (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); change = true; }
-                if (VertSpeedMaxtmp < 0)
-                    VertSpeedMaxtmp = 0;
-                GUILayout.Label ("m/s", GUILayout.ExpandWidth (true));
-                if (change || GUILayout.Button (Localizer.Format("#MechJeb_Aircraftauto_btnset3"), autopilot.VertSpeedMax == VertSpeedMaxtmp ? btWhite : btGreen)) {
-                    autopilot.VertSpeedMax = VertSpeedMaxtmp;
-                }
-                GUILayout.EndHorizontal ();
             }
 
 
@@ -164,8 +150,8 @@ namespace MuMech
                 if (GUILayout.Button("+", GUILayout.Width(18))) { RollMaxtmp.val += (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); change = true; }
                 RollMaxtmp = MuUtils.Clamp (RollMaxtmp, -60, 60);
                 GUILayout.Label ("°", GUILayout.ExpandWidth (true));
-                if (change || GUILayout.Button (Localizer.Format("#MechJeb_Aircraftauto_btnset6"), autopilot.RollMax == RollMaxtmp ? btWhite : btGreen)) {
-                    autopilot.RollMax = RollMaxtmp;
+                if (change || GUILayout.Button (Localizer.Format("#MechJeb_Aircraftauto_btnset6"), autopilot.RollLimit == RollMaxtmp ? btWhite : btGreen)) {
+                    autopilot.RollLimit = RollMaxtmp;
                 }
                 GUILayout.EndHorizontal ();
             }
@@ -213,19 +199,19 @@ namespace MuMech
                 if (autopilot.SpeedHoldEnabled)
                     GUILayout.Label (Localizer.Format("#MecgJeb_Aircraftauto_error1", autopilot.a_err.ToString ("F2"),autopilot.RealAccelerationTarget.ToString ("F2"),autopilot.cur_acc.ToString ("F2")),GUILayout.ExpandWidth (false));//"error:"<<1>>" Target:"<<2>> " Cur:"<<3>>
 
-                GUILayout.BeginHorizontal ();
-                GUILayout.Label (Localizer.Format("#MechJeb_Aircraftauto_Label9"), GUILayout.ExpandWidth (true));//"VertSpeed"
-                GUILayout.Label ("Kp", GUILayout.ExpandWidth (false));
-                autopilot.VerKp.text = GUILayout.TextField (autopilot.VerKp.text, GUILayout.Width (40));
-                GUILayout.Label ("i", GUILayout.ExpandWidth (false));
-                autopilot.VerKi.text = GUILayout.TextField (autopilot.VerKi.text, GUILayout.Width (40));
-                GUILayout.Label ("d", GUILayout.ExpandWidth (false));
-                autopilot.VerKd.text = GUILayout.TextField (autopilot.VerKd.text, GUILayout.Width (40));
-                GUILayout.EndHorizontal ();
-                if (autopilot.VertSpeedHoldEnabled)
-                    GUILayout.Label(Localizer.Format("#MecgJeb_Aircraftauto_error2", autopilot.v_err.ToString("F2"), autopilot.RealVertSpeedTarget.ToString("F2"), vesselState.speedVertical.ToString("F2"), GUILayout.ExpandWidth(false)));//error:" Target:"" Cur:"
-                
-                GUILayout.BeginHorizontal ();
+                GUILayout.BeginHorizontal();
+                GUILayout.Label(Localizer.Format("#MechJeb_Aircraftauto_Label9"), GUILayout.ExpandWidth(true));//"VertSpeed"
+                GUILayout.Label("Kp", GUILayout.ExpandWidth(false));
+                autopilot.PitKp.text = GUILayout.TextField(autopilot.PitKp.text, GUILayout.Width(40));
+                GUILayout.Label("i", GUILayout.ExpandWidth(false));
+                autopilot.PitKi.text = GUILayout.TextField(autopilot.PitKi.text, GUILayout.Width(40));
+                GUILayout.Label("d", GUILayout.ExpandWidth(false));
+                autopilot.PitKd.text = GUILayout.TextField(autopilot.PitKd.text, GUILayout.Width(40));
+                GUILayout.EndHorizontal();
+                //if (autopilot.VertSpeedHoldEnabled)
+                    //    GUILayout.Label(Localizer.Format("#MecgJeb_Aircraftauto_error2", autopilot.v_err.ToString("F2"), autopilot.RealVertSpeedTarget.ToString("F2"), vesselState.speedVertical.ToString("F2"), GUILayout.ExpandWidth(false)));//error:" Target:"" Cur:"
+
+                    GUILayout.BeginHorizontal ();
                 GUILayout.Label (Localizer.Format("#MechJeb_Aircraftauto_Label10"), GUILayout.ExpandWidth (true));//Roll
                 GUILayout.Label ("Kp", GUILayout.ExpandWidth (false));
                 autopilot.RolKp.text = GUILayout.TextField (autopilot.RolKp.text, GUILayout.Width (40));
@@ -244,9 +230,20 @@ namespace MuMech
                 GUILayout.Label ("d", GUILayout.ExpandWidth (false));
                 autopilot.YawKd.text = GUILayout.TextField (autopilot.YawKd.text, GUILayout.Width (40));
                 GUILayout.EndHorizontal ();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label (Localizer.Format("#MechJeb_Aircraftauto_Limits"), GUILayout.ExpandWidth (false));//Yaw Control Limit
+                GUILayout.EndHorizontal();
+
                 GUILayout.BeginHorizontal ();
-                GUILayout.Label (Localizer.Format("#MechJeb_Aircraftauto_Label11"), GUILayout.ExpandWidth (false));//Yaw Control Limit
+                GUILayout.Label (Localizer.Format("#MechJeb_Aircraftauto_PitchDownLimit"), GUILayout.ExpandWidth (false));
+                autopilot.PitchDownLimit.text = GUILayout.TextField(autopilot.PitchDownLimit.text, GUILayout.Width(40));
+                GUILayout.Label(Localizer.Format("#MechJeb_Aircraftauto_PitchUpLimit"), GUILayout.ExpandWidth(false));
+                autopilot.PitchUpLimit.text = GUILayout.TextField(autopilot.PitchUpLimit.text, GUILayout.Width(40));
+                GUILayout.Label(Localizer.Format("#MechJeb_Aircraftauto_YawLimit"), GUILayout.ExpandWidth(false));
                 autopilot.YawLimit.text = GUILayout.TextField (autopilot.YawLimit.text, GUILayout.Width (40));
+                GUILayout.Label(Localizer.Format("#MechJeb_Aircraftauto_RollLimit"), GUILayout.ExpandWidth(false));
+                autopilot.RollLimit.text = GUILayout.TextField(autopilot.RollLimit.text, GUILayout.Width(40));
                 GUILayout.EndHorizontal ();
             }
             base.WindowGUI (windowID);

--- a/MechJeb2/MechJebModuleAirplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleAirplaneGuidance.cs
@@ -15,6 +15,7 @@ namespace MuMech
 
         }
 
+        [Persistent(pass = (int)Pass.Local)]
         bool showpid = false;
 
         [Persistent (pass = (int)Pass.Global)]
@@ -104,6 +105,18 @@ namespace MuMech
                     autopilot.VertSpeedTarget = VertSpeedTargettmp;
                 }
                 GUILayout.EndHorizontal ();
+            } else {
+                GUILayout.BeginHorizontal();
+                GUILayout.Label(Localizer.Format("#MechJeb_Aircraftauto_VS"), GUILayout.Width(140));//"    V/S ±"
+                change = false;
+                if (GUILayout.Button("-", GUILayout.Width(18))) { VertSpeedTargettmp.val -= (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); change = true; }
+                VertSpeedTargettmp.text = GUILayout.TextField(VertSpeedTargettmp.text, GUILayout.ExpandWidth(true), GUILayout.Width(60));
+                if (GUILayout.Button("+", GUILayout.Width(18))) { VertSpeedTargettmp.val += (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); change = true; }
+                GUILayout.Label("°", GUILayout.ExpandWidth(true));
+                if (change || GUILayout.Button(Localizer.Format("#MechJeb_Aircraftauto_btnset6"), autopilot.VertSpeedTarget == VertSpeedTargettmp ? btWhite : btGreen)) {
+                    autopilot.VertSpeedTarget = VertSpeedTargettmp;
+                }
+                GUILayout.EndHorizontal();
             }
 
 
@@ -150,8 +163,11 @@ namespace MuMech
                 if (GUILayout.Button("+", GUILayout.Width(18))) { RollMaxtmp.val += (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); change = true; }
                 RollMaxtmp = MuUtils.Clamp (RollMaxtmp, -60, 60);
                 GUILayout.Label ("°", GUILayout.ExpandWidth (true));
-                if (change || GUILayout.Button (Localizer.Format("#MechJeb_Aircraftauto_btnset6"), autopilot.RollLimit == RollMaxtmp ? btWhite : btGreen)) {
-                    autopilot.RollLimit = RollMaxtmp;
+
+                print("GUI: " + autopilot.BankAngle + " vs " + RollMaxtmp);
+
+                if (change || GUILayout.Button (Localizer.Format("#MechJeb_Aircraftauto_btnset6"), autopilot.BankAngle == RollMaxtmp ? btWhite : btGreen)) {
+                    autopilot.BankAngle = RollMaxtmp;
                 }
                 GUILayout.EndHorizontal ();
             }
@@ -200,7 +216,7 @@ namespace MuMech
                     GUILayout.Label (Localizer.Format("#MecgJeb_Aircraftauto_error1", autopilot.a_err.ToString ("F2"),autopilot.RealAccelerationTarget.ToString ("F2"),autopilot.cur_acc.ToString ("F2")),GUILayout.ExpandWidth (false));//"error:"<<1>>" Target:"<<2>> " Cur:"<<3>>
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_Aircraftauto_Label9"), GUILayout.ExpandWidth(true));//"VertSpeed"
+                GUILayout.Label(Localizer.Format("#MechJeb_Aircraftauto_Pitch"), GUILayout.ExpandWidth(true));//"VertSpeed"
                 GUILayout.Label("Kp", GUILayout.ExpandWidth(false));
                 autopilot.PitKp.text = GUILayout.TextField(autopilot.PitKp.text, GUILayout.Width(40));
                 GUILayout.Label("i", GUILayout.ExpandWidth(false));
@@ -208,10 +224,10 @@ namespace MuMech
                 GUILayout.Label("d", GUILayout.ExpandWidth(false));
                 autopilot.PitKd.text = GUILayout.TextField(autopilot.PitKd.text, GUILayout.Width(40));
                 GUILayout.EndHorizontal();
-                //if (autopilot.VertSpeedHoldEnabled)
-                    //    GUILayout.Label(Localizer.Format("#MecgJeb_Aircraftauto_error2", autopilot.v_err.ToString("F2"), autopilot.RealVertSpeedTarget.ToString("F2"), vesselState.speedVertical.ToString("F2"), GUILayout.ExpandWidth(false)));//error:" Target:"" Cur:"
+                if (autopilot.VertSpeedHoldEnabled)
+                   GUILayout.Label(Localizer.Format("#MecgJeb_Aircraftauto_error2", autopilot.pitch_err.ToString("F2"), autopilot.RealPitchTarget.ToString("F2"), vesselState.currentPitch.ToString("F2"), autopilot.pitch_act.ToString("F5"), GUILayout.ExpandWidth(false)));//error:" Target:"" Cur:"
 
-                    GUILayout.BeginHorizontal ();
+                GUILayout.BeginHorizontal ();
                 GUILayout.Label (Localizer.Format("#MechJeb_Aircraftauto_Label10"), GUILayout.ExpandWidth (true));//Roll
                 GUILayout.Label ("Kp", GUILayout.ExpandWidth (false));
                 autopilot.RolKp.text = GUILayout.TextField (autopilot.RolKp.text, GUILayout.Width (40));
@@ -220,6 +236,8 @@ namespace MuMech
                 GUILayout.Label ("d", GUILayout.ExpandWidth (false));
                 autopilot.RolKd.text = GUILayout.TextField (autopilot.RolKd.text, GUILayout.Width (40));
                 GUILayout.EndHorizontal ();
+                if (autopilot.RollHoldEnabled)
+                    GUILayout.Label(Localizer.Format("#MecgJeb_Aircraftauto_error2", autopilot.roll_err.ToString("F2"), autopilot.RealRollTarget.ToString("F2"), (-vesselState.currentRoll).ToString("F2"), autopilot.roll_act.ToString("F5"), GUILayout.ExpandWidth(false)));//error:" Target:"" Cur:"
 
                 GUILayout.BeginHorizontal ();
                 GUILayout.Label ("Yaw", GUILayout.ExpandWidth (true));
@@ -230,6 +248,8 @@ namespace MuMech
                 GUILayout.Label ("d", GUILayout.ExpandWidth (false));
                 autopilot.YawKd.text = GUILayout.TextField (autopilot.YawKd.text, GUILayout.Width (40));
                 GUILayout.EndHorizontal ();
+                if (autopilot.HeadingHoldEnabled)
+                    GUILayout.Label(Localizer.Format("#MecgJeb_Aircraftauto_error2", autopilot.yaw_err.ToString("F2"), autopilot.RealYawTarget.ToString("F2"), autopilot.curr_yaw.ToString("F2"), autopilot.yaw_act.ToString("F5"), GUILayout.ExpandWidth(false)));//error:" Target:"" Cur:"
 
                 GUILayout.BeginHorizontal();
                 GUILayout.Label (Localizer.Format("#MechJeb_Aircraftauto_Limits"), GUILayout.ExpandWidth (false));//Yaw Control Limit

--- a/MechJeb2/MechJebModuleAirplaneGuidance.cs
+++ b/MechJeb2/MechJebModuleAirplaneGuidance.cs
@@ -163,9 +163,6 @@ namespace MuMech
                 if (GUILayout.Button("+", GUILayout.Width(18))) { RollMaxtmp.val += (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); change = true; }
                 RollMaxtmp = MuUtils.Clamp (RollMaxtmp, -60, 60);
                 GUILayout.Label ("°", GUILayout.ExpandWidth (true));
-
-                print("GUI: " + autopilot.BankAngle + " vs " + RollMaxtmp);
-
                 if (change || GUILayout.Button (Localizer.Format("#MechJeb_Aircraftauto_btnset6"), autopilot.BankAngle == RollMaxtmp ? btWhite : btGreen)) {
                     autopilot.BankAngle = RollMaxtmp;
                 }

--- a/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleSpaceplaneAutopilot.cs
@@ -26,6 +26,112 @@ namespace MuMech
             }
         }
 
+        /// <summary>
+        /// Set to true if reverse thrusters are engaged.
+        /// </summary>
+        private bool bEngagedReverseThrusters = false;
+
+        /// <summary>
+        /// Set to true if user wants reverse thrust upon touchdown.
+        /// </summary>
+        public bool bEngageReverseIfAvailable = true;
+
+        [Persistent(pass = (int)(Pass.Global | Pass.Local))]
+        public bool bBreakAsSoonAsLanded = false;
+
+        /// <summary>
+        /// The runway to land at.
+        /// </summary>
+        public Runway runway;
+
+        /// <summary>
+        /// Glide slope angle for approach (3-5 seems to work best).
+        /// </summary>
+        [Persistent(pass = (int)(Pass.Global | Pass.Local))]
+        public EditableDouble glideslope = 2.5;
+
+        /// <summary>
+        /// The angle between the runway centerline and an intercept to that
+        /// line where the lines intersect at the final approach point, on
+        /// both sides. This forms an approach where if the vessel is within
+        /// the cone, it will align with the final approach point. Otherwise,
+        /// it will fly towards the initial approach point and then turn
+        /// around and intercept the glide slope for final approach.
+        /// </summary>
+        private const double lateralApproachConeAngle = 30.0;
+
+        /// <summary>
+        /// Final approach distance in meters, at which point the aircraft
+        /// should be aligned with the runway and only minor adjustments should
+        /// be required.
+        /// </summary>
+        private const double lateralDistanceFromTouchdownToFinalApproach = 3700;
+
+        /// <summary>
+        /// Approach intercept angle; the angle at which the aircraft will
+        /// intercept the glide slope laterally.
+        /// </summary>
+        private const double lateralInterceptAngle = 30.0;
+
+        /// <summary>
+        /// Target angle of attack during flare.
+        /// </summary>
+        private const double targetFlareAoA = 15.0;
+
+        /// <summary>
+        /// Altitude in meters when flare will start.
+        /// </summary>
+        private const double startFlareAtAltitude = 20.0;
+
+        /// <summary>
+        /// Rate of turn in degrees per second.
+        /// </summary>
+        public const double targetRateOfTurn = 3.0;
+
+        /// <summary>
+        /// Minimum approach speed in meters per second. Stall + 10 seems to
+        /// result in a decent approach and landing.
+        /// </summary>
+        [Persistent(pass = (int)(Pass.Global | Pass.Local))]
+        public EditableDouble approachSpeed = 80.0;
+
+        [Persistent(pass = (int)(Pass.Global | Pass.Local))]
+        public EditableDouble touchdownSpeed = 60.0;
+
+        /// <summary>
+        /// Maximum allowed bank angle.
+        /// </summary>
+        [Persistent(pass = (int)(Pass.Global | Pass.Local))]
+        public EditableDouble maximumSafeBankAngle = 25.0;
+
+        /// <summary>
+        /// Maximum allowed vertical speed to bring the vessel on the glideslope in m/s
+        /// </summary>
+        public const double maximumVerticalSpeedCorrection = 10.0;
+
+        /// <summary>
+        /// Angle of attack at the start of flare state.
+        /// </summary>
+        private double flareStartAoA = 0.0;
+
+        /// <summary>
+        /// Angle between centerline and aircraft at the point where
+        /// the aircraft is perpendicular to the initial approach point
+        /// at a distance of turn diameter.
+        /// </summary>
+        private double angleToFinalApproachPointTurnDiameter = 20.0;
+
+        /// <summary>
+        /// Touchdown AoA and speed recorded for smooth main gear touchdown.
+        /// </summary>
+        private double touchdownMomentAoA = 0.0;
+        private double touchdownMomentSpeed = 0.0;
+
+        /// <summary>
+        /// Threshold in seconds to move on to the next waypoint.
+        /// </summary>
+        private double secondsThresholdToNextWaypoint = 5.0;
+
         public void Autoland(object controller)
         {
             users.Add(controller);
@@ -197,112 +303,6 @@ namespace MuMech
             }
         }
 
-        /// <summary>
-        /// Set to true if reverse thrusters are engaged.
-        /// </summary>
-        private bool bEngagedReverseThrusters = false;
-
-        /// <summary>
-        /// Set to true if user wants reverse thrust upon touchdown.
-        /// </summary>
-        public bool bEngageReverseIfAvailable = true;
-
-        [Persistent(pass = (int)(Pass.Global | Pass.Local))]
-        public bool bBreakAsSoonAsLanded = false;
-
-        /// <summary>
-        /// The runway to land at.
-        /// </summary>
-        public Runway runway;
-
-        /// <summary>
-        /// Glide slope angle for approach (3-5 seems to work best).
-        /// </summary>
-        [Persistent(pass = (int)(Pass.Global | Pass.Local))]
-        public EditableDouble glideslope = 3.0;
-
-        /// <summary>
-        /// The angle between the runway centerline and an intercept to that
-        /// line where the lines intersect at the final approach point, on
-        /// both sides. This forms an approach where if the vessel is within
-        /// the cone, it will align with the final approach point. Otherwise,
-        /// it will fly towards the initial approach point and then turn
-        /// around and intercept the glide slope for final approach.
-        /// </summary>
-        private const double lateralApproachConeAngle = 30.0;
-
-        /// <summary>
-        /// Final approach distance in meters, at which point the aircraft
-        /// should be aligned with the runway and only minor adjustments should
-        /// be required.
-        /// </summary>
-        private const double lateralDistanceFromTouchdownToFinalApproach = 3700;
-
-        /// <summary>
-        /// Approach intercept angle; the angle at which the aircraft will
-        /// intercept the glide slope laterally.
-        /// </summary>
-        private const double lateralInterceptAngle = 30.0;
-
-        /// <summary>
-        /// Target angle of attack during flare.
-        /// </summary>
-        private const double targetFlareAoA = 15.0;
-
-        /// <summary>
-        /// Altitude in meters when flare will start.
-        /// </summary>
-        private const double startFlareAtAltitude = 20.0;
-
-        /// <summary>
-        /// Rate of turn in degrees per second.
-        /// </summary>
-        public const double targetRateOfTurn = 3.0;
-
-        /// <summary>
-        /// Minimum approach speed in meters per second. Stall + 10 seems to
-        /// result in a decent approach and landing.
-        /// </summary>
-        [Persistent(pass = (int)(Pass.Global | Pass.Local))]
-        public EditableDouble approachSpeed = 80.0;
-
-        [Persistent(pass = (int)(Pass.Global | Pass.Local))]
-        public EditableDouble touchdownSpeed = 60.0;
-
-        /// <summary>
-        /// Maximum allowed bank angle.
-        /// </summary>
-        [Persistent(pass = (int)(Pass.Global | Pass.Local))]
-        public EditableDouble maximumSafeBankAngle = 25.0;
-
-        /// <summary>
-        /// Maximum allowed vertical speed to bring the vessel on the glideslope in m/s
-        /// </summary>
-        public const double maximumVerticalSpeedCorrection = 10.0;
-
-        /// <summary>
-        /// Angle of attack at the start of flare state.
-        /// </summary>
-        private double flareStartAoA = 0.0;
-
-        /// <summary>
-        /// Angle between centerline and aircraft at the point where
-        /// the aircraft is perpendicular to the initial approach point
-        /// at a distance of turn diameter.
-        /// </summary>
-        private double angleToFinalApproachPointTurnDiameter = 20.0;
-
-        /// <summary>
-        /// Touchdown AoA and speed recorded for smooth main gear touchdown.
-        /// </summary>
-        private double touchdownMomentAoA = 0.0;
-        private double touchdownMomentSpeed = 0.0;
-
-        /// <summary>
-        /// Threshold in seconds to move on to the next waypoint.
-        /// </summary>
-        private double secondsThresholdToNextWaypoint = 5.0;
-
         public double GetAutolandTargetAltitude(Vector3d vectorToWaypoint)
         {
             double lat, lon, alt;
@@ -322,24 +322,21 @@ namespace MuMech
             // possible so that we don't overshoot or undershoot the runway.
             if (approachState == AutolandApproachState.TOUCHDOWN || approachState == AutolandApproachState.FAP)
             {
+                Debug.Assert(vertSpeed < 0);
+
                 Vector3d vectorToCorrectPointOnGlideslope = runway.GetPointOnGlideslope(glideslope, LateralDistance(vesselState.CoM, runway.GetVectorToTouchdown()));
                 double desiredAlt = GetAutolandTargetAltitude(vectorToCorrectPointOnGlideslope) - 10;
                 double deltaToCorrectAlt = desiredAlt - vesselState.altitudeTrue;
-
-                Debug.Assert(vertSpeed < 0);
-
                 double expPerMeter = (Math.Log(maximumVerticalSpeedCorrection + 1) - Math.Log(1)) / desiredAlt;
                 double adjustment = Math.Exp(expPerMeter * Math.Abs(deltaToCorrectAlt)) - 1;
 
-        //        print("adjustment: " + adjustment);
-
-                vertSpeed += deltaToCorrectAlt > 0 ? adjustment : -1 * adjustment;
+                vertSpeed += deltaToCorrectAlt > 0 ? adjustment : -adjustment;
             }
 
             if (approachState == AutolandApproachState.FLARE)
             {
                 vertSpeed = deltaAlt / 8 - 0.2f;
-                vertSpeed = UtilMath.Clamp(vertSpeed, -4, 4);
+                vertSpeed = UtilMath.Clamp(vertSpeed, -2, 2);
             }
 
             return vertSpeed;
@@ -418,20 +415,14 @@ namespace MuMech
 
             switch (approachState)
             {
-                case AutolandApproachState.ROLLOUT:
-                    return 0;
-            }
-
-            switch (approachState)
-            {
                 case AutolandApproachState.WAITINGFORFLARE:
                 case AutolandApproachState.TOUCHDOWN:
                 case AutolandApproachState.FLARE:
                     return touchdownSpeed;
-            }
-
-            if (approachState == AutolandApproachState.FAP){
-                return (touchdownSpeed + approachSpeed) / 2;
+                case AutolandApproachState.FAP:
+                    return (touchdownSpeed + approachSpeed) / 2;
+                case AutolandApproachState.ROLLOUT:
+                    return 0;
             }
 
             return approachSpeed;
@@ -567,7 +558,11 @@ namespace MuMech
             else if (approachState == AutolandApproachState.ROLLOUT)
             {
                 if (vesselState.speedSurface < 1.0)
+                {
                     AutopilotOff();
+                    // disable the actual autopilot so we dont takeoff again after we landed
+                    Autopilot.enabled = false;
+                }
 
                 return runway.End();
             }

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -151,6 +151,31 @@ namespace MuMech
 
         public MovingAverage3d angularVelocityAvg = new MovingAverage3d(5);
 
+        // instantaneous values
+        public double currentPitch
+        {
+            get
+            {
+                return (rotationVesselSurface.eulerAngles.x > 180) ? (360.0 - rotationVesselSurface.eulerAngles.x) : -rotationVesselSurface.eulerAngles.x;
+            }
+        }
+
+        public double currentRoll
+        {
+            get
+            {
+                return (rotationVesselSurface.eulerAngles.z > 180) ? (rotationVesselSurface.eulerAngles.z - 360.0) : rotationVesselSurface.eulerAngles.z;
+            }
+        }
+
+        public double currentHeading
+        {
+            get
+            {
+                return rotationVesselSurface.eulerAngles.y;
+            }
+        }
+
         public double radius;  //distance from planet center
 
         public double mass;
@@ -668,9 +693,9 @@ namespace MuMech
             double tempAoD = UtilMath.Rad2Deg * Math.Acos(MuUtils.Clamp(Vector3.Dot(vessel.ReferenceTransform.up, surfaceVelocity.normalized), -1, 1));
             displacementAngle.value = double.IsNaN(tempAoD) || speedSurface.value < 0.01 ? 0 : tempAoD;
 
-            vesselHeading.value = rotationVesselSurface.eulerAngles.y;
-            vesselPitch.value = (rotationVesselSurface.eulerAngles.x > 180) ? (360.0 - rotationVesselSurface.eulerAngles.x) : -rotationVesselSurface.eulerAngles.x;
-            vesselRoll.value = (rotationVesselSurface.eulerAngles.z > 180) ? (rotationVesselSurface.eulerAngles.z - 360.0) : rotationVesselSurface.eulerAngles.z;
+            vesselHeading.value = currentHeading;
+            vesselPitch.value = currentPitch;
+            vesselRoll.value = currentRoll;
 
             altitudeASL.value = vessel.mainBody.GetAltitude(CoM);
 


### PR DESCRIPTION
So this PR turned out to be much bigger than expected.

- use roll for turns instead of yaw
- adds operational limits for pitch up/down, roll and yaw
- removes the "max descent rate" field from Autoland because it's not needed anymore.
- uses a pitch PID instead of a vertical speed PID.
- adds vertical speed field to altitude hold mode
- adds PID info text (current state, target, error and PID signal) to let the user know what's going on

tested with Aeris 3A, Gull, Mallard, and one of my own designs.


