### PR TITLE
cleanup Makefile and TorquePI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,9 @@ build/%.dll: ${MECHJEBFILES}
 		/reference:"${MANAGED}/mscorlib.dll" \
 		/reference:"${MANAGED}/System.Core.dll" \
 		/reference:"${MANAGED}/System.dll" \
-		/reference:"${MANAGED}/UnityEngine.dll" \
 		/reference:"${MANAGED}/UnityEngine.AnimationModule.dll" \
 		/reference:"${MANAGED}/UnityEngine.AssetBundleModule.dll" \
 		/reference:"${MANAGED}/UnityEngine.CoreModule.dll" \
-		/reference:"${MANAGED}/UnityEngine.ImageConversionModule.dll" \
 		/reference:"${MANAGED}/UnityEngine.IMGUIModule.dll" \
 		/reference:"${MANAGED}/UnityEngine.InputLegacyModule.dll" \
 		/reference:"${MANAGED}/UnityEngine.PhysicsModule.dll" \

--- a/MechJeb2/AttitudeControllers/TorquePI.cs
+++ b/MechJeb2/AttitudeControllers/TorquePI.cs
@@ -6,46 +6,14 @@ namespace MuMech.AttitudeControllers
     {
         public PIDLoop Loop { get; set; }
 
-        public double I { get; private set; }
-
-        public MovingAverage TorqueAdjust { get; set; }
-
-        private double tr;
-
-        public double Tr
-        {
-            get { return tr; }
-            set
-            {
-                tr = value;
-                ts = 4.0 * tr / 2.76;
-            }
-        }
-
-        private double ts;
-
-        public double Ts
-        {
-            get { return ts; }
-            set
-            {
-                ts = value;
-                tr = 2.76 * ts / 4.0;
-            }
-        }
-
         public TorquePI()
         {
             Loop = new PIDLoop();
-            Ts = 2; /* FIXME: use high pass filter to measure output noise and decrease this value when no noise, and increase when it oscillates */
-            TorqueAdjust = new MovingAverage();
         }
 
         public double Update(double input, double setpoint, double MomentOfInertia, double maxOutput)
         {
-            I = MomentOfInertia;
-
-            Loop.Ki = MomentOfInertia * Math.Pow(4.0 / ts, 2);
+            Loop.Ki = MomentOfInertia * 4;
             Loop.Kp = 2 * Math.Pow(MomentOfInertia * Loop.Ki, 0.5);
             return Loop.Update(input, setpoint, maxOutput);
         }


### PR DESCRIPTION
don't need a few UnityEngine dlls and the TorquePI class had
an ton of code which dated back to kOS doing its own dynamic
MOI correction code which was all dead code.
