### PR TITLE
More BetterController improvements

### DIFF
--- a/MechJeb2/AttitudeControllers/BaseAttitudeController.cs
+++ b/MechJeb2/AttitudeControllers/BaseAttitudeController.cs
@@ -12,6 +12,10 @@
         public virtual void OnModuleDisabled()
         {
         }
+        
+        public virtual void OnModuleEnabled()
+        {
+        }
 
         public virtual void OnStart()
         {
@@ -56,6 +60,11 @@
 
         public virtual void GUI()
         {
+        }
+
+        public virtual void Reset(int i)
+        {
+            Reset();
         }
     }
 }


### PR DESCRIPTION
1. rename the use of "alpha" in low pass filters to "smooth".

2. manual control of an axis selectively Resets only that axis
   in the controller.

3. some better handling of some internal state and possible
   NaN/Inf values in the PID, along with the first tick getting
   zero for torque somehow.

4. cruft removal where most of the other uses of Alpha were also
   removed -- abandoned attempt at adding a third accel PID state.
   (MaxAlpha still remains though).

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>