### PR TITLE
cleanup in rover module

### DIFF
--- a/MechJeb2/MechJebModuleRoverController.cs
+++ b/MechJeb2/MechJebModuleRoverController.cs
@@ -74,9 +74,7 @@ namespace MuMech
 		[EditableInfoItem("#MechJeb_TractionBrakeLimit", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Type)] // Traction Brake Limit
 		public EditableDouble tractionLimit = 75;
 		
-		public List<Part> wheels = new List<Part>();
 		public List<ModuleWheelBase> wheelbases = new List<ModuleWheelBase>();
-		public List<WheelCollider> colliders = new List<WheelCollider>();
 		public Vector3 norm = Vector3.zero;
 		
 		public override void OnStart(PartModule.StartState state)
@@ -104,11 +102,6 @@ namespace MuMech
 
 			try
 			{
-				wheels.Clear();
-				wheels.AddRange(vessel.Parts.FindAll(p => p.HasModule<ModuleWheelBase>() /*&& p.FindModelComponent<WheelCollider>() != null*/ && p.GetModule<ModuleWheelBase>().wheelType != WheelType.LEG));
-				colliders.Clear();
-				wheels.ForEach(p => colliders.AddRange(p.FindModelComponents<WheelCollider>()));
-
 				wheelbases.Clear();
 				wheelbases.AddRange(vessel.Parts.Where(
 					p => p.HasModule<ModuleWheelBase>()
@@ -150,7 +143,7 @@ namespace MuMech
 		
 		public void CalculateTraction()
 		{
-			if (wheels.Count == 0 && colliders.Count == 0) { OnVesselModified(vessel); }
+			if (wheelbases.Count == 0) { OnVesselModified(vessel); }
 			RaycastHit hit;
 			Physics.Raycast(vessel.CoM + vesselState.surfaceVelocity * terrainLookAhead + vesselState.up * 100, -vesselState.up, out hit, 500, 1 << 15, QueryTriggerInteraction.Ignore);
 			norm = hit.normal;

--- a/MechJeb2/MechJebModuleRoverController.cs
+++ b/MechJeb2/MechJebModuleRoverController.cs
@@ -12,32 +12,32 @@ namespace MuMech
 		private CelestialBody lastBody = null;
 		public bool LoopWaypoints = false;
 		
-		[ToggleInfoItem("#MechJeb_ControlHeading", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]//Heading control
+		[ToggleInfoItem("#MechJeb_ControlHeading", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)] // Heading control
 		public bool ControlHeading;
 
-		[EditableInfoItem("#MechJeb_Heading", InfoItem.Category.Rover, width = 40), Persistent(pass = (int)Pass.Local)]//Heading
+		[EditableInfoItem("#MechJeb_Heading", InfoItem.Category.Rover, width = 40), Persistent(pass = (int)Pass.Local)] // Heading
 		public EditableDouble heading = 0;
 
-		[ToggleInfoItem("#MechJeb_ControlSpeed", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]//Speed control
+		[ToggleInfoItem("#MechJeb_ControlSpeed", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)] // Speed control
 		public bool ControlSpeed = false;
 
-		[EditableInfoItem("#MechJeb_Speed", InfoItem.Category.Rover, width = 40), Persistent(pass = (int)Pass.Local)]//Speed
+		[EditableInfoItem("#MechJeb_Speed", InfoItem.Category.Rover, width = 40), Persistent(pass = (int)Pass.Local)] // Speed
 		public EditableDouble speed = 10;
 
-        [ToggleInfoItem("#MechJeb_BrakeOnEject", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]//Brake on Pilot Eject
-        public bool BrakeOnEject = false;
+		[ToggleInfoItem("#MechJeb_BrakeOnEject", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)] // Brake on Pilot Eject
+		public bool BrakeOnEject = false;
 
-        [ToggleInfoItem("#MechJeb_BrakeOnEnergyDepletion", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]//Brake on Energy Depletion
+		[ToggleInfoItem("#MechJeb_BrakeOnEnergyDepletion", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)] // Brake on Energy Depletion
 		public bool BrakeOnEnergyDepletion = false;
-		
-        [ToggleInfoItem("#MechJeb_WarpToDaylight", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]//Warp until Day if Depleted
+
+		[ToggleInfoItem("#MechJeb_WarpToDaylight", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)] // Warp until Day if Depleted
 		public bool WarpToDaylight = false;
 		public bool waitingForDaylight = false;
 
-		[ToggleInfoItem("#MechJeb_StabilityControl", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]//Stability Control
+		[ToggleInfoItem("#MechJeb_StabilityControl", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)] // Stability Control
 		public bool StabilityControl = false;
 
-		[ToggleInfoItem("#MechJeb_LimitAcceleration", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local | (int)Pass.Type)]//Limit Acceleration
+		[ToggleInfoItem("#MechJeb_LimitAcceleration", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local | (int)Pass.Type)] // Limit Acceleration
 		public bool LimitAcceleration = false;
 
 		public PIDController headingPID;
@@ -45,33 +45,33 @@ namespace MuMech
 
 //		private LineRenderer line;
 		
-		[EditableInfoItem("#MechJeb_SafeTurnspeed", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Type)]//Safe turnspeed
+		[EditableInfoItem("#MechJeb_SafeTurnspeed", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Type)] // Safe turnspeed
 		public EditableDouble turnSpeed = 3;
-		[EditableInfoItem("#MechJeb_TerrainLookAhead", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Terrain Look Ahead
+		[EditableInfoItem("#MechJeb_TerrainLookAhead", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Terrain Look Ahead
 		public EditableDouble terrainLookAhead = 1.0;
-		[EditableInfoItem("#MechJeb_BrakeSpeedLimit", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Type)]//Brake Speed Limit
+		[EditableInfoItem("#MechJeb_BrakeSpeedLimit", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Type)] // Brake Speed Limit
 		public EditableDouble brakeSpeedLimit = 0.7;
 
-		[EditableInfoItem("#MechJeb_HeadingPIDP", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Heading PID P
+		[EditableInfoItem("#MechJeb_HeadingPIDP", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Heading PID P
 		public EditableDouble hPIDp = 0.03; // 0.01
-		[EditableInfoItem("#MechJeb_HeadingPIDI", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Heading PID I
+		[EditableInfoItem("#MechJeb_HeadingPIDI", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Heading PID I
 		public EditableDouble hPIDi = 0.002; // 0.001
-		[EditableInfoItem("#MechJeb_HeadingPIDD", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Heading PID D
+		[EditableInfoItem("#MechJeb_HeadingPIDD", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Heading PID D
 		public EditableDouble hPIDd = 0.005;
 		
-		[EditableInfoItem("#MechJeb_SpeedPIDP", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Speed PID P
+		[EditableInfoItem("#MechJeb_SpeedPIDP", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Speed PID P
 		public EditableDouble sPIDp = 2.0;
-		[EditableInfoItem("#MechJeb_SpeedPIDI", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Speed PID I
+		[EditableInfoItem("#MechJeb_SpeedPIDI", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Speed PID I
 		public EditableDouble sPIDi = 0.1;
-		[EditableInfoItem("#MechJeb_SpeedPIDD", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Speed PID D
+		[EditableInfoItem("#MechJeb_SpeedPIDD", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Speed PID D
 		public EditableDouble sPIDd = 0.001;
 		
-		[ValueInfoItem("#MechJeb_SpeedIntAcc", InfoItem.Category.Rover, format = ValueInfoItem.SI, units = "m/s")]//Speed Int Acc
+		[ValueInfoItem("#MechJeb_SpeedIntAcc", InfoItem.Category.Rover, format = ValueInfoItem.SI, units = "m/s")] // Speed Int Acc
 		public double speedIntAcc = 0;
 
-		[ValueInfoItem("#MechJeb_Traction", InfoItem.Category.Rover, format = "F0", units = "%")]//Traction
+		[ValueInfoItem("#MechJeb_Traction", InfoItem.Category.Rover, format = "F0", units = "%")] // Traction
 		public float traction = 0;
-		[EditableInfoItem("#MechJeb_TractionBrakeLimit", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Type)]//Traction Brake Limit
+		[EditableInfoItem("#MechJeb_TractionBrakeLimit", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Type)] // Traction Brake Limit
 		public EditableDouble tractionLimit = 75;
 		
 		public List<Part> wheels = new List<Part>();
@@ -100,10 +100,10 @@ namespace MuMech
 		public void OnVesselModified(Vessel v)
 		{
 
-            //TODO : need to look into the new ModuleWheelSteering ModuleWheelMotor ModuleWheelBrakes ModuleWheelBase ModuleWheelSuspension and see what they could bring
+			// TODO : need to look into the new ModuleWheelSteering ModuleWheelMotor ModuleWheelBrakes ModuleWheelBase ModuleWheelSuspension and see what they could bring
 
-            try
-            {
+			try
+			{
 				wheels.Clear();
 				wheels.AddRange(vessel.Parts.FindAll(p => p.HasModule<ModuleWheelBase>() /*&& p.FindModelComponent<WheelCollider>() != null*/ && p.GetModule<ModuleWheelBase>().wheelType != WheelType.LEG));
 				colliders.Clear();
@@ -118,9 +118,9 @@ namespace MuMech
 			catch (Exception) {}
 		}
 		
-		[ValueInfoItem("#MechJeb_Headingerror", InfoItem.Category.Rover, format = "F1", units = "º")]//Heading error
+		[ValueInfoItem("#MechJeb_Headingerror", InfoItem.Category.Rover, format = "F1", units = "º")] // Heading error
 		public double headingErr;
-		[ValueInfoItem("#MechJeb_Speederror", InfoItem.Category.Rover, format = ValueInfoItem.SI, units = "m/s")]//Speed error
+		[ValueInfoItem("#MechJeb_Speederror", InfoItem.Category.Rover, format = ValueInfoItem.SI, units = "m/s")] // Speed error
 		public double speedErr;
 		public double tgtSpeed;
 		public MuMech.MovingAverage etaSpeed = new MovingAverage(50);
@@ -137,10 +137,10 @@ namespace MuMech
 			var diff = toLon - fromLon;
 			if (diff < -180) { diff += 360; }
 			if (diff >  180) { diff -= 360; }
-			Vector3 myPos  = fromPos - body.transform.position;
+			Vector3 myPos = fromPos - body.transform.position;
 			Vector3 north = body.transform.position + ((float)body.Radius * body.transform.up) - fromPos;
 			Vector3 tgtPos = toPos - fromPos;
-            return (diff < 0 ? -1 : 1) * Vector3.Angle(Vector3d.Exclude(myPos.normalized, north.normalized), Vector3.ProjectOnPlane(tgtPos.normalized, myPos.normalized));
+			return (diff < 0 ? -1 : 1) * Vector3.Angle(Vector3d.Exclude(myPos.normalized, north.normalized), Vector3.ProjectOnPlane(tgtPos.normalized, myPos.normalized));
 		}
 
 		public float TurningSpeed(double speed, double error)
@@ -156,14 +156,14 @@ namespace MuMech
 			norm = hit.normal;
 			traction = 0;
 
-		    for (int i = 0; i < wheelbases.Count; i++)
-		    {
-		        var w = wheelbases[i];
-		        if (w.isGrounded)
-		        {
-		            traction += 100;
-		        }
-		    }
+			for (int i = 0; i < wheelbases.Count; i++)
+			{
+				var w = wheelbases[i];
+				if (w.isGrounded)
+				{
+					traction += 100;
+				}
+			}
 
 			traction /= wheelbases.Count;
 		}
@@ -208,8 +208,8 @@ namespace MuMech
 					// var maxSpeed = (wp.MaxSpeed > 0 ? Math.Min((float)speed, wp.MaxSpeed) : speed); // use waypoints maxSpeed if set and smaller than set the speed or just stick with the set speed
 					var maxSpeed = (wp.MaxSpeed > 0 ? wp.MaxSpeed : speed); // speed used to go towards the waypoint, using the waypoints maxSpeed if set or just stick with the set speed
 					var minSpeed = (wp.MinSpeed > 0 ? wp.MinSpeed :
-					               (nextWP != null ? TurningSpeed((nextWP.MaxSpeed > 0 ? nextWP.MaxSpeed : speed), heading - HeadingToPos(wp.Position, nextWP.Position)) :
-					               (distance - wp.Radius > 50 ? turnSpeed.val : 1)));
+								(nextWP != null ? TurningSpeed((nextWP.MaxSpeed > 0 ? nextWP.MaxSpeed : speed), heading - HeadingToPos(wp.Position, nextWP.Position)) :
+								(distance - wp.Radius > 50 ? turnSpeed.val : 1)));
 					minSpeed = (wp.Quicksave ? 1 : minSpeed);
 					// ^ speed used to go through the waypoint, using half the set speed or maxSpeed as minSpeed for routing waypoints (all except the last)
 					var newSpeed = Math.Min(maxSpeed, Math.Max((distance - wp.Radius) / curSpeed, minSpeed)); // brake when getting closer
@@ -324,13 +324,13 @@ namespace MuMech
 				}
 				var fSpeed = (float)curSpeed;
 				Vector3 fwd = (Vector3)(traction > 0 ? // V when the speed is low go for the vessels forward, else with a bit of velocity
-				                        vesselState.forward * 4 - vessel.transform.right * s.wheelSteer * Mathf.Sign(fSpeed) : // and then add the steering
-				                        vesselState.surfaceVelocity); // in the air so follow velocity
+							vesselState.forward * 4 - vessel.transform.right * s.wheelSteer * Mathf.Sign(fSpeed) : // and then add the steering
+							vesselState.surfaceVelocity); // in the air so follow velocity
 				Vector3.OrthoNormalize(ref norm, ref fwd);
 				var quat = Quaternion.LookRotation(fwd, norm);
-				
-                if (vesselState.torqueAvailable.sqrMagnitude > 0)
-				    core.attitude.attitudeTo(quat, AttitudeReference.INERTIAL, this);
+
+				if (vesselState.torqueAvailable.sqrMagnitude > 0)
+					core.attitude.attitudeTo(quat, AttitudeReference.INERTIAL, this);
 			}
 			
 			if (BrakeOnEnergyDepletion)
@@ -339,12 +339,12 @@ namespace MuMech
 				var energyLeft = batteries.Sum(p => p.Resources.Get(PartResourceLibrary.ElectricityHashcode).amount) / batteries.Sum(p => p.Resources.Get(PartResourceLibrary.ElectricityHashcode).maxAmount); 
 				var openSolars = vessel.mainBody.atmosphere && // true if in atmosphere and there are breakable solarpanels that aren't broken nor retracted
 					vessel.FindPartModulesImplementing<ModuleDeployableSolarPanel>().FindAll(p => p.isBreakable && p.deployState != ModuleDeployablePart.DeployState.BROKEN &&
-					                                                                         p.deployState != ModuleDeployablePart.DeployState.RETRACTED).Count > 0;
+									p.deployState != ModuleDeployablePart.DeployState.RETRACTED).Count > 0;
 				
 				if (openSolars && energyLeft > 0.99)
 				{
 					vessel.FindPartModulesImplementing<ModuleDeployableSolarPanel>().FindAll(p => p.isBreakable &&
-					                                                                         p.deployState == ModuleDeployablePart.DeployState.EXTENDED).ForEach(p => p.Retract());
+									p.deployState == ModuleDeployablePart.DeployState.EXTENDED).ForEach(p => p.Retract());
 				}
 				
 				if (energyLeft < 0.05 && Math.Sign(s.wheelThrottle) + Math.Sign(curSpeed) != 0) { s.wheelThrottle = 0; } // save remaining energy by not using it for acceleration
@@ -356,7 +356,7 @@ namespace MuMech
 				}
 
 				if (curSpeed < 0.1 && energyLeft < 0.05 && !waitingForDaylight &&
-				    vessel.FindPartModulesImplementing<ModuleDeployableSolarPanel>().FindAll(p => p.deployState == ModuleDeployablePart.DeployState.EXTENDED).Count > 0)
+					vessel.FindPartModulesImplementing<ModuleDeployableSolarPanel>().FindAll(p => p.deployState == ModuleDeployablePart.DeployState.EXTENDED).Count > 0)
 				{
 					waitingForDaylight = true;
 				}
@@ -454,30 +454,31 @@ namespace MuMech
 		
 		public override void OnLoad(ConfigNode local, ConfigNode type, ConfigNode global)
 		{
-            base.OnLoad(local, type, global);
+			base.OnLoad(local, type, global);
 
-            if (local != null)
-            {
-                var wps = local.GetNode("Waypoints");
-                if (wps != null && wps.HasNode("Waypoint"))
-                {
-                    int.TryParse(wps.GetValue("Index"), out WaypointIndex);
-                    Waypoints.Clear();
-                    foreach (ConfigNode cn in wps.GetNodes("Waypoint"))
-                    {
-                        Waypoints.Add(new MechJebWaypoint(cn));
-                    }
-                }
-            }
+			if (local != null)
+			{
+				var wps = local.GetNode("Waypoints");
+				if (wps != null && wps.HasNode("Waypoint"))
+				{
+					int.TryParse(wps.GetValue("Index"), out WaypointIndex);
+					Waypoints.Clear();
+					foreach (ConfigNode cn in wps.GetNodes("Waypoint"))
+					{
+						Waypoints.Add(new MechJebWaypoint(cn));
+					}
+				}
+			}
 		}
 		
 		public override void OnSave(ConfigNode local, ConfigNode type, ConfigNode global)
 		{
-            base.OnSave(local, type, global);
+			base.OnSave(local, type, global);
 
-            if (local == null) return;
+			if (local == null) return;
 
 			if (local.HasNode("Waypoints")) { local.RemoveNode("Waypoints"); }
+
 			if (Waypoints.Count > 0) {
 				ConfigNode cn = local.AddNode("Waypoints");
 				cn.AddValue("Index", WaypointIndex);

--- a/MechJeb2/MechJebModuleRoverController.cs
+++ b/MechJeb2/MechJebModuleRoverController.cs
@@ -12,46 +12,14 @@ namespace MuMech
 		private CelestialBody lastBody = null;
 		public bool LoopWaypoints = false;
 		
-//		protected bool controlHeading;
 		[ToggleInfoItem("#MechJeb_ControlHeading", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]//Heading control
-		public bool ControlHeading;  // TODO: change things back to properties when ConfigNodes can save and load these
-//		{
-//			get { return controlHeading; }
-//			set
-//			{
-//				controlHeading = value;
-//                if (controlHeading || controlSpeed || brakeOnEject)
-//				{
-//					users.Add(this);
-//				}
-//				else
-//				{
-//					users.Remove(this);
-//				}
-//			}
-//		}
+		public bool ControlHeading;
 
 		[EditableInfoItem("#MechJeb_Heading", InfoItem.Category.Rover, width = 40), Persistent(pass = (int)Pass.Local)]//Heading
 		public EditableDouble heading = 0;
 
-//		protected bool controlSpeed = false;
 		[ToggleInfoItem("#MechJeb_ControlSpeed", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Local)]//Speed control
 		public bool ControlSpeed = false;
-//		{
-//			get { return controlSpeed; }
-//			set
-//			{
-//				controlSpeed = value;
-//                if (controlHeading || controlSpeed || brakeOnEject)
-//				{
-//					users.Add(this);
-//				}
-//				else
-//				{
-//					users.Remove(this);
-//				}
-//			}
-//		}
 
 		[EditableInfoItem("#MechJeb_Speed", InfoItem.Category.Rover, width = 40), Persistent(pass = (int)Pass.Local)]//Speed
 		public EditableDouble speed = 10;
@@ -145,7 +113,6 @@ namespace MuMech
 				wheelbases.AddRange(vessel.Parts.Where(
 					p => p.HasModule<ModuleWheelBase>()
 					&& p.GetModule<ModuleWheelBase>().wheelType != WheelType.LEG
-//					&& (p.GetModule<ModuleWheels.ModuleWheelSteering>()?.steeringEnabled == true || p.GetModule<ModuleWheels.ModuleWheelMotorSteering>()?.steeringEnabled == true)
 				).Select(p => p.GetModule<ModuleWheelBase>()));
 			}
 			catch (Exception) {}
@@ -188,33 +155,6 @@ namespace MuMech
 			Physics.Raycast(vessel.CoM + vesselState.surfaceVelocity * terrainLookAhead + vesselState.up * 100, -vesselState.up, out hit, 500, 1 << 15, QueryTriggerInteraction.Ignore);
 			norm = hit.normal;
 			traction = 0;
-//			foreach (var c in colliders) {
-//				//WheelHit hit;
-//				//if (c.GetGroundHit(out hit)) { traction += 1; }
-//				if (Physics.Raycast(c.transform.position + c.center, -(vesselState.up + norm.normalized) / 2, out hit, c.radius + 1.5f, 1 << 15)) {
-//					traction += (1.5f - (hit.distance - c.radius)) * 100;
-//				}
-//			}
-
-/*
-		    for (int i = 0; i < wheels.Count; i++)
-		    {
-		        var w = wheels[i];
-		        if (w.GroundContact)
-		        {
-		            traction += 100;
-		        }
-		    }
-*/
-
-//		    for (int i = 0; i < colliders.Count; i++)
-//		    {
-//		        var c = colliders[i];
-//		        if (c.isGrounded)
-//		        {
-//		            traction += 100;
-//		        }
-//		    }
 
 		    for (int i = 0; i < wheelbases.Count; i++)
 		    {
@@ -274,8 +214,6 @@ namespace MuMech
 					// ^ speed used to go through the waypoint, using half the set speed or maxSpeed as minSpeed for routing waypoints (all except the last)
 					var newSpeed = Math.Min(maxSpeed, Math.Max((distance - wp.Radius) / curSpeed, minSpeed)); // brake when getting closer
 					newSpeed = (newSpeed > turnSpeed ? TurningSpeed(newSpeed, headingErr) : newSpeed); // reduce speed when turning a lot
-//					if (LimitAcceleration) { newSpeed = curSpeed + Mathf.Clamp((float)(newSpeed - curSpeed), -1.5f, 0.5f); }
-//					newSpeed = tgtSpeed + Mathf.Clamp((float)(newSpeed - tgtSpeed), -Time.deltaTime * 8f, Time.deltaTime * 2f);
 					var radius = Math.Max(wp.Radius, 10);
 					if (distance < radius)
 					{
@@ -291,12 +229,10 @@ namespace MuMech
 							{
 								newSpeed = 0;
 								brake = true;
-//								tgtSpeed.force(newSpeed);
 								if (curSpeed < brakeSpeedLimit)
 								{
 									if (wp.Quicksave)
 									{
-										//if (s.mainThrottle > 0) { s.mainThrottle = 0; }
 										if (FlightGlobals.ClearToSave() == ClearToSaveStatus.CLEAR)
 										{
 											WaypointIndex = -1;
@@ -310,19 +246,13 @@ namespace MuMech
 										ControlHeading = ControlSpeed = false;
 									}
 								}
-//								else {
-//									Debug.Log("Is this even getting called?");
-//									WaypointIndex++;
-//								}
 							}
 						}
 						else
 						{
 							if (wp.Quicksave)
 							{
-								//if (s.mainThrottle > 0) { s.mainThrottle = 0; }
 								newSpeed = 0;
-//								tgtSpeed.force(newSpeed);
 								if (curSpeed < brakeSpeedLimit)
 								{
 									if (FlightGlobals.ClearToSave() == ClearToSaveStatus.CLEAR)
@@ -354,7 +284,6 @@ namespace MuMech
 				{
 					float limit = (Math.Abs(curSpeed) > turnSpeed ? Mathf.Clamp((float)((turnSpeed + 6) / Square(curSpeed)), 0.1f, 1f) : 1f);
 					// turnSpeed needs to be higher than curSpeed or it will never steer as much as it could even at 0.2m/s above it
-					// double act = headingPID.Compute(headingErr * headingErr / 10 * Math.Sign(headingErr));
 					double act = headingPID.Compute(headingErr);
 					if (traction >= tractionLimit) {
 						s.wheelSteer = Mathf.Clamp((float)act, -limit, limit);
@@ -367,7 +296,6 @@ namespace MuMech
 			if (BrakeOnEject && vessel.GetReferenceTransformPart() == null)
 			{
 				s.wheelThrottle = 0;
-//				vessel.ActionGroups.SetGroup(KSPActionGroup.Brakes, true);
 				brake = true;
 			}
 			else if (ControlSpeed)
@@ -379,25 +307,11 @@ namespace MuMech
 				{
 					float act = (float)speedPID.Compute(speedErr);
 					s.wheelThrottle = Mathf.Clamp(act, -1f, 1f);
-					// s.wheelThrottle = (!LimitAcceleration ? Mathf.Clamp(act, -1, 1) : // I think I'm using these ( ? : ) a bit too much
-						// (traction == 0 ? 0 : (act < 0 ? Mathf.Clamp(act, -1f, 1f) : (lastThrottle + Mathf.Clamp(act - lastThrottle, -0.01f, 0.01f)) * (traction < tractionLimit ? -1 : 1))));
-//						(lastThrottle + Mathf.Clamp(act, -0.01f, 0.01f)));
-//					Debug.Log(s.wheelThrottle + Mathf.Clamp(act, -0.01f, 0.01f));
 					if (curSpeed < 0 & s.wheelThrottle < 0) { s.wheelThrottle = 0; } // don't go backwards
 					if (Mathf.Sign(act) + Mathf.Sign(s.wheelThrottle) == 0) { s.wheelThrottle = Mathf.Clamp(act, -1f, 1f); }
-					if (speedErr < -1 && StabilityControl && Mathf.Sign(s.wheelThrottle) + Math.Sign(curSpeed) == 0) { // StabilityControl && traction > 50 &&
-////						vessel.ActionGroups.SetGroup(KSPActionGroup.Brakes, true);
+					if (speedErr < -1 && StabilityControl && Mathf.Sign(s.wheelThrottle) + Math.Sign(curSpeed) == 0) {
 						brake = true;
-//						foreach (Part p in wheels) {
-//							if (p.GetModule<ModuleWheels.ModuleWheelDamage>().stressPercent >= 0.01) { // #TODO needs adaptive braking
-//								brake = false;
-//								break;
-//							}
-//						}
 					}
-////					else if (!StabilityControl || traction <= 50 || speedErr > -0.2 || Mathf.Sign(s.wheelThrottle) + Mathf.Sign((float)curSpeed) != 0) {
-////						vessel.ActionGroups.SetGroup(KSPActionGroup.Brakes, (GameSettings.BRAKES.GetKey() && vessel.isActiveVessel));
-////					}
 					lastThrottle = Mathf.Clamp(s.wheelThrottle, -1, 1);
 				}
 			}
@@ -407,42 +321,16 @@ namespace MuMech
 				if (!core.attitude.users.Contains(this))
 				{
 					core.attitude.users.Add(this);
-//					line.enabled = true;
 				}
-//				float scale = Vector3.Distance(FlightCamera.fetch.mainCamera.transform.position, vessel.CoM) / 900f;
-//				line.SetPosition(0, vessel.CoM);
-//				line.SetPosition(1, vessel.CoM + hit.normal * 5);
-//				line.SetWidth(0, scale + 0.1f);
 				var fSpeed = (float)curSpeed;
-//				if (Mathf.Abs(fSpeed) >= turnSpeed * 0.75) {
 				Vector3 fwd = (Vector3)(traction > 0 ? // V when the speed is low go for the vessels forward, else with a bit of velocity
-//				                        ((Mathf.Abs(fSpeed) <= turnSpeed ? vesselState.forward : vesselState.surfaceVelocity / 4) - vessel.transform.right * s.wheelSteer) * Mathf.Sign(fSpeed) :
-//				                        // ^ and then add the steering
 				                        vesselState.forward * 4 - vessel.transform.right * s.wheelSteer * Mathf.Sign(fSpeed) : // and then add the steering
 				                        vesselState.surfaceVelocity); // in the air so follow velocity
 				Vector3.OrthoNormalize(ref norm, ref fwd);
 				var quat = Quaternion.LookRotation(fwd, norm);
 				
-//				if (traction > 0 || speed <= turnSpeed) {
-//					var u = new Vector3(0, 1, 0);
-//
-//					var q = FlightGlobals.ship_rotation;
-//					var q_s = quat;
-//
-//					var q_u = new Quaternion(u.x, u.y, u.z, 0);
-//					var a = Quaternion.Dot(q, q_s * q_u);
-//					var q_qs = Quaternion.Dot(q, q_s);
-//					var b = (a == 0) ? Math.Sign(q_qs) : (q_qs / a);
-//					var g = b / Mathf.Sqrt((b * b) + 1);
-//					var gu = Mathf.Sqrt(1 - (g * g)) * u;
-//					var q_d = new Quaternion() { w = g, x = gu.x, y = gu.y, z = gu.z };
-//					var n = q_s * q_d;
-//
-//					quat = n;
-//				}
                 if (vesselState.torqueAvailable.sqrMagnitude > 0)
 				    core.attitude.attitudeTo(quat, AttitudeReference.INERTIAL, this);
-//				}
 			}
 			
 			if (BrakeOnEnergyDepletion)
@@ -474,7 +362,6 @@ namespace MuMech
 				}
 			}
 			
-//			brake = brake && (s.wheelThrottle == 0); // release brake if the user or AP want to drive
 			if (s.wheelThrottle != 0 && (Math.Sign(s.wheelThrottle) + Math.Sign(curSpeed) != 0 || curSpeed < 1))
 			{
 				brake = false; // the AP or user want to drive into the direction of momentum so release the brake

--- a/MechJeb2/MechJebModuleRoverWindow.cs
+++ b/MechJeb2/MechJebModuleRoverWindow.cs
@@ -83,7 +83,7 @@ namespace MuMech
 //			GUILayout.Label("Debug1: " + autopilot.debug1.ToString("F3"));
 			
 			GUILayout.BeginHorizontal();
-			if (core.target != null && core.target.Target != null) // && (core.target.targetBody == orbit.referenceBody || (core.target.Orbit != null ? core.target.Orbit.referenceBody == orbit.referenceBody : false))) {
+			if (core.target != null && core.target.Target != null)
 			{
 				var vssl = core.target.Target.GetVessel();
 				
@@ -103,7 +103,6 @@ namespace MuMech
 				{
 					if (vssl != null) {	autopilot.Waypoints.Add(new MechJebWaypoint(vssl, 25f)); }
 					else { autopilot.Waypoints.Add(new MechJebWaypoint(core.target.GetPositionTargetPosition())); }
-//					if (autopilot.WaypointIndex < 0) { autopilot.WaypointIndex = autopilot.Waypoints.Count - 1; }
 				}
 			}
 			GUILayout.EndHorizontal();

--- a/MechJeb2/MechJebModuleRoverWindow.cs
+++ b/MechJeb2/MechJebModuleRoverWindow.cs
@@ -16,7 +16,7 @@ namespace MuMech
 
 		public override string GetName()
 		{
-			return Localizer.Format("#MechJeb_Rover_title");//"Rover Autopilot"
+			return Localizer.Format("#MechJeb_Rover_title"); // "Rover Autopilot"
 		}
 
 		public override string IconName()
@@ -55,28 +55,28 @@ namespace MuMech
 			if (GUILayout.Button("+", GUILayout.Width(18))) { autopilot.speed.val += (GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1); }
 			GUILayout.EndHorizontal();
 			ed.registry.Find(i => i.id == "Value:RoverController.speedErr").DrawItem();
-            ed.registry.Find(i => i.id == "Toggle:RoverController.StabilityControl").DrawItem();
+			ed.registry.Find(i => i.id == "Toggle:RoverController.StabilityControl").DrawItem();
 
-            if (!core.settings.hideBrakeOnEject)
-            {
-            	ed.registry.Find(i => i.id == "Toggle:RoverController.BrakeOnEject").DrawItem();
-            }
-            
-            ed.registry.Find(i => i.id == "Toggle:RoverController.BrakeOnEnergyDepletion").DrawItem();
-            if (autopilot.BrakeOnEnergyDepletion)
-            {
-            	ed.registry.Find(i => i.id == "Toggle:RoverController.WarpToDaylight").DrawItem();
-            }
+			if (!core.settings.hideBrakeOnEject)
+			{
+				ed.registry.Find(i => i.id == "Toggle:RoverController.BrakeOnEject").DrawItem();
+			}
+
+			ed.registry.Find(i => i.id == "Toggle:RoverController.BrakeOnEnergyDepletion").DrawItem();
+			if (autopilot.BrakeOnEnergyDepletion)
+			{
+				ed.registry.Find(i => i.id == "Toggle:RoverController.WarpToDaylight").DrawItem();
+			}
 
 			GUILayout.BeginVertical();
 			
 			GUILayout.BeginHorizontal();
-			GUILayout.Label(Localizer.Format("#MechJeb_Rover_label1"), GUILayout.ExpandWidth(true));//"Target Speed"
+			GUILayout.Label(Localizer.Format("#MechJeb_Rover_label1"), GUILayout.ExpandWidth(true)); // "Target Speed"
 			GUILayout.Label(autopilot.tgtSpeed.ToString("F1"), GUILayout.ExpandWidth(false));
 			GUILayout.EndHorizontal();
 
 			GUILayout.BeginHorizontal();
-			GUILayout.Label(Localizer.Format("#MechJeb_Rover_label2"), GUILayout.ExpandWidth(true));//"Waypoints"
+			GUILayout.Label(Localizer.Format("#MechJeb_Rover_label2"), GUILayout.ExpandWidth(true)); // "Waypoints"
 			GUILayout.Label("Index " + (autopilot.WaypointIndex + 1).ToString() + " of " + autopilot.Waypoints.Count.ToString(), GUILayout.ExpandWidth(false));
 			GUILayout.EndHorizontal();
 			
@@ -87,21 +87,21 @@ namespace MuMech
 			{
 				var vssl = core.target.Target.GetVessel();
 				
-				if (GUILayout.Button(Localizer.Format("#MechJeb_Rover_button1")))//"To Target"
+				if (GUILayout.Button(Localizer.Format("#MechJeb_Rover_button1"))) // "To Target"
 				{
 					core.GetComputerModule<MechJebModuleWaypointWindow>().selIndex = -1;
 					autopilot.WaypointIndex = 0;
 					autopilot.Waypoints.Clear();
-					if (vssl != null) {	autopilot.Waypoints.Add(new MechJebWaypoint(vssl, 25f)); }
+					if (vssl != null) { autopilot.Waypoints.Add(new MechJebWaypoint(vssl, 25f)); }
 					else { autopilot.Waypoints.Add(new MechJebWaypoint(core.target.GetPositionTargetPosition())); }
 					autopilot.ControlHeading = autopilot.ControlSpeed = true;
 					vessel.ActionGroups.SetGroup(KSPActionGroup.Brakes, false);
 					autopilot.LoopWaypoints = alt;
 				}
 
-				if (GUILayout.Button(Localizer.Format("#MechJeb_Rover_button2")))//"Add Target"
+				if (GUILayout.Button(Localizer.Format("#MechJeb_Rover_button2"))) // "Add Target"
 				{
-					if (vssl != null) {	autopilot.Waypoints.Add(new MechJebWaypoint(vssl, 25f)); }
+					if (vssl != null) { autopilot.Waypoints.Add(new MechJebWaypoint(vssl, 25f)); }
 					else { autopilot.Waypoints.Add(new MechJebWaypoint(core.target.GetPositionTargetPosition())); }
 				}
 			}
@@ -110,18 +110,18 @@ namespace MuMech
 			GUILayout.BeginHorizontal();
 			if (autopilot.Waypoints.Count > 0) {
 				if (!autopilot.ControlHeading || !autopilot.ControlSpeed) {
-					if (GUILayout.Button(Localizer.Format("#MechJeb_Rover_button3"))) {//"Drive"
+					if (GUILayout.Button(Localizer.Format("#MechJeb_Rover_button3"))) { // "Drive"
 						autopilot.WaypointIndex = Mathf.Max(0, (alt ? 0 : autopilot.WaypointIndex));
 						autopilot.ControlHeading = autopilot.ControlSpeed = true;
 						// autopilot.LoopWaypoints = alt;
 					}
 				}
-				else if (GUILayout.Button(Localizer.Format("#MechJeb_Rover_button4"))) {//"Stop"
+				else if (GUILayout.Button(Localizer.Format("#MechJeb_Rover_button4"))) { // "Stop"
 					// autopilot.WaypointIndex = -1; // more annoying than helpful
 					autopilot.ControlHeading = autopilot.ControlSpeed = autopilot.LoopWaypoints = false;
 				}
 			}
-			if (GUILayout.Button(Localizer.Format("#MechJeb_Rover_button5"))) {//"Waypoints"
+			if (GUILayout.Button(Localizer.Format("#MechJeb_Rover_button5"))) { // "Waypoints"
 				var waypoints = core.GetComputerModule<MechJebModuleWaypointWindow>();
 				waypoints.enabled = !waypoints.enabled;
 				if (waypoints.enabled) {

--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -19,7 +19,7 @@ namespace MuMech
 		public float MaxSpeed;
 		public bool Quicksave;
 
-		public CelestialBody Body  {
+		public CelestialBody Body {
 			get { return (Target != null ? Target.mainBody : FlightGlobals.ActiveVessel.mainBody); }
 		}
 
@@ -176,37 +176,37 @@ namespace MuMech
 		public WaypointMode Mode = WaypointMode.Rover;
 		public MechJebModuleRoverController ap;
 		public static List<MechJebWaypointRoute> Routes = new List<MechJebWaypointRoute>();
-		[EditableInfoItem("#MechJeb_MohoMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Moho Mapdist
+		[EditableInfoItem("#MechJeb_MohoMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Moho Mapdist
 		public EditableDouble MohoMapdist = 5000;
-		[EditableInfoItem("#MechJeb_EveMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Eve Mapdist
+		[EditableInfoItem("#MechJeb_EveMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Eve Mapdist
 		public EditableDouble EveMapdist = 5000;
-		[EditableInfoItem("#MechJeb_GillyMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Gilly Mapdist
+		[EditableInfoItem("#MechJeb_GillyMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Gilly Mapdist
 		public EditableDouble GillyMapdist = -500;
-		[EditableInfoItem("#MechJeb_KerbinMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Kerbin Mapdist
+		[EditableInfoItem("#MechJeb_KerbinMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Kerbin Mapdist
 		public EditableDouble KerbinMapdist = 500;
-		[EditableInfoItem("#MechJeb_MunMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Mun Mapdist
+		[EditableInfoItem("#MechJeb_MunMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Mun Mapdist
 		public EditableDouble MunMapdist = 4000;
-		[EditableInfoItem("#MechJeb_MinmusMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Minmus Mapdist
+		[EditableInfoItem("#MechJeb_MinmusMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Minmus Mapdist
 		public EditableDouble MinmusMapdist = 3500;
-		[EditableInfoItem("#MechJeb_DunaMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Duna Mapdist
+		[EditableInfoItem("#MechJeb_DunaMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Duna Mapdist
 		public EditableDouble DunaMapdist = 5000;
-		[EditableInfoItem("#MechJeb_IkeMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Ike Mapdist
+		[EditableInfoItem("#MechJeb_IkeMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Ike Mapdist
 		public EditableDouble IkeMapdist = 4000;
-		[EditableInfoItem("#MechJeb_DresMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Dres Mapdist
+		[EditableInfoItem("#MechJeb_DresMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Dres Mapdist
 		public EditableDouble DresMapdist = 1500;
-		[EditableInfoItem("#MechJeb_EelooMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Eeloo Mapdist
+		[EditableInfoItem("#MechJeb_EelooMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Eeloo Mapdist
 		public EditableDouble EelooMapdist = 2000;
-		[EditableInfoItem("#MechJeb_JoolMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Jool Mapdist
+		[EditableInfoItem("#MechJeb_JoolMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Jool Mapdist
 		public EditableDouble JoolMapdist = 30000;
-		[EditableInfoItem("#MechJeb_TyloMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Tylo Mapdist
+		[EditableInfoItem("#MechJeb_TyloMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Tylo Mapdist
 		public EditableDouble TyloMapdist = 5000;
-		[EditableInfoItem("#MechJeb_LaytheMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Laythe Mapdist
+		[EditableInfoItem("#MechJeb_LaytheMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Laythe Mapdist
 		public EditableDouble LaytheMapdist = 1000;
-		[EditableInfoItem("#MechJeb_PolMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Pol Mapdist
+		[EditableInfoItem("#MechJeb_PolMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Pol Mapdist
 		public EditableDouble PolMapdist = 500;
-		[EditableInfoItem("#MechJeb_BopMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Bop Mapdist
+		[EditableInfoItem("#MechJeb_BopMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Bop Mapdist
 		public EditableDouble BopMapdist = 1000;
-		[EditableInfoItem("#MechJeb_VallMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)]//Vall Mapdist
+		[EditableInfoItem("#MechJeb_VallMapdist", InfoItem.Category.Rover), Persistent(pass = (int)Pass.Global)] // Vall Mapdist
 		public EditableDouble VallMapdist = 5000;
 
 		internal int selIndex = -1;
@@ -216,9 +216,9 @@ namespace MuMech
 		internal string tmpMaxSpeed = "";
 		internal string tmpLat = "";
 		internal string tmpLon = "";
-	    internal const string coordRegEx = @"^([nsew])?\s*(-?\d+(?:\.\d+)?)(?:[°:\s]+(-?\d+(?:\.\d+)?))?(?:[':\s]+(-?\d+(?:\.\d+)?))?(?:[^nsew]*([nsew])?)?$";
+		internal const string coordRegEx = @"^([nsew])?\s*(-?\d+(?:\.\d+)?)(?:[°:\s]+(-?\d+(?:\.\d+)?))?(?:[':\s]+(-?\d+(?:\.\d+)?))?(?:[^nsew]*([nsew])?)?$";
 
-	    private Vector2 scroll;
+		private Vector2 scroll;
 		private GUIStyle styleActive;
 		private GUIStyle styleInactive;
 		private GUIStyle styleQuicksave;
@@ -542,7 +542,7 @@ namespace MuMech
 						dist += Vector3.Distance((i == ap.WaypointIndex || (ap.WaypointIndex == -1 && i == 0) ? vessel.CoM : (Vector3)ap.Waypoints[i - 1].Position), (Vector3)wp.Position);
 					}
 					string str = string.Format("[{0}] - {1} - R: {2:F1} m\n       S: {3:F0} ~ {4:F0} - D: {5}m - ETA: {6}", i + 1, wp.GetNameWithCoords(), wp.Radius,
-					                           minSpeed, maxSpeed, MuUtils.ToSI(dist, -1), GuiUtils.TimeToDHMS(eta));
+									minSpeed, maxSpeed, MuUtils.ToSI(dist, -1), GuiUtils.TimeToDHMS(eta));
 					GUI.backgroundColor = (i == ap.WaypointIndex ? new Color(0.5f, 1f, 0.5f) : Color.white);
 					if (GUILayout.Button(str, (i == selIndex ? styleActive : (wp.Quicksave ? styleQuicksave : styleInactive))))
 					{
@@ -671,37 +671,38 @@ namespace MuMech
 					ap.Waypoints.RemoveAt(selIndex);
 					if (ap.WaypointIndex > selIndex) { ap.WaypointIndex--; }
 				}
-			    selIndex = -1;
+				selIndex = -1;
 				//if (ap.WaypointIndex >= ap.Waypoints.Count) { ap.WaypointIndex = ap.Waypoints.Count - 1; }
 			}
 			if (GUILayout.Button((alt ? "Top" : "Up"), GUILayout.Width(57)) && selIndex > 0 && selIndex < ap.Waypoints.Count && ap.Waypoints.Count >= 2)
-            {
-                if (alt)
-                {
-                    var t = ap.Waypoints[selIndex];
-                    ap.Waypoints.RemoveAt(selIndex);
-                    ap.Waypoints.Insert(0, t);
-                    selIndex = 0;
-                }
-                else
-                {
-                    ap.Waypoints.Swap(selIndex, --selIndex);
-                }
-            }
-            if (GUILayout.Button((alt ? "Bottom" : "Down"), GUILayout.Width(57)) && selIndex >= 0 && selIndex < ap.Waypoints.Count - 1 && ap.Waypoints.Count >= 2)
-            {
-                if (alt)
-                {
-                    var t = ap.Waypoints[selIndex];
-                    ap.Waypoints.RemoveAt(selIndex);
-                    ap.Waypoints.Add(t);
-                    selIndex = ap.Waypoints.Count - 1;
-                }
-                else
-                {
-                    ap.Waypoints.Swap(selIndex, ++selIndex);
-                }
-            }
+			{
+				if (alt)
+				{
+					var t = ap.Waypoints[selIndex];
+					ap.Waypoints.RemoveAt(selIndex);
+					ap.Waypoints.Insert(0, t);
+					selIndex = 0;
+				}
+				else
+				{
+					ap.Waypoints.Swap(selIndex, --selIndex);
+				}
+			}
+
+			if (GUILayout.Button((alt ? "Bottom" : "Down"), GUILayout.Width(57)) && selIndex >= 0 && selIndex < ap.Waypoints.Count - 1 && ap.Waypoints.Count >= 2)
+			{
+				if (alt)
+				{
+					var t = ap.Waypoints[selIndex];
+					ap.Waypoints.RemoveAt(selIndex);
+					ap.Waypoints.Add(t);
+					selIndex = ap.Waypoints.Count - 1;
+				}
+				else
+				{
+					ap.Waypoints.Swap(selIndex, ++selIndex);
+				}
+			}
 			if (GUILayout.Button("Routes"))
 			{
 				showPage = pages.routes;
@@ -743,7 +744,7 @@ namespace MuMech
 					ed.registry.Find(i => i.id == "Editable:RoverController.hPIDi").DrawItem();
 					ed.registry.Find(i => i.id == "Editable:RoverController.hPIDd").DrawItem();
 					ed.registry.Find(i => i.id == "Editable:RoverController.terrainLookAhead").DrawItem();
-		//			ed.registry.Find(i => i.id == "Value:RoverController.speedIntAcc").DrawItem();
+//					ed.registry.Find(i => i.id == "Value:RoverController.speedIntAcc").DrawItem();
 					ed.registry.Find(i => i.id == "Editable:RoverController.tractionLimit").DrawItem();
 					ed.registry.Find(i => i.id == "Toggle:RoverController.LimitAcceleration").DrawItem();
 					GUILayout.EndVertical();
@@ -1019,7 +1020,7 @@ namespace MuMech
 
 		public override string GetName()
 		{
-            return Localizer.Format("#MechJeb_Waypointhelper_title");//"Waypoint Help"
+			return Localizer.Format("#MechJeb_Waypointhelper_title"); // "Waypoint Help"
 		}
 
 		public override string IconName()
@@ -1047,75 +1048,75 @@ namespace MuMech
 				btnActive.active.textColor = btnActive.hover.textColor = btnActive.focused.textColor = btnActive.normal.textColor = Color.green;
 			}
 
-		 	selTopic = GUILayout.SelectionGrid(selTopic, topics, topics.Length);
+			selTopic = GUILayout.SelectionGrid(selTopic, topics, topics.Length);
 
-		 	switch (topics[selTopic])
-		 	{
-                case "Rover Controller":
-		 			HelpTopic("Holding a set Heading", "To hold a specific heading just tick the box next to 'Heading control' and the autopilot will try to keep going for the entered heading." +
-		 			          "\nThis also needs to be enabled when the autopilot is supposed to drive to a waypoint" +
-		 			          "'Heading Error' simply shows the error between current heading and target heading.");
-		 			HelpTopic("Holding a set Speed", "To hold a specific speed just tick the box next to 'Speed control' and the autopilot will try to keep going at the entered speed." +
-		 			          "\nThis also needs to be enabled when the autopilot is supposed to drive to a waypoint" +
-		 			          "'Speed Error' simply shows the error between current speed and target speed.");
-		 			HelpTopic("More stability while driving and nice landings", "If you turn on 'Stability Control' then the autopilot will use the reaction wheel's torque to keep the rover aligned with the surface." +
-		 			          "\nThis means that if you make a jump the autopilot will try to align the rover in the best possible way to land as straight and flat as possible given the available time and torque." +
-		 			          "\nBe aware that this doesn't make your rover indestructible, only relatively unlikely to land in a bad way." +
-		 			          "\n\n'Stability Control' will also limit the brake to reduce the chances of flipping over from too much braking power." +
-		 			          "\nSee 'Settings' -> 'Traction and Braking'. This setting is also saved per vessel.");
-		 			HelpTopic("Brake on Pilot Eject", "With this option enabled the rover will stop if the pilot (on manned rovers) should get thrown out of his seat.");
-		 			HelpTopic("Target Speed", "Current speed the autopilot tries to achieve.");
-		 			HelpTopic("Waypoint Index", "Overview of waypoints and which the autopilot is currently driving to.");
-		 			HelpTopic("Button 'Waypoints'", "Opens the waypoint list to set up a route.");
-		 			HelpTopic("Button 'Follow' / 'Stop'", "This sets the autopilot to drive along the set route starting at the first waypoint. Only visible when atleast one waypoint is set." +
-		 			          "\n\nAlt click will set the autopilot to 'Loop Mode' which will make it go for the first waypoint again after reaching the last." +
-		 			          "If the only waypoint happens to be a target it will keep following that instead of only going to it once." +
-		 			          "\n\nIf the autopilot is already active the 'Follow' button will turn into the 'Stop' button which will obviously stop it when pressed.");
-		 			HelpTopic("Button 'To Target'", "Clears the route, adds the target as only waypoint and starts the autopilot. Only visible with a selected target." +
-		 			          "\n\nAlt click will set the autopilot to 'Loop Mode' which will make it continue to follow the target, pausing when near it instead of turning off then.");
-		 			HelpTopic("Button 'Add Target'", "Adds the selected target as a waypoint either at the end of the route or before the selected waypoint. Only visible with a selected target.");
-		 			break;
+			switch (topics[selTopic])
+			{
+				case "Rover Controller":
+					HelpTopic("Holding a set Heading", "To hold a specific heading just tick the box next to 'Heading control' and the autopilot will try to keep going for the entered heading." +
+					          "\nThis also needs to be enabled when the autopilot is supposed to drive to a waypoint" +
+					          "'Heading Error' simply shows the error between current heading and target heading.");
+					HelpTopic("Holding a set Speed", "To hold a specific speed just tick the box next to 'Speed control' and the autopilot will try to keep going at the entered speed." +
+					          "\nThis also needs to be enabled when the autopilot is supposed to drive to a waypoint" +
+					          "'Speed Error' simply shows the error between current speed and target speed.");
+					HelpTopic("More stability while driving and nice landings", "If you turn on 'Stability Control' then the autopilot will use the reaction wheel's torque to keep the rover aligned with the surface." +
+					          "\nThis means that if you make a jump the autopilot will try to align the rover in the best possible way to land as straight and flat as possible given the available time and torque." +
+					          "\nBe aware that this doesn't make your rover indestructible, only relatively unlikely to land in a bad way." +
+					          "\n\n'Stability Control' will also limit the brake to reduce the chances of flipping over from too much braking power." +
+					          "\nSee 'Settings' -> 'Traction and Braking'. This setting is also saved per vessel.");
+					HelpTopic("Brake on Pilot Eject", "With this option enabled the rover will stop if the pilot (on manned rovers) should get thrown out of his seat.");
+					HelpTopic("Target Speed", "Current speed the autopilot tries to achieve.");
+					HelpTopic("Waypoint Index", "Overview of waypoints and which the autopilot is currently driving to.");
+					HelpTopic("Button 'Waypoints'", "Opens the waypoint list to set up a route.");
+					HelpTopic("Button 'Follow' / 'Stop'", "This sets the autopilot to drive along the set route starting at the first waypoint. Only visible when atleast one waypoint is set." +
+					          "\n\nAlt click will set the autopilot to 'Loop Mode' which will make it go for the first waypoint again after reaching the last." +
+					          "If the only waypoint happens to be a target it will keep following that instead of only going to it once." +
+					          "\n\nIf the autopilot is already active the 'Follow' button will turn into the 'Stop' button which will obviously stop it when pressed.");
+					HelpTopic("Button 'To Target'", "Clears the route, adds the target as only waypoint and starts the autopilot. Only visible with a selected target." +
+					          "\n\nAlt click will set the autopilot to 'Loop Mode' which will make it continue to follow the target, pausing when near it instead of turning off then.");
+					HelpTopic("Button 'Add Target'", "Adds the selected target as a waypoint either at the end of the route or before the selected waypoint. Only visible with a selected target.");
+					break;
 
-		 		case "Waypoints":
-		 			HelpTopic("Adding Waypoints", "Adds a new waypoint to the route at the end or before the currently selected waypoint, " +
-		 			          "simply click the terrain or somewhere on the body in Mapview." +
-		 			          "\n\nAlt clicking will reverse the route for easier going back and holding Alt while clicking the terrain or body in Mapview will allow to add more waypoints without having to click the button again.");
-		 			HelpTopic("Removing Waypoints", "Removes the currently selected waypoint." +
-		 			          "\n\nAlt clicking will remove all waypoints.");
-		 			HelpTopic("Reordering Waypoints", "'Up' and 'Down' will move the selected waypoint up or down in the list, Alt clicking will move it to the top or bottom respectively.");
-		 			HelpTopic("Waypoint Radius", "Radius defines the distance to the center of the waypoint after which the waypoint will be considered 'reached'." +
-		 			          "\n\nA radius of 5m (default) simply means that when you're 5m from the waypoint away the autopilot will jump to the next or turn off if it was the last." +
-		 			          "\n\nThe 'A' button behind the textfield will set the entered radius for all waypoints.");
-		 			HelpTopic("Speedlimits", "The two speed textfields represent the minimum and maximum speed for the waypoint." +
-		 			          "\n\nThe maximum speed is the speed the autopilot tries to reach to get to the waypoint." +
-		 			          "\n\nThe minimum speed was before used to set the speed with which the autopilot will go through the waypoint, but that got reworked now to be based on the next waypoint's max. speed and the turn needed at the waypoint." +
-		 			          "\n\nI have no idea what this will currently do if set so better just leave it at 0..." +
-		 			          "\n\nThe 'A' buttons set their respective speed for all waypoints.");
-		 			HelpTopic("Quicksaving at a Waypoint", "Clicking the 'QS' button will turn on QuickSave for that waypoint." +
-		 			          "\n\nThis will make the autopilot stop and try to quicksave at that waypoint and then continue. A QuickSave waypoint has yellow text instead of white." +
-		 			          "\n\nSmall sideeffect: leaving the throttle up will prevent the saving from occurring effectively pausing the autopilot at that point until interefered with. (Discovered by Greys)" +
-		 			          "\n\nAlt clicking will toggle QS for all waypoints including the clicked one.");
-		 			HelpTopic("Changing the current target Waypoint", "Alt clicking a waypoint will mark it as the current target waypoint. The active waypoint has a green tinted background.");
-		 			break;
+				case "Waypoints":
+					HelpTopic("Adding Waypoints", "Adds a new waypoint to the route at the end or before the currently selected waypoint, " +
+					          "simply click the terrain or somewhere on the body in Mapview." +
+					          "\n\nAlt clicking will reverse the route for easier going back and holding Alt while clicking the terrain or body in Mapview will allow to add more waypoints without having to click the button again.");
+					HelpTopic("Removing Waypoints", "Removes the currently selected waypoint." +
+					          "\n\nAlt clicking will remove all waypoints.");
+					HelpTopic("Reordering Waypoints", "'Up' and 'Down' will move the selected waypoint up or down in the list, Alt clicking will move it to the top or bottom respectively.");
+					HelpTopic("Waypoint Radius", "Radius defines the distance to the center of the waypoint after which the waypoint will be considered 'reached'." +
+					          "\n\nA radius of 5m (default) simply means that when you're 5m from the waypoint away the autopilot will jump to the next or turn off if it was the last." +
+					          "\n\nThe 'A' button behind the textfield will set the entered radius for all waypoints.");
+					HelpTopic("Speedlimits", "The two speed textfields represent the minimum and maximum speed for the waypoint." +
+					          "\n\nThe maximum speed is the speed the autopilot tries to reach to get to the waypoint." +
+					          "\n\nThe minimum speed was before used to set the speed with which the autopilot will go through the waypoint, but that got reworked now to be based on the next waypoint's max. speed and the turn needed at the waypoint." +
+					          "\n\nI have no idea what this will currently do if set so better just leave it at 0..." +
+					          "\n\nThe 'A' buttons set their respective speed for all waypoints.");
+					HelpTopic("Quicksaving at a Waypoint", "Clicking the 'QS' button will turn on QuickSave for that waypoint." +
+					          "\n\nThis will make the autopilot stop and try to quicksave at that waypoint and then continue. A QuickSave waypoint has yellow text instead of white." +
+					          "\n\nSmall sideeffect: leaving the throttle up will prevent the saving from occurring effectively pausing the autopilot at that point until interefered with. (Discovered by Greys)" +
+					          "\n\nAlt clicking will toggle QS for all waypoints including the clicked one.");
+					HelpTopic("Changing the current target Waypoint", "Alt clicking a waypoint will mark it as the current target waypoint. The active waypoint has a green tinted background.");
+					break;
 
-		 		case "Routes":
-		 			HelpTopic("Routes Help", "The empty textfield is for saving routes, enter a name there before clicking 'Save'." +
-		 			          "\n\nTo load a route simply select one from the list and click 'Load'." +
-		 			          "\n\nTo delete a route simply select it and a 'Delete' button will appear right of it.");
-		 			break;
+				case "Routes":
+					HelpTopic("Routes Help", "The empty textfield is for saving routes, enter a name there before clicking 'Save'." +
+					          "\n\nTo load a route simply select one from the list and click 'Load'." +
+					          "\n\nTo delete a route simply select it and a 'Delete' button will appear right of it.");
+					break;
 
-		 		case "Settings":
-		 			HelpTopic("Heading / Speed PID", "These parameters control the behaviour of the heading's / speed's PID. Saved globally so NO TOUCHING unless you know what you're doing (or atleast know how to write down numbers to restore it if you mess up)");
-		 			HelpTopic("Safe Turn Speed", "'Safe Turn Speed' tells the autopilot which speed the rover can usually go full turn through corners without tipping over." +
-		 			          "\n\nGiven how differently terrain can be and other influences you can just leave it at 3 m/s but if you're impatient or just want to experiment feel free to test around. Saved per vessel type (same named vessels will share the setting).");
-		 			HelpTopic("Traction and Braking", "'Traction' shows in % how many wheels have ground contact." +
-		 			          "\n'Traction Brake Limit' defines what traction is atleast needed for the autopilot to still apply the brakes (given 'Stability Control' is active) even if you hold the brake down." +
-		 			          "\nThis means the default setting of 75 will make it brake only if atleast 3 wheels have ground contact." +
-		 			          "\n'Traction Brake Limit' is saved per vessel type." +
-		 			          "\n\nIf you have 'Stability Control' off then it won't take care of your brake and you can flip as much as you want.");
-		 			HelpTopic("Changing the route height in Mapview", "These values define offsets for the route height in Mapview. Given how weird it's set up it can be that they are too high or too low so I added these for easier adjusting. Saved globally, I think.");
-		 			break;
-		 	}
+				case "Settings":
+					HelpTopic("Heading / Speed PID", "These parameters control the behaviour of the heading's / speed's PID. Saved globally so NO TOUCHING unless you know what you're doing (or atleast know how to write down numbers to restore it if you mess up)");
+					HelpTopic("Safe Turn Speed", "'Safe Turn Speed' tells the autopilot which speed the rover can usually go full turn through corners without tipping over." +
+					          "\n\nGiven how differently terrain can be and other influences you can just leave it at 3 m/s but if you're impatient or just want to experiment feel free to test around. Saved per vessel type (same named vessels will share the setting).");
+					HelpTopic("Traction and Braking", "'Traction' shows in % how many wheels have ground contact." +
+					          "\n'Traction Brake Limit' defines what traction is atleast needed for the autopilot to still apply the brakes (given 'Stability Control' is active) even if you hold the brake down." +
+					          "\nThis means the default setting of 75 will make it brake only if atleast 3 wheels have ground contact." +
+					          "\n'Traction Brake Limit' is saved per vessel type." +
+					          "\n\nIf you have 'Stability Control' off then it won't take care of your brake and you can flip as much as you want.");
+					HelpTopic("Changing the route height in Mapview", "These values define offsets for the route height in Mapview. Given how weird it's set up it can be that they are too high or too low so I added these for easier adjusting. Saved globally, I think.");
+					break;
+			}
 
 			base.WindowGUI(windowID);
 		}
@@ -1153,9 +1154,9 @@ namespace MuMech
 			line = obj.AddComponent<LineRenderer>();
 			line.useWorldSpace = true;
 			line.material = material;
-		    line.startWidth = 10.0f;
-		    line.endWidth = 10.0f;
-		    line.positionCount = 2;
+			line.startWidth = 10.0f;
+			line.endWidth = 10.0f;
+			line.positionCount = 2;
 			return true;
 		}
 
@@ -1223,11 +1224,11 @@ namespace MuMech
 				//float width = (MapView.MapIsEnabled ? (float)mainBody.Radius / 10000 : 1);
 
 				pastPath.startWidth = width;
-			    pastPath.endWidth = width;
+				pastPath.endWidth = width;
 				currPath.startWidth = width;
-			    currPath.endWidth = width;
+				currPath.endWidth = width;
 				nextPath.startWidth = width;
-			    nextPath.endWidth = width;
+				nextPath.endWidth = width;
 				selWP.gameObject.layer = pastPath.gameObject.layer = currPath.gameObject.layer = nextPath.gameObject.layer = (MapView.MapIsEnabled ? 9 : 0);
 
 				int sel = ap.core.GetComputerModule<MechJebModuleWaypointWindow>().selIndex;
@@ -1236,7 +1237,7 @@ namespace MuMech
 				{
 					float w = Vector3.Distance(FlightCamera.fetch.mainCamera.transform.position, ap.Waypoints[sel].Position) / 600f + 0.1f;
 					selWP.startWidth = 0;
-				    selWP.endWidth = w * 10f;
+					selWP.endWidth = w * 10f;
 					selWP.SetPosition(0, RaisePositionOverTerrain(ap.Waypoints[sel].Position, targetHeight + 3f));
 					selWP.SetPosition(1, RaisePositionOverTerrain(ap.Waypoints[sel].Position, targetHeight + 3f + w * 15f));
 				}
@@ -1245,7 +1246,7 @@ namespace MuMech
 				{
 //					Debug.Log("drawing pastPath");
 					pastPath.enabled = true;
-				    pastPath.positionCount = ap.WaypointIndex + 1;
+					pastPath.positionCount = ap.WaypointIndex + 1;
 					for (int i = 0; i < ap.WaypointIndex; i++)
 					{
 //						Debug.Log("vert " + i.ToString());
@@ -1279,7 +1280,7 @@ namespace MuMech
 				{
 //					Debug.Log("drawing nextPath of " + nextCount + " verts");
 					nextPath.enabled = true;
-				    nextPath.positionCount = nextCount;
+					nextPath.positionCount = nextCount;
 					nextPath.SetPosition(0, RaisePositionOverTerrain((ap.WaypointIndex == -1 ? ap.vessel.CoM : (Vector3)ap.Waypoints[ap.WaypointIndex].Position), targetHeight));
 					for (int i = 0; i < nextCount - 1; i++)
 					{

--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -23,7 +23,7 @@ namespace MuMech
 			get { return (Target != null ? Target.mainBody : FlightGlobals.ActiveVessel.mainBody); }
 		}
 
-		public MechJebWaypoint(double Latitude, double Longitude, float Radius = defaultRadius, string Name = "", float MinSpeed = 0, float MaxSpeed = 0) { //, CelestialBody Body = null) {
+		public MechJebWaypoint(double Latitude, double Longitude, float Radius = defaultRadius, string Name = "", float MinSpeed = 0, float MaxSpeed = 0) {
 			this.Latitude = Latitude;
 			this.Longitude = Longitude;
 			this.Radius = Radius;
@@ -33,7 +33,7 @@ namespace MuMech
 			Update();
 		}
 
-		public MechJebWaypoint(Vector3d Position, float Radius = defaultRadius, string Name = "", float MinSpeed = 0, float MaxSpeed = 0) { //, CelestialBody Body = null) {
+		public MechJebWaypoint(Vector3d Position, float Radius = defaultRadius, string Name = "", float MinSpeed = 0, float MaxSpeed = 0) {
 			this.Latitude = Body.GetLatitude(Position);
 			this.Longitude = Body.GetLongitude(Position);
 			this.Radius = Radius;
@@ -165,30 +165,6 @@ namespace MuMech
 				}
 			}
 		}
-
-//		public new void Add(MechJebWaypoint Waypoint) {
-//			this.Add(Waypoint);
-//			updateStats();
-//		}
-//
-//		public new void Insert(int Index, MechJebWaypoint Waypoint) {
-//			this.Insert(Index, Waypoint);
-//			updateStats();
-//		}
-//
-//		public new void Remove(MechJebWaypoint Waypoint) {
-//			this.Remove(Waypoint);
-//			updateStats();
-//		}
-//
-//		public new void RemoveAt(int Index) {
-//			this.RemoveAt(Index);
-//			updateStats();
-//		}
-//
-//		public new void RemoveRange() {
-//
-//		}
 	}
 
 	public class MechJebModuleWaypointWindow : DisplayModule {
@@ -352,7 +328,6 @@ namespace MuMech
 			CelestialBody body = FlightGlobals.currentMainBody;
 			Ray mouseRay = FlightCamera.fetch.mainCamera.ScreenPointToRay(Input.mousePosition);
 			RaycastHit raycast;
-//			mouseRay.origin = ScaledSpace.ScaledToLocalSpace(mouseRay.origin);
 			Vector3d relOrigin = mouseRay.origin - body.position;
 			Vector3d relSurfacePosition;
 			if (Physics.Raycast(mouseRay, out raycast, (float)body.Radius * 4f, 1 << 15, QueryTriggerInteraction.Ignore))
@@ -1007,7 +982,7 @@ namespace MuMech
 
 		public override void OnFixedUpdate()
 		{
-			if (vessel.isActiveVessel && (renderer == null || renderer.ap != ap)) { MechJebRouteRenderer.AttachToMapView(core); } //MechJebRouteRenderer.AttachToMapView(core); }
+			if (vessel.isActiveVessel && (renderer == null || renderer.ap != ap)) { MechJebRouteRenderer.AttachToMapView(core); }
 			ap.Waypoints.ForEach(wp => wp.Update());
 //			float scale = Vector3.Distance(FlightCamera.fetch.mainCamera.transform.position, vessel.CoM) / 900f;
 //			greenLine.SetPosition(0, vessel.CoM);


### PR DESCRIPTION
The rover module contains many lines of disabled code. This cleans out the unused code and unifies use of whitespace

I'm currently [trying to understand](/lampeh/MechJeb2/blob/roverwip/MechJeb2/MechJebModuleRoverController.cs) why the rover AP does what it does and might even get some useful changes out of it. This one at least makes it easier to read.