### PR TITLE
Tweak the default staging delays

### DIFF
--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -17,9 +17,9 @@ namespace MuMech
 
         //adjustable parameters:
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
-        public EditableDouble autostagePreDelay = 0.5;
+        public EditableDouble autostagePreDelay = 0.0;
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
-        public EditableDouble autostagePostDelay = 1.0;
+        public EditableDouble autostagePostDelay = 0.5;
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]
         public EditableInt autostageLimit = 0;
         [Persistent(pass = (int)(Pass.Type | Pass.Global))]


### PR DESCRIPTION
On the theory that these date back to KSP 0.23 era, tweak these
delays down a bit.

The pre-delay doesn't make any sense to me since if you've drained
a tank or flamed out an engine -- what are you waiting for?  Get
rid of it.

The post-delay can probably be tightened up a bit, people should
also consider using sep motors to get rid of burned out stages.

Its tweakable anyway.