### PR TITLE
Use control point direction for RCS thrust

### DIFF
--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -1275,7 +1275,7 @@ namespace MuMech
             if (thrustVectorMaxThrottle.magnitude == 0 && vessel.ActionGroups[KSPActionGroup.RCS])
             {
                 rcsThrust = true;
-                thrustVectorMaxThrottle += (Vector3d)(vessel.transform.up) * rcsThrustAvailable.down;
+                thrustVectorMaxThrottle += forward * rcsThrustAvailable.down;
             }
             else
             {


### PR DESCRIPTION
Calculation of thrustVectorMaxThrottle for RCS used the static control part transform, not the switchable control point and would not enable the RCS throttle when the control point was set to "reverse".