### PR TITLE
replace hard-coded LeftAlt with GameSettings.MODIFIER_KEY

### DIFF
--- a/MechJeb2/MechJebModuleRoverWindow.cs
+++ b/MechJeb2/MechJebModuleRoverWindow.cs
@@ -32,7 +32,7 @@ namespace MuMech
 		protected override void WindowGUI(int windowID)
 		{
 			MechJebModuleCustomWindowEditor ed = core.GetComputerModule<MechJebModuleCustomWindowEditor>();
-			bool alt = Input.GetKey(KeyCode.LeftAlt);
+			bool alt = GameSettings.MODIFIER_KEY.GetKey();
 
 			if (GUI.Button(new Rect(windowPos.width - 48, 0, 13, 20), "?", GuiUtils.yellowOnHover))
 			{

--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -539,10 +539,9 @@ namespace MuMech
 		{
 			return new GUILayoutOption[] { GUILayout.Width(500), GUILayout.Height(400) };
 		}
-
 		public void DrawPageWaypoints()
 		{
-			bool alt = Input.GetKey(KeyCode.LeftAlt);
+			bool alt = GameSettings.MODIFIER_KEY.GetKey();
 			scroll = GUILayout.BeginScrollView(scroll);
 			if (ap.Waypoints.Count > 0) {
 				waypointRects = new Rect[ap.Waypoints.Count];
@@ -749,7 +748,7 @@ namespace MuMech
 
 		public void DrawPageSettings()
 		{
-			bool alt = Input.GetKey(KeyCode.LeftAlt);
+			bool alt = GameSettings.MODIFIER_KEY.GetKey();
 			titleAdd = "Settings";
 			MechJebModuleCustomWindowEditor ed = core.GetComputerModule<MechJebModuleCustomWindowEditor>();
 			if (!ap.enabled) { ap.CalculateTraction(); } // keep calculating traction just for displaying it
@@ -836,7 +835,7 @@ namespace MuMech
 
 		public void DrawPageRoutes()
 		{
-			bool alt = Input.GetKey(KeyCode.LeftAlt);
+			bool alt = GameSettings.MODIFIER_KEY.GetKey();
 			titleAdd = "Routes for " + vessel.mainBody.bodyName;
 
 			scroll = GUILayout.BeginScrollView(scroll);
@@ -938,7 +937,7 @@ namespace MuMech
 				styleQuicksave.active.textColor = styleQuicksave.focused.textColor = styleQuicksave.hover.textColor = styleQuicksave.normal.textColor = Color.yellow;
 			}
 
-			bool alt = Input.GetKey(KeyCode.LeftAlt);
+			bool alt = GameSettings.MODIFIER_KEY.GetKey();
 
 			switch (showPage)
 			{


### PR DESCRIPTION
The alternate rover buttons are not available if LeftAlt + mouse click cannot be used. Other parts of MJ already use GameSettings.MODIFIER_KEY.GetKey().