### PR TITLE
Fix copy_build.bat to correctly support paths with spaces

### DIFF
--- a/MechJeb2/copy_build.bat
+++ b/MechJeb2/copy_build.bat
@@ -8,34 +8,58 @@ SET TargetDir=%2
 SET TargetName=%3
 SET ProjectDir=%4
 
-echo %TargetPath% %TargetDir% %TargetName% %ProjectDir%
+echo:
+echo Target Path: %TargetPath%
+echo Target Dir: %TargetDir%
+echo Target Name: %TargetName%
+echo Project Dir: %ProjectDir%
+echo:
+echo Mono: "%MONO%"
+echo pdb2mdb: "%PDB2MDB%"
+echo kspdir: "%KSPDIR%"
 
 IF NOT EXIST "%MONO%" (
 	echo Expected "%MONO%" to point to mono.exe
 	exit 0
 )
 
-IF EXIST %PDB2MDB% (
-	"%MONO%" "%PDB2MDB%" %TargetPath%
-) ELSE (
-	echo Unable to find %PDB2MDB%
+IF NOT EXIST "%PDB2MDB%" (
+	echo Unable to find "%PDB2MDB%"
 )
 
-IF NOT EXIST %KSPDIR%\* (
+IF NOT EXIST "%KSPDIR%\*" (
 	echo Expected "%KSPDIR%" to point to a directory but it is not
 	exit 0
 )
 
+echo:
 echo Copying to "%KSPDIR%"
-IF EXIST "%TargetPath%" xcopy /Y /I "%TargetPath%" "%KSPDIR%\GameData\MechJeb2\Plugins\"
-IF EXIST "%TargetDir%%TargetName%.pdb" xcopy /Y /I "%TargetDir%%TargetName%.pdb" "%KSPDIR%\GameData\MechJeb2\Plugins\"
-IF EXIST "%TargetDir%%TargetName%.dll.mdb" xcopy /Y /I "%TargetDir%%TargetName%.dll.mdb" "%KSPDIR%\GameData\MechJeb2\Plugins\"
+echo:
+IF EXIST %TargetPath% xcopy /Y /I %TargetPath% "%KSPDIR%\GameData\MechJeb2\Plugins\"
+echo:
 
-IF EXIST "%ProjectDir%..\Bundles" xcopy /S /Y /I "%ProjectDir%..\Bundles" "%KSPDIR%\GameData\MechJeb2\Bundles"
-IF EXIST "%ProjectDir%..\Icons" xcopy /S /Y /I "%ProjectDir%..\Icons" "%KSPDIR%\GameData\MechJeb2\Icons"
-IF EXIST "%ProjectDir%..\Localization" xcopy /S /Y /I "%ProjectDir%..\Localization" "%KSPDIR%\GameData\MechJeb2\Localization"
-IF EXIST "%ProjectDir%..\Parts" xcopy /S /Y /I "%ProjectDir%..\Parts" "%KSPDIR%\GameData\MechJeb2\Parts"
-IF EXIST "%ProjectDir%..\LandingSites.cfg" xcopy /Y /I "%ProjectDir%..\LandingSites.cfg" "%KSPDIR%\GameData\MechJeb2\"
+IF EXIST %TargetDir%%TargetName%.pdb xcopy /Y /I "%TargetDir%%TargetName%.pdb" "%KSPDIR%\GameData\MechJeb2\Plugins\"
+echo:
+
+IF EXIST %TargetDir%%TargetName%.dll.mdb xcopy /Y /I "%TargetDir%%TargetName%.dll.mdb" "%KSPDIR%\GameData\MechJeb2\Plugins\"
+echo:
+
+
+IF EXIST %ProjectDir%..\Bundles xcopy /S /Y /I "%ProjectDir%..\Bundles" "%KSPDIR%\GameData\MechJeb2\Bundles"
+echo:
+
+IF EXIST %ProjectDir%..\Icons xcopy /S /Y /I "%ProjectDir%..\Icons" "%KSPDIR%\GameData\MechJeb2\Icons"
+echo:
+
+IF EXIST %ProjectDir%..\Localization xcopy /S /Y /I "%ProjectDir%..\Localization" "%KSPDIR%\GameData\MechJeb2\Localization"
+echo:
+
+IF EXIST %ProjectDir%..\Parts xcopy /S /Y /I "%ProjectDir%..\Parts" "%KSPDIR%\GameData\MechJeb2\Parts"
+echo:
+
+IF EXIST %ProjectDir%..\LandingSites.cfg xcopy /Y /I "%ProjectDir%..\LandingSites.cfg" "%KSPDIR%\GameData\MechJeb2\"
+echo:
+
 
 :: Display the time of compilation so I don't waste time testing code I did not compile...
 time /t


### PR DESCRIPTION
There was some inconsistent quotes.  In VS, the batch file is called with all arguments passed with double quotes wrapping, but they were once again wrapped in "" in later checks, which would cause paths to look like

`""C:\My Path With Spaces""`, which fails.