### PR TITLE
#1171 - ignore surface trigger colliders in raycasts

### DIFF
--- a/MechJeb2/MechJebModuleRoverController.cs
+++ b/MechJeb2/MechJebModuleRoverController.cs
@@ -177,7 +177,7 @@ namespace MuMech
 		{
 			if (wheels.Count == 0 && colliders.Count == 0) { OnVesselModified(vessel); }
 			RaycastHit hit;
-			Physics.Raycast(vessel.CoM + vesselState.surfaceVelocity * terrainLookAhead + vesselState.up * 100, -vesselState.up, out hit, 500, 1 << 15);
+			Physics.Raycast(vessel.CoM + vesselState.surfaceVelocity * terrainLookAhead + vesselState.up * 100, -vesselState.up, out hit, 500, 1 << 15, QueryTriggerInteraction.Ignore);
 			norm = hit.normal;
 			traction = 0;
 //			foreach (var c in colliders) {

--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -97,7 +97,7 @@ namespace MuMech
 					var rayPos = Body.position + dir * (Body.Radius + 50000);
 					dir = (Vector3d)(Body.position - rayPos).normalized;
 					RaycastHit hit;
-					var raycast = Physics.Raycast(rayPos, dir, out hit, (float)Body.Radius, 1 << 15);
+					var raycast = Physics.Raycast(rayPos, dir, out hit, (float)Body.Radius, 1 << 15, QueryTriggerInteraction.Ignore);
 					if (raycast) {
 						dir = (hit.point - Body.position);
 						Position = Body.position + dir.normalized * (dir.magnitude + 0.5);
@@ -355,7 +355,7 @@ namespace MuMech
 //			mouseRay.origin = ScaledSpace.ScaledToLocalSpace(mouseRay.origin);
 			Vector3d relOrigin = mouseRay.origin - body.position;
 			Vector3d relSurfacePosition;
-			if (Physics.Raycast(mouseRay, out raycast, (float)body.Radius * 4f, 1 << 15))
+			if (Physics.Raycast(mouseRay, out raycast, (float)body.Radius * 4f, 1 << 15, QueryTriggerInteraction.Ignore))
 			{
 				return new Coordinates(body.GetLatitude(raycast.point), MuUtils.ClampDegrees180(body.GetLongitude(raycast.point)));
 			}


### PR DESCRIPTION
Works for me. Fixes problems caused by the BG scanner arms in rover stability control and waypoint selection and display.

closes #1171 