### PR TITLE
Possible fix for NK for modular launch platforms

### DIFF
--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -179,7 +179,7 @@ namespace MuMech
             //don't decouple active or idle engines or tanks
             UpdateActiveModuleEngines();
             UpdateBurnedResources();
-            if (InverseStageDecouplesActiveOrIdleEngineOrTank(vessel.currentStage - 1, vessel, burnedResources, activeModuleEngines))
+            if (InverseStageDecouplesActiveOrIdleEngineOrTank(vessel.currentStage - 1, vessel, burnedResources, activeModuleEngines) && !InverseStageReleasesClamps(vessel.currentStage - 1, vessel))
                 return;
 
             // prevent staging when the current stage has active engines and the next stage has any engines (but not decouplers or clamps)


### PR DESCRIPTION
At any rate if you've got launch clamps we should launch, if you have a
burning engine on the other side of your clamps we should leave that behind.
