### PR TITLE
add missing IconName override in CustomInfoWindow

### DIFF
--- a/MechJeb2/MechJebModuleCustomInfoWindow.cs
+++ b/MechJeb2/MechJebModuleCustomInfoWindow.cs
@@ -170,6 +170,11 @@ namespace MuMech
             return title;
         }
 
+        public override string IconName()
+        {
+            return title;
+        }
+
         public MechJebModuleCustomInfoWindow(MechJebCore core) : base(core) { }
     }
 


### PR DESCRIPTION
fixes #1403 
Tested, and the icons now show up again with correct names, icons, etc.