### PR TITLE
Fix PVG ullage motors and break apart FuelFlowSim

### DIFF
--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using KSP.UI;
 using KSP.UI.Screens;
 using Smooth.Dispose;
 using Smooth.Pools;
@@ -10,55 +9,56 @@ using UnityToolbag;
 
 namespace MuMech
 {
-    public class FuelFlowSimulation
+    public partial class FuelFlowSimulation
     {
-        public int simStage; //the simulated rocket's current stage
-        private readonly List<FuelNode> nodes = new List<FuelNode>(); //a list of FuelNodes representing all the parts of the ship
-        private readonly Dictionary<Part, FuelNode> nodeLookup = new Dictionary<Part, FuelNode>();
-        private readonly Dictionary<FuelNode, Part> partLookup = new Dictionary<FuelNode, Part>();
+        private          int                        _simStage;                          //the simulated rocket's current stage
+        private readonly List<FuelNode>             _nodes      = new List<FuelNode>(); //a list of FuelNodes representing all the parts of the ship
+        private readonly Dictionary<Part, FuelNode> _nodeLookup = new Dictionary<Part, FuelNode>();
+        private readonly Dictionary<FuelNode, Part> _partLookup = new Dictionary<FuelNode, Part>();
 
-        private double KpaToAtmospheres;
+        private double _kpaToAtmospheres;
 
         //Takes a list of parts so that the simulation can be run in the editor as well as the flight scene
         public void Init(List<Part> parts, bool dVLinearThrust)
         {
             //print("==================================================");
             //print("Init Start");
-            KpaToAtmospheres = PhysicsGlobals.KpaToAtmospheres;
+            _kpaToAtmospheres = PhysicsGlobals.KpaToAtmospheres;
 
             // Create FuelNodes corresponding to each Part
-            nodes.Clear();
-            nodeLookup.Clear();
-            partLookup.Clear();
+            _nodes.Clear();
+            _nodeLookup.Clear();
+            _partLookup.Clear();
 
             Part negOnePart = parts[0];
 
+            // initial parts scan, construct the nodes and lookup tables, and choose our root part
             for (int index = 0; index < parts.Count; index++)
             {
                 Part part = parts[index];
                 FuelNode node = FuelNode.Borrow(part, dVLinearThrust);
-                nodeLookup[part] = node;
-                partLookup[node] = part;
-                nodes.Add(node);
-                if ( part.inverseStage < 0 && negOnePart == null )
+                _nodeLookup[part] = node;
+                _partLookup[node] = part;
+                _nodes.Add(node);
+                if (part.inverseStage < 0 && negOnePart == null)
                     negOnePart = part;
             }
 
-            if ( negOnePart == null )
+            if (negOnePart == null)
                 negOnePart = parts[0];
 
             // Determine when each part will be decoupled
-            nodeLookup[negOnePart].AssignDecoupledInStage(negOnePart, null, nodeLookup, -1);
+            _nodeLookup[negOnePart].AssignDecoupledInStage(negOnePart, null, _nodeLookup, -1);
 
-            simStage = StageManager.LastStage;
+            _simStage = StageManager.LastStage;
 
             // Set up the fuel flow graph
             for (int i = 0; i < parts.Count; i++)
             {
                 Part p = parts[i];
-                FuelNode node = nodeLookup[p];
-                node.AddCrossfeedSouces(p.crossfeedPartSet.GetParts(), nodeLookup);
-                if (node.decoupledInStage >= simStage) simStage = node.decoupledInStage + 1;
+                FuelNode node = _nodeLookup[p];
+                node.AddCrossfeedSouces(p.crossfeedPartSet.GetParts(), _nodeLookup);
+                if (node.decoupledInStage >= _simStage) _simStage = node.decoupledInStage + 1;
             }
 
             // Add a fake stage if we are beyond the first one
@@ -66,39 +66,35 @@ namespace MuMech
             // and fail to get proper info when the ship was never staged and
             // some engine were activated manually
             if (StageManager.CurrentStage > StageManager.LastStage)
-                simStage++;
+                _simStage++;
             //print("Init End");
         }
 
         //Simulate the activation and execution of each stage of the rocket,
         //and return stats for each stage
-        public Stats[] SimulateAllStages(float throttle, double staticPressureKpa, double atmDensity, double machNumber)
+        public FuelStats[] SimulateAllStages(float throttle, double staticPressureKpa, double atmDensity, double machNumber)
         {
-            Stats[] stages = new Stats[simStage + 1];
+            var stages = new FuelStats[_simStage + 1];
 
-            int maxStages = simStage - 1;
-
-            double staticPressure = staticPressureKpa * KpaToAtmospheres;
+            double staticPressure = staticPressureKpa * _kpaToAtmospheres;
 
             //print("**************************************************");
             //print("SimulateAllStages starting from stage " + simStage + " throttle=" + throttle + " staticPressureKpa=" + staticPressureKpa + " atmDensity=" + atmDensity + " machNumber=" + machNumber);
 
-            while (simStage >= 0)
+            while (_simStage >= 0)
             {
                 //print("Simulating stage " + simStage + "(vessel mass = " + VesselMass(simStage) + ")");
-                stages[simStage] = SimulateStage(throttle, staticPressure, atmDensity, machNumber);
-                if (simStage + 1 < stages.Length)
-                    stages[simStage].stagedMass = stages[simStage + 1].endMass - stages[simStage].startMass;
+                stages[_simStage] = SimulateStage(throttle, staticPressure, atmDensity, machNumber);
+                if (_simStage + 1 < stages.Length)
+                    stages[_simStage].StagedMass = stages[_simStage + 1].EndMass - stages[_simStage].StartMass;
                 //print("Staging at t = " + t);
                 SimulateStageActivation();
             }
 
             //print("SimulateAllStages ended");
 
-            for (int i = 0; i < nodes.Count; i++)
-            {
-                nodes[i].Release();
-            }
+            for (int i = 0; i < _nodes.Count; i++) _nodes[i].Release();
+
             return stages;
         }
 
@@ -109,141 +105,125 @@ namespace MuMech
 
         //Simulate (the rest of) the current stage of the simulated rocket,
         //and return stats for the stage
-        private Stats SimulateStage(float throttle, double staticPressure, double atmDensity, double machNumber)
+        private FuelStats SimulateStage(float throttle, double staticPressure, double atmDensity, double machNumber)
         {
             //need to set initial consumption rates for VesselThrust and AllowedToStage to work right
-            for (int i = 0; i < nodes.Count; i++)
-            {
-                nodes[i].SetConsumptionRates(throttle, staticPressure, atmDensity, machNumber);
-            }
+            for (int i = 0; i < _nodes.Count; i++) _nodes[i].SetConsumptionRates(throttle, staticPressure, atmDensity, machNumber);
 
-            Stats stats = new Stats();
-            stats.startMass = VesselMass(simStage);
-            stats.startThrust = VesselThrust();
-            stats.endMass = stats.startMass;
-            stats.resourceMass = 0;
-            stats.maxAccel = stats.endMass > 0 ? stats.startThrust / stats.endMass : 0;
-            stats.deltaTime = 0;
-            stats.deltaV = 0;
+            var fuelStats = new FuelStats();
+            fuelStats.StartMass    = VesselMass(_simStage);
+            fuelStats.StartThrust  = VesselThrust();
+            fuelStats.EndThrust    = VesselThrust();
+            fuelStats.EndMass      = fuelStats.StartMass;
+            fuelStats.ResourceMass = 0;
+            fuelStats.MaxAccel     = fuelStats.EndMass > 0 ? fuelStats.EndThrust / fuelStats.EndMass : 0;
+            fuelStats.DeltaTime    = 0;
+            fuelStats.DeltaV       = 0;
 
             // track active engines to "fingerprint" this stage
             // (could improve by adding fuel tanks being drained and thereby support drop-tanks)
-            stats.parts = new List<Part>();
-            var engines = FindActiveEngines().value;
-            for(int i = 0; i < engines.Count; i++) {
-                stats.parts.Add(partLookup[engines[i]]);
-            }
+            fuelStats.Parts = new List<Part>();
+            List<FuelNode> engines = FindActiveEngines().value;
+            for (int i = 0; i < engines.Count; i++) fuelStats.Parts.Add(_partLookup[engines[i]]);
 
-            const int maxSteps = 100;
-            int step;
-            for (step = 0; step < maxSteps; step++)
+            const int MAX_STEPS = 100;
+
+            int stepsLeft = MAX_STEPS;
+            while (true)
             {
-                //print("Stage " + simStage + " step " + step + " endMass " + stats.endMass.ToString("F3"));
+                //print("Stage " + simStage + " step " + step + " endMass " + fuelStats.endMass.ToString("F3"));
                 if (AllowedToStage()) break;
-                double dt;
-                stats = stats.Append(SimulateTimeStep(double.MaxValue, throttle, staticPressure, atmDensity, machNumber, out dt));
+
+                fuelStats = fuelStats.Append(SimulateTimeStep(double.MaxValue, throttle, staticPressure, atmDensity, machNumber, out double dt));
                 //print("Stage " + simStage + " step " + step + " dt " + dt);
                 // BS engine detected. Bail out.
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
                 if (dt == double.MaxValue || double.IsInfinity(dt))
-                {
                     //print("BS engine detected. Bail out.");
                     break;
-                }
+
+                if (--stepsLeft == 0)
+                    throw new Exception("FuelFlowSimulation.SimulateStage reached max step count of " + MAX_STEPS);
             }
 
-            //print("Finished stage " + simStage + " after " + step + " steps");
-            if (step == maxSteps) throw new Exception("FuelFlowSimulation.SimulateStage reached max step count of " + maxSteps);
+            //Debug.Log("thrust = " + fuelStats.startThrust + " ISP = " + fuelStats.isp + " FuelFlow = " + ( fuelStats.startMass - fuelStats.endMass ) / fuelStats.deltaTime * 1000 + " num = " + FindActiveEngines(true).value.Count );
 
-            //Debug.Log("thrust = " + stats.startThrust + " ISP = " + stats.isp + " FuelFlow = " + ( stats.startMass - stats.endMass ) / stats.deltaTime * 1000 + " num = " + FindActiveEngines(true).value.Count );
-
-            return stats;
+            return fuelStats;
         }
 
         //Simulate a single time step, and return stats for the time step.
         // - desiredDt is the requested time step size. Often the actual time step size
         //   with be less than this. The actual step size is reported in dt.
-        private Stats SimulateTimeStep(double desiredDt, float throttle, double staticPressure, double atmDensity, double machNumber, out double dt)
+        private FuelStats SimulateTimeStep(double desiredDt, float throttle, double staticPressure, double atmDensity, double machNumber,
+            out double dt)
         {
-            Stats stats = new Stats();
+            var fuelStats = new FuelStats();
 
-            for (int i = 0; i < nodes.Count; i++)
-            {
-                nodes[i].ResetDrainRates();
-            }
-            for (int i = 0; i < nodes.Count; i++)
-            {
-                nodes[i].SetConsumptionRates(throttle, staticPressure, atmDensity, machNumber);
-            }
+            for (int i = 0; i < _nodes.Count; i++) _nodes[i].ResetDrainRates();
 
-            stats.startMass = VesselMass(simStage);
-            stats.startThrust = VesselThrust();
+            for (int i = 0; i < _nodes.Count; i++) _nodes[i].SetConsumptionRates(throttle, staticPressure, atmDensity, machNumber);
 
-            using (var engines = FindActiveEngines())
+            fuelStats.StartMass   = VesselMass(_simStage);
+            // over a single timestep the thrust is considered constant, we don't support thrust curves.
+            fuelStats.StartThrust = fuelStats.EndThrust  = VesselThrust();
+            
+            using (Disposable<List<FuelNode>> engines = FindActiveEngines())
             {
                 if (engines.value.Count > 0)
                 {
-                    for (int i = 0; i < engines.value.Count; i++)
-                    {
-                        engines.value[i].AssignResourceDrainRates(nodes);
-                    }
+                    for (int i = 0; i < engines.value.Count; i++) engines.value[i].AssignResourceDrainRates(_nodes);
                     //foreach (FuelNode n in nodes) n.DebugDrainRates();
 
-                    double maxDt = nodes.Slinq().Select(n => n.MaxTimeStep()).Min();
+                    double maxDt = _nodes.Slinq().Select(n => n.MaxTimeStep()).Min();
                     dt = Math.Min(desiredDt, maxDt);
 
                     //print("Simulating time step of " + dt);
 
-                    for (int i = 0; i < nodes.Count; i++)
-                    {
-                        nodes[i].DrainResources(dt);
-                        //nodes[i].DebugResources();
-                    }
+                    for (int i = 0; i < _nodes.Count; i++)
+                        _nodes[i].DrainResources(dt);
+                    //nodes[i].DebugResources();
                 }
                 else
                 {
                     dt = 0;
                 }
             }
+            
+            fuelStats.DeltaTime    = dt;
+            fuelStats.EndMass      = VesselMass(_simStage);
+            fuelStats.ResourceMass = fuelStats.StartMass - fuelStats.EndMass;
+            fuelStats.MaxAccel     = fuelStats.EndMass > 0 ? fuelStats.EndThrust / fuelStats.EndMass : 0;
+            fuelStats.ComputeTimeStepDeltaV();
+            fuelStats.Isp = fuelStats.StartMass > fuelStats.EndMass
+                ? fuelStats.DeltaV / (9.80665f * Math.Log(fuelStats.StartMass / fuelStats.EndMass))
+                : 0;
+            
+            //print("timestep: " + dt + " start thrust: " + fuelStats.StartThrust + " end thrust: " + fuelStats.EndThrust);
 
-            stats.deltaTime = dt;
-            stats.endMass = VesselMass(simStage);
-            stats.resourceMass = stats.startMass - stats.endMass;
-            stats.maxAccel = stats.endMass > 0 ? stats.startThrust / stats.endMass : 0;
-            stats.ComputeTimeStepDeltaV();
-            stats.isp = stats.startMass > stats.endMass ? stats.deltaV / (9.80665f * Math.Log(stats.startMass / stats.endMass)) : 0;
-
-            return stats;
+            return fuelStats;
         }
 
         //Active the next stage of the simulated rocket and remove all nodes that get decoupled by the new stage
         private void SimulateStageActivation()
         {
-            simStage--;
+            _simStage--;
 
-            using (Disposable<List<FuelNode>> decoupledNodes = ListPool<FuelNode>.Instance.BorrowDisposable())
+            using Disposable<List<FuelNode>> decoupledNodes = ListPool<FuelNode>.Instance.BorrowDisposable();
+
+            _nodes.Slinq().Where((n, stage) => n.decoupledInStage >= stage, _simStage).AddTo(decoupledNodes);
+
+            for (int i = 0; i < decoupledNodes.value.Count; i++)
             {
-                nodes.Slinq().Where((n, stage) => n.decoupledInStage >= stage, simStage).AddTo(decoupledNodes);
-
-                for (int i = 0; i < decoupledNodes.value.Count; i++)
-                {
-                    FuelNode decoupledNode = decoupledNodes.value[i];
-                    nodes.Remove(decoupledNode); //remove the decoupled nodes from the simulated ship
-                    //print("Decoupling: " + decoupledNode.partName + " decoupledInStage=" + decoupledNode.decoupledInStage);
-                }
-
-                for (int i = 0; i < nodes.Count; i++)
-                {
-                    for (int j = 0; j < decoupledNodes.value.Count; j++)
-                    {
-                        nodes[i].RemoveSourceNode(decoupledNodes.value[j]); //remove the decoupled nodes from the remaining nodes' source lists
-                    }
-                }
-
-                for (int i = 0; i < decoupledNodes.value.Count; i++)
-                {
-                    decoupledNodes.value[i].Release(); // We can now return them to the pool
-                }
+                FuelNode decoupledNode = decoupledNodes.value[i];
+                _nodes.Remove(decoupledNode); //remove the decoupled nodes from the simulated ship
+                //print("Decoupling: " + decoupledNode.partName + " decoupledInStage=" + decoupledNode.decoupledInStage);
             }
+
+            for (int i = 0; i < _nodes.Count; i++)
+            for (int j = 0; j < decoupledNodes.value.Count; j++)
+                _nodes[i].RemoveSourceNode(decoupledNodes.value[j]); //remove the decoupled nodes from the remaining nodes' source lists
+
+            for (int i = 0; i < decoupledNodes.value.Count; i++) decoupledNodes.value[i].Release(); // We can now return them to the pool
         }
 
         //Whether we've used up the current stage
@@ -252,34 +232,30 @@ namespace MuMech
             //print("Checking whether allowed to stage at t = " + t);
             //print("Checking whether allowed to stage");
 
-            using (var activeEngines = FindActiveEngines())
+            using (Disposable<List<FuelNode>> activeEngines = FindActiveEngines())
             {
                 //print("  activeEngines.Count = " + activeEngines.value.Count);
 
                 //if no engines are active, we can always stage
                 if (activeEngines.value.Count == 0)
-                {
                     //print("Allowed to stage because no active engines");
                     return true;
-                }
 
                 using (Disposable<List<int>> burnedResources = ListPool<int>.Instance.BorrowDisposable())
                 {
                     activeEngines.value.Slinq().SelectMany(eng => eng.BurnedResources().Slinq()).Distinct().AddTo(burnedResources);
 
                     //if staging would decouple an active engine or non-empty fuel tank, we're not allowed to stage
-                    for (int i = 0; i < nodes.Count; i++)
+                    for (int i = 0; i < _nodes.Count; i++)
                     {
-                        FuelNode n = nodes[i];
+                        FuelNode n = _nodes[i];
                         //print(n.partName + " is sepratron? " + n.isSepratron);
-                        if (n.decoupledInStage == (simStage - 1) && !n.isSepratron)
+                        if (n.decoupledInStage == _simStage - 1 && !n.isSepratron)
                         {
                             if (activeEngines.value.Contains(n))
-                            {
                                 //print("Not allowed to stage because " + n.partName + " is an active engine (" + activeEngines.value.Contains(n) +")");
                                 //n.DebugResources();
                                 return false;
-                            }
 
                             if (n.ContainsResources(burnedResources.value))
                             {
@@ -287,12 +263,10 @@ namespace MuMech
                                 for (int j = 0; j < activeEnginesCount; j++)
                                 {
                                     FuelNode engine = activeEngines.value[j];
-                                    if ( engine.CanDrawFrom(n))
-                                    {
+                                    if (engine.CanDrawFrom(n))
                                         //print("Not allowed to stage because " + n.partName + " contains resources (" + n.ContainsResources(burnedResources.value) + ") reachable by an active engine");
                                         //n.DebugResources();
                                         return false;
-                                    }
                                 }
                             }
                         }
@@ -304,39 +278,29 @@ namespace MuMech
                     bool activeEnginesWorking = false;
                     bool partDecoupledInNextStage = false;
 
-                    for (int i = 0; i < nodes.Count; i++)
+                    for (int i = 0; i < _nodes.Count; i++)
                     {
-                        FuelNode n = nodes[i];
+                        FuelNode n = _nodes[i];
                         if (activeEngines.value.Contains(n))
-                        {
-                            if (n.CanDrawNeededResources(nodes))
-                            {
+                            if (n.CanDrawNeededResources(_nodes))
                                 //print("Part " + n.partName + " is an active engine that still has resources to draw on.");
                                 activeEnginesWorking = true;
-                            }
-                        }
 
-                        if (n.decoupledInStage == (simStage - 1))
-                        {
+                        if (n.decoupledInStage == _simStage - 1)
                             //print("Part " + n.partName + " is decoupled in the next stage.");
                             partDecoupledInNextStage = true;
-                        }
                     }
 
                     if (!partDecoupledInNextStage && activeEnginesWorking)
-                    {
                         //print("Not allowed to stage because nothing is decoupled in the next stage, and there are already other engines active.");
                         return false;
-                    }
                 }
             }
 
             //if this isn't the last stage, we're allowed to stage because doing so wouldn't drop anything important
-            if (simStage > 0)
-            {
+            if (_simStage > 0)
                 //print("Allowed to stage because this isn't the last stage");
                 return true;
-            }
 
             //print("Not allowed to stage because there are active engines and this is the last stage");
 
@@ -347,849 +311,34 @@ namespace MuMech
         private double VesselMass(int stage)
         {
             double sum = 0;
-            for (int i = 0; i < nodes.Count; i++)
-            {
-                sum += nodes[i].Mass(stage);
-            }
-            return sum;
-        }
+            for (int i = 0; i < _nodes.Count; i++) sum += _nodes[i].Mass(stage);
 
-        private double VesselIsp()
-        {
-            double sumThrust = 0;
-            double sumThrustOverIsp = 0;
-            using (var activeEngines = FindActiveEngines())
-            {
-                for(int i = 0; i < activeEngines.value.Count; i++)
-                {
-                    sumThrust += activeEngines.value[i].partThrust;
-                    sumThrustOverIsp += activeEngines.value[i].partThrust;
-                }
-            }
-            return sumThrust / sumThrustOverIsp;
+            return sum;
         }
 
         private double VesselThrust()
         {
             double sumThrust = 0;
-            using (var activeEngines = FindActiveEngines())
-            {
-                for(int i = 0; i < activeEngines.value.Count; i++)
-                {
-                    sumThrust += activeEngines.value[i].partThrust;
-                }
-            }
+
+            using Disposable<List<FuelNode>> activeEngines = FindActiveEngines();
+
+            for (int i = 0; i < activeEngines.value.Count; i++) sumThrust += activeEngines.value[i].partThrust;
+
             return sumThrust;
         }
 
         //Returns a list of engines that fire during the current simulated stage.
         private Disposable<List<FuelNode>> FindActiveEngines()
         {
-            var param = new Smooth.Algebraics.Tuple<int, List<FuelNode>>(simStage, nodes);
-            var activeEngines = ListPool<FuelNode>.Instance.BorrowDisposable();
+            var param = new Smooth.Algebraics.Tuple<int, List<FuelNode>>(_simStage, _nodes);
+            Disposable<List<FuelNode>> activeEngines = ListPool<FuelNode>.Instance.BorrowDisposable();
             //print("Finding engines in " + nodes.Count + " parts, there are " + nodes.Slinq().Where(n => n.isEngine).Count());
             //nodes.Slinq().Where(n => n.isEngine).ForEach(node => print("  (" + node.partName + " " + node.inverseStage + ">=" + simStage + " " + (node.inverseStage >= simStage) + ")"));
             //print("Finding active engines: excluding resource considerations, there are " + nodes.Slinq().Where(n => n.isEngine && n.inverseStage >= simStage).Count());
-            nodes.Slinq().Where((n, p) => n.isEngine && n.inverseStage >= p.Item1 && n.isDrawingResources && n.CanDrawNeededResources(p.Item2), param).AddTo(activeEngines.value);
+            _nodes.Slinq().Where((n, p) => n.isEngine && n.inverseStage >= p.Item1 && n.isDrawingResources && n.CanDrawNeededResources(p.Item2),
+                param).AddTo(activeEngines.value);
             //print("Finding active engines: including resource considerations, there are " + activeEngines.value.Count);
             return activeEngines;
-        }
-
-        //A Stats struct describes the result of the simulation over a certain interval of time (e.g., one stage)
-        public struct Stats
-        {
-            public double startMass;
-            public double endMass;
-            public double startThrust;
-            public double maxAccel;
-            public double deltaTime;
-            public double deltaV;
-
-            public double resourceMass;
-            public double isp;
-            public double stagedMass;
-
-            public double StartTWR(double geeASL) { return startMass > 0 ? startThrust / (9.80665 * geeASL * startMass) : 0; }
-            public double MaxTWR(double geeASL) { return maxAccel / (9.80665 * geeASL); }
-
-            public List<Part> parts;
-
-            //Computes the deltaV from the other fields. Only valid when the thrust is constant over the time interval represented.
-            public void ComputeTimeStepDeltaV()
-            {
-                if (deltaTime > 0 && startMass > endMass && startMass > 0 && endMass > 0)
-                {
-                    deltaV = startThrust * deltaTime / (startMass - endMass) * Math.Log(startMass / endMass);
-                }
-                else
-                {
-                    deltaV = 0;
-                }
-            }
-
-            //Append joins two Stats describing adjacent intervals of time into one describing the combined interval
-            public Stats Append(Stats s)
-            {
-                return new Stats
-                {
-                    startMass = this.startMass,
-                    endMass = s.endMass,
-                    resourceMass = startMass - s.endMass,
-                    startThrust = this.startThrust,
-                    maxAccel = Math.Max(this.maxAccel, s.maxAccel),
-                    deltaTime = this.deltaTime + (s.deltaTime < float.MaxValue && !double.IsInfinity(s.deltaTime) ? s.deltaTime : 0),
-                    deltaV = this.deltaV + s.deltaV,
-                    parts = this.parts,
-                    isp = this.startMass == s.endMass ? 0 : (this.deltaV + s.deltaV) / (9.80665f * Math.Log(this.startMass / s.endMass))
-                };
-            }
-        }
-    }
-
-    //A FuelNode is a compact summary of a Part, containing only the information needed to run the fuel flow simulation.
-    public class FuelNode
-    {
-        private readonly struct EngineInfo
-        {
-            public readonly ModuleEngines engineModule;
-            public readonly Vector3d thrustVector;
-
-            public EngineInfo(ModuleEngines engineModule)
-            {
-                this.engineModule = engineModule;
-
-                thrustVector = Vector3d.zero;
-
-                for (int i = 0; i < engineModule.thrustTransforms.Count; i++)
-                    thrustVector -= engineModule.thrustTransforms[i].forward * engineModule.thrustTransformMultipliers[i];
-            }
-        }
-
-        readonly DefaultableDictionary<int, double> resources = new DefaultableDictionary<int, double>(0);       //the resources contained in the part
-        readonly KeyableDictionary<int, double> resourceConsumptions = new KeyableDictionary<int, double>();     //the resources this part consumes per unit time when active at full throttle
-        readonly DefaultableDictionary<int, double> resourceDrains = new DefaultableDictionary<int, double>(0);  //the resources being drained from this part per unit time at the current simulation time
-        readonly DefaultableDictionary<int, bool> freeResources = new DefaultableDictionary<int, bool>(false);  //the resources that are "free" and assumed to be infinite like IntakeAir
-
-        // if a resource amount falls below this amount we say that the resource has been drained
-        // set to the smallest amount that the user can see is non-zero in the resource tab or by
-        // right-clicking.
-        const double DRAINED = 1E-4;
-
-        KeyableDictionary<int, ResourceFlowMode> propellantFlows = new KeyableDictionary<int, ResourceFlowMode>();  //flow modes of propellants since the engine can override them
-
-        readonly List<FuelNode> crossfeedSources = new List<FuelNode>();
-
-        public int decoupledInStage;    //the stage in which this part will be decoupled from the rocket
-        public int inverseStage;        //stage in which this part is activated
-        public bool isLaunchClamp;        //whether this part is a launch clamp
-        public bool isSepratron;        //whether this part is a sepratron
-        public bool isEngine = false;   //whether this part is an engine
-        public bool isthrottleLocked = false;
-        public bool activatesEvenIfDisconnected = false;
-        public bool isDrawingResources = true; // Is the engine actually using any resources
-
-        private double resourceRequestRemainingThreshold;
-        private int resourcePriority;
-
-        double dryMass = 0; //the mass of this part, not counting resource mass
-        double crewMass = 0; //the mass of this part crew
-        float modulesUnstagedMass;   // the mass of the modules of this part before staging
-        float modulesStagedMass = 0; // the mass of the modules of this part after staging
-
-        public string partName; //for debugging
-
-        Part part;
-        bool dVLinearThrust;
-        Vector3d vesselOrientation;
-
-        readonly List<EngineInfo> engineInfos = new List<EngineInfo>();
-
-        private static readonly Pool<FuelNode> pool = new Pool<FuelNode>(Create, Reset);
-
-        private delegate double CrewMass(ProtoCrewMember crew);
-        private static readonly CrewMass CrewMassDelegate;
-
-        static FuelNode()
-        {
-            if (Versioning.version_major == 1 && Versioning.version_minor < 11)
-            {
-                CrewMassDelegate = CrewMassOld;
-            }
-            else
-            {
-                CrewMassDelegate = CrewMassNew;
-            }
-        }
-
-        private static double CrewMassOld(ProtoCrewMember crew)
-        {
-            return PhysicsGlobals.KerbalCrewMass;
-        }
-
-        private static double CrewMassNew(ProtoCrewMember crew)
-        {
-            return PhysicsGlobals.KerbalCrewMass + crew.ResourceMass() + crew.InventoryMass();
-        }
-
-        public static int PoolSize
-        {
-            get { return pool.Size; }
-        }
-
-        private static FuelNode Create()
-        {
-            return new FuelNode();
-        }
-
-        public void Release()
-        {
-            pool.Release(this);
-        }
-
-        private static void Reset(FuelNode obj)
-        {
-        }
-
-        public static FuelNode Borrow(Part part, bool dVLinearThrust)
-        {
-            FuelNode node = pool.Borrow();
-            node.Init(part, dVLinearThrust);
-            return node;
-        }
-
-        private void Init(Part part, bool dVLinearThrust)
-        {
-            this.part = part;
-            this.dVLinearThrust = dVLinearThrust;
-            resources.Clear();
-            resourceConsumptions.Clear();
-            resourceDrains.Clear();
-            freeResources.Clear();
-
-            crossfeedSources.Clear();
-
-            isEngine = false;
-            isthrottleLocked = false;
-            activatesEvenIfDisconnected = part.ActivatesEvenIfDisconnected;
-            isLaunchClamp = part.IsLaunchClamp();
-
-            dryMass = 0;
-            crewMass = 0;
-            modulesStagedMass = 0;
-
-            decoupledInStage = int.MinValue;
-
-            vesselOrientation = HighLogic.LoadedScene == GameScenes.EDITOR ? EditorLogic.VesselRotation * Vector3d.up : part.vessel.GetTransform().up;
-
-            modulesUnstagedMass = 0;
-            if (!isLaunchClamp)
-            {
-                dryMass = part.prefabMass; // Intentionally ignore the physic flag.
-                
-                if (HighLogic.LoadedSceneIsFlight && part.protoModuleCrew != null)
-                {
-                    for (var i = 0; i < part.protoModuleCrew.Count; i++)
-                    {
-                        ProtoCrewMember crewMember = part.protoModuleCrew[i];
-                        crewMass += CrewMassDelegate(crewMember);
-                    }
-                }
-                else if (HighLogic.LoadedSceneIsEditor)
-                {
-                    if (CrewAssignmentDialog.Instance != null && CrewAssignmentDialog.Instance.CurrentManifestUnsafe != null)
-                    {
-                        PartCrewManifest partCrewManifest = CrewAssignmentDialog.Instance.CurrentManifestUnsafe.GetPartCrewManifest(part.craftID);
-                        if (partCrewManifest != null)
-                        {
-                            ProtoCrewMember[] partCrew = null;
-                            partCrewManifest.GetPartCrew(ref partCrew);
-
-                            for (var i = 0; i < partCrew.Length; i++)
-                            {
-                                ProtoCrewMember crewMember = partCrew[i];
-                                if (crewMember == null ) continue;
-                                crewMass += CrewMassDelegate(crewMember);
-                            }
-                        }
-                    }
-                }
-
-                modulesUnstagedMass = part.GetModuleMassNoAlloc((float) dryMass, ModifierStagingSituation.UNSTAGED);
-
-                modulesStagedMass = part.GetModuleMassNoAlloc((float) dryMass, ModifierStagingSituation.STAGED);
-
-                float currentModulesMass = part.GetModuleMassNoAlloc((float) dryMass, ModifierStagingSituation.CURRENT);
-
-                // if it was manually staged
-                if (currentModulesMass == modulesStagedMass)
-                {
-                    modulesUnstagedMass = modulesStagedMass;
-                }
-
-                //print(part.partInfo.name.PadRight(25) + " " + part.mass.ToString("F4") + " " + part.GetPhysicslessChildMass().ToString("F4") + " " + modulesUnstagedMass.ToString("F4") + " " + modulesStagedMass.ToString("F4"));
-            }
-
-            inverseStage = part.inverseStage;
-            partName = part.partInfo.name;
-
-            resourceRequestRemainingThreshold = Math.Max(part.resourceRequestRemainingThreshold, DRAINED);
-            resourcePriority = part.GetResourcePriority();
-
-            //note which resources this part has stored
-            for (int i = 0; i < part.Resources.Count; i++)
-            {
-                PartResource r = part.Resources[i];
-                if (r.info.density > 0)
-                {
-                    if (r.flowState)
-                    {
-                        resources[r.info.id] = r.amount;
-                    }
-                    else
-                    {
-                        dryMass += (r.amount * r.info.density); // disabled resources are just dead weight
-                    }
-                }
-                else
-                {
-                    freeResources[r.info.id] = true;
-                }
-                // Including the ressource in the CRP.
-                if (r.info.name == "IntakeAir" || r.info.name == "IntakeLqd" || r.info.name == "IntakeAtm")
-                    freeResources[r.info.id] = true;
-            }
-
-            engineInfos.Clear();
-
-            // determine if we've got at least one useful ModuleEngine
-            // we only do these test for the first ModuleEngines in the Part, could any other ones actually differ?
-            for (int i = 0; i < part.Modules.Count; i++)
-            {
-                if (!(part.Modules[i] is ModuleEngines e) || !e.isEnabled) continue;
-
-                // Only count engines that either are ignited or will ignite in the future:
-                if (!isEngine && (HighLogic.LoadedSceneIsEditor || inverseStage < StageManager.CurrentStage || e.getIgnitionState) && (e.thrustPercentage > 0 || e.minThrust > 0))
-                {
-                    // if an engine has been activated early, pretend it is in the current stage:
-                    if (e.getIgnitionState && inverseStage < StageManager.CurrentStage)
-                        inverseStage = StageManager.CurrentStage;
-
-                    isEngine = true;
-                    isthrottleLocked = e.throttleLocked;
-                }
-
-                engineInfos.Add(new EngineInfo(e));
-            }
-        }
-
-        // We are not necessarily traversing from the root part but from any interior part, so that p.parent is just another potential child node
-        // in our traversal.  This is a helper to loop over all the children (including the "p.parent") in our traversal.
-        private void AssignChildrenDecoupledInStage(Part p, Part traversalParent, Dictionary<Part, FuelNode> nodeLookup, int parentDecoupledInStage)
-        {
-            for (int i = 0; i < p.children.Count; i++)
-            {
-                Part child = p.children[i];
-                if ( child != null && child != traversalParent )
-                    nodeLookup[child].AssignDecoupledInStage(child, p, nodeLookup, parentDecoupledInStage);
-            }
-            if ( p.parent != null && p.parent != traversalParent )
-                nodeLookup[p.parent].AssignDecoupledInStage(p.parent, p, nodeLookup, parentDecoupledInStage);
-        }
-
-        // Determine when this part will be decoupled given when its traversal-order parent will be decoupled.
-        // Then recurse to all of this part's "children" (including the p.parent if the traversalParent is coming from a child).
-        public void AssignDecoupledInStage(Part p, Part traversalParent, Dictionary<Part, FuelNode> nodeLookup, int parentDecoupledInStage)
-        {
-            // Already processed (this gets used where we assign the attached part, then loop over all the children and expect the
-            // one we already hit to be skipped by this)
-            if (decoupledInStage != int.MinValue)
-                return;
-
-            bool isDecoupler = false;
-            decoupledInStage = parentDecoupledInStage;
-
-            for (int i = 0; i < p.Modules.Count; i++)
-            {
-                PartModule m = p.Modules[i];
-
-                ModuleDecouple mDecouple = m as ModuleDecouple;
-                if (mDecouple != null)
-                {
-                    if (!mDecouple.isDecoupled && mDecouple.stagingEnabled && p.stagingOn)
-                    {
-                        if (mDecouple.isOmniDecoupler)
-                        {
-                            // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
-                            isDecoupler = true;
-                            decoupledInStage = p.inverseStage;
-                            AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-                        }
-                        else
-                        {
-                            AttachNode attach;
-                            if (HighLogic.LoadedSceneIsEditor)
-                            {
-                                if (mDecouple.explosiveNodeID != "srf")
-                                    attach = p.FindAttachNode(mDecouple.explosiveNodeID);
-                                else
-                                    attach = p.srfAttachNode;
-                            }
-                            else
-                            {
-                                attach = mDecouple.ExplosiveNode;
-                            }
-
-                            if (attach != null && attach.attachedPart != null)
-                            {
-                                if (attach.attachedPart == traversalParent && mDecouple.staged)
-                                {
-                                    // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
-                                    isDecoupler = true;
-                                    decoupledInStage = p.inverseStage;
-                                    AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-                                }
-                                else
-                                {
-                                    // We are still attached to our traversalParent.  The part we decouple is dropped when we decouple.  The part and other children are dropped with the traversalParent.
-                                    isDecoupler = true;
-                                    decoupledInStage = parentDecoupledInStage;
-                                    nodeLookup[attach.attachedPart].AssignDecoupledInStage(attach.attachedPart, p, nodeLookup, p.inverseStage);
-                                    AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-                                }
-                            }
-                        }
-                        break; // Hopefully no one made part with multiple decoupler modules ?
-                    }
-                }
-
-                ModuleAnchoredDecoupler mAnchoredDecoupler = m as ModuleAnchoredDecoupler;
-                if (mAnchoredDecoupler != null)
-                {
-                    if (!mAnchoredDecoupler.isDecoupled && mAnchoredDecoupler.stagingEnabled && p.stagingOn)
-                    {
-                        AttachNode attach;
-                        if (HighLogic.LoadedSceneIsEditor)
-                        {
-                            if (mAnchoredDecoupler.explosiveNodeID != "srf")
-                                attach = p.FindAttachNode(mAnchoredDecoupler.explosiveNodeID);
-                            else
-                                attach = p.srfAttachNode;
-                        }
-                        else
-                        {
-                            attach = mAnchoredDecoupler.ExplosiveNode;
-                        }
-                        if (attach != null && attach.attachedPart != null)
-                        {
-                            if (attach.attachedPart == traversalParent && mAnchoredDecoupler.staged)
-                            {
-                                // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
-                                isDecoupler = true;
-                                decoupledInStage = p.inverseStage;
-                                AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-                            }
-                            else
-                            {
-                                // We are still attached to our traversalParent.  The part we decouple is dropped when we decouple.  The part and other children are dropped with the traversalParent.
-                                isDecoupler = true;
-                                decoupledInStage = parentDecoupledInStage;
-                                nodeLookup[attach.attachedPart].AssignDecoupledInStage(attach.attachedPart, p, nodeLookup, p.inverseStage);
-                                AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-                            }
-                        }
-                        break;
-                    }
-                }
-
-                ModuleDockingNode mDockingNode = m as ModuleDockingNode;
-                if (mDockingNode != null)
-                {
-                    if (mDockingNode.staged && mDockingNode.stagingEnabled && p.stagingOn)
-                    {
-                        Part attachedPart = mDockingNode.referenceNode.attachedPart;
-                        if (attachedPart != null)
-                        {
-                            if (attachedPart == traversalParent)
-                            {
-                                // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
-                                isDecoupler = true;
-                                decoupledInStage = p.inverseStage;
-                                AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-                                isDecoupler = true;
-                            }
-                            else
-                            {
-                                // We are still attached to our traversalParent.  The part we decouple is dropped when we decouple.  The part and other children are dropped with the traversalParent.
-                                isDecoupler = true;
-                                decoupledInStage = parentDecoupledInStage;
-                                nodeLookup[attachedPart].AssignDecoupledInStage(attachedPart, p, nodeLookup, p.inverseStage);
-                                AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-                            }
-                        }
-                    }
-                    break;
-                }
-
-                if (m.moduleName == "ProceduralFairingDecoupler")
-                {
-                    if (!m.Fields["decoupled"].GetValue<bool>(m) && m.stagingEnabled && p.stagingOn)
-                    {
-                        // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
-                        isDecoupler = true;
-                        decoupledInStage = p.inverseStage;
-                        AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-                        isDecoupler = true;
-                        break;
-                    }
-                }
-            }
-
-            if (isLaunchClamp)
-            {
-                decoupledInStage = p.inverseStage > parentDecoupledInStage ? p.inverseStage : parentDecoupledInStage;
-            }
-            else if (!isDecoupler)
-            {
-                decoupledInStage = parentDecoupledInStage;
-            }
-
-            isSepratron = isEngine && isthrottleLocked && activatesEvenIfDisconnected && (inverseStage == decoupledInStage);
-
-            AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-        }
-
-        public static void print(object message)
-        {
-            Dispatcher.InvokeAsync(() => MonoBehaviour.print("[MechJeb2] " + message));
-        }
-
-        public double partThrust;
-
-        public void SetConsumptionRates(float throttle, double atmospheres, double atmDensity, double machNumber)
-        {
-            if (isEngine)
-            {
-                resourceConsumptions.Clear();
-                propellantFlows.Clear();
-
-                //double sumThrustOverIsp = 0;
-                partThrust = 0;
-
-                isDrawingResources = false;
-
-                foreach (EngineInfo engineInfo in engineInfos)
-                {
-                    ModuleEngines e = engineInfo.engineModule;
-                    // thrust is correct.
-                    Vector3d thrust;
-                    // note that isp and massFlowRate do not include ignoreForIsp fuels like HTP and so need to be fixed for effective isp and the
-                    // actual mdot of the rocket needs to be fixed to include HTP.
-                    //
-                    // IMHO: using ignoreForIsp is just wrong.  full stop.  engines should never set this and should set the correct effective isp in
-                    // the config for the engine.  makes everything simpler and fixes the UI to show the correct ISP.  going this direction we are going
-                    // to get bug reports that e.g. mechjeb is reporting 299s for an RD-108 when RF and KSP are displaying 308s everywhere.  which is not
-                    // going to be a bug at all.  as long as the thrust is correct, the effective isp is correct, and the fuel fractions are correct then
-                    // the rocket equation just works and HTP should not be "ignored".   keeping it out of the atmosphereCurve just makes this annoying
-                    // here and screws up the KSP API display of ISP.
-                    //
-                    double isp, massFlowRate;
-                    EngineValuesAtConditions(engineInfo, throttle, atmospheres, atmDensity, machNumber, out thrust, out isp, out massFlowRate, cosLoss: dVLinearThrust);
-                    partThrust += thrust.magnitude;
-
-                    if ( massFlowRate > 0 )
-                        isDrawingResources = true;
-
-                    double totalDensity = 0;
-
-                    for(int j = 0; j < e.propellants.Count; j++)
-                    {
-                        var p = e.propellants[j];
-                        double density = MuUtils.ResourceDensity(p.id);
-
-                        // zero density draws (eC, air intakes, etc) are skipped, we have to assume you open your solar panels or
-                        // air intakes or whatever it is you need for them to function.  they don't affect the mass of the vehicle
-                        // so they do not affect the rocket equation.  they are assumed to be "renewable" or effectively infinite.
-                        // (we keep them out of the propellantFlows dict here so they're just ignored by the sim later).
-                        //
-                        if (density > 0)
-                        {
-                            // hopefully different EngineModules in the same part don't have different flow modes for the same propellant
-                            if (!propellantFlows.ContainsKey(p.id))
-                                propellantFlows.Add(p.id, p.GetFlowMode());
-                        }
-
-                        // have to ignore ignoreForIsp fuels here since we're dealing with the massflowrate of the other fuels
-                        if (!p.ignoreForIsp)
-                        {
-                            totalDensity += p.ratio * density;
-                        }
-                    }
-
-                    // this is also the volume flow rate of the non-ignoreForIsp fuels.  although this is a bit janky since the p.ratios in most
-                    // stock engines sum up to 2, not 1 (1.1 + 0.9), so this is not per-liter but per-summed-ratios (the massflowrate you get out
-                    // of the atmosphere curves (above) are also similarly adjusted by these ratios -- it is a bit of a horror show).
-                    double volumeFlowRate = massFlowRate / totalDensity;
-
-                    for(int j = 0; j < e.propellants.Count; j++)
-                    {
-                        var p = e.propellants[j];
-                        double density = MuUtils.ResourceDensity(p.id);
-
-                        // this is the individual propellant volume rate.  we are including the ignoreForIsp fuels in this loop and this will
-                        // correctly calculate the volume rates of all the propellants, in L/sec.  if you sum these it'll be larger than the
-                        // volumeFlowRate by including both the ignoreForIsp fuels and if the ratios sum up to more than one.
-                        double propVolumeRate = p.ratio * volumeFlowRate;
-
-                        // same density check here as above to keep massless propellants out of the ResourceConsumptions dict as well
-                        if (density > 0)
-                        {
-                            if (resourceConsumptions.ContainsKey(p.id))
-                                resourceConsumptions[p.id] += propVolumeRate;
-                            else
-                                resourceConsumptions.Add(p.id, propVolumeRate);
-                        }
-                    }
-                }
-            }
-        }
-
-        public void AddCrossfeedSouces(HashSet<Part> parts, Dictionary<Part, FuelNode> nodeLookup)
-        {
-            using (var it = parts.GetEnumerator())
-            {
-                while (it.MoveNext())
-                {
-                    FuelNode fuelnode;
-                    if (nodeLookup.TryGetValue(it.Current, out fuelnode))
-                        crossfeedSources.Add(fuelnode);
-                }
-            }
-        }
-
-        //call this when a node no longer exists, so that this node knows that it's no longer a valid source
-        public void RemoveSourceNode(FuelNode n)
-        {
-            crossfeedSources.Remove(n);
-        }
-
-        //return the mass of the simulated FuelNode. This is not the same as the mass of the Part,
-        //because the simulated node may have lost resources, and thus mass, during the simulation.
-        public double Mass(int simStage)
-        {
-            //print("\n(" + simStage + ") " + partName.PadRight(25) + " dryMass " + dryMass.ToString("F3")
-            //          + " ResMass " + (resources.Keys.Sum(id => resources[id] * MuUtils.ResourceDensity(id))).ToString("F3")
-            //          + " Fairing Mass " + (inverseStage < simStage ? fairingMass : 0).ToString("F3")
-            //          + " (" + fairingMass.ToString("F3") + ")"
-            //          + " ModuleMass " + moduleMass.ToString("F3")
-            //          );
-
-            //return dryMass + resources.Keys.Sum(id => resources[id] * MuUtils.ResourceDensity(id)) +
-            double resMass = resources.KeysList.Slinq().Select((r, rs) => rs[r] * MuUtils.ResourceDensity(r), resources).Sum();
-            return dryMass + crewMass + resMass +
-                   (inverseStage < simStage ? modulesUnstagedMass : modulesStagedMass);
-        }
-
-        public void ResetDrainRates()
-        {
-            resourceDrains.Clear();
-        }
-
-        public void DrainResources(double dt)
-        {
-            foreach (int type in resourceDrains.KeysList)
-                if (!freeResources[type])
-                    resources[type] -= dt * resourceDrains[type];
-        }
-
-
-        public void DebugResources()
-        {
-            foreach (KeyValuePair<int, double> type in resources)
-                print(partName + " " + PartResourceLibrary.Instance.GetDefinition(type.Key).name + " is " + type.Value);
-        }
-
-        public void DebugDrainRates()
-        {
-            foreach (int type in resourceDrains.Keys)
-            {
-                print(partName + "'s drain rate of " + PartResourceLibrary.Instance.GetDefinition(type).name + "(" + type  + ") is " + resourceDrains[type] + " free=" + freeResources[type]);
-            }
-        }
-
-        public double MaxTimeStep()
-        {
-            //DebugDrainRates();
-            var param = new Smooth.Algebraics.Tuple<DefaultableDictionary<int, double>, double, DefaultableDictionary<int, double>, DefaultableDictionary<int, bool>>(resources, resourceRequestRemainingThreshold, resourceDrains, freeResources);
-            if (!resourceDrains.KeysList.Slinq().Any((id, p) => !p.Item4[id] && p.Item1[id] > p.Item2, param)) return double.MaxValue;
-            return resourceDrains.KeysList.Slinq().Where((id, p) => !p.Item4[id] && p.Item1[id] > p.Item2, param).Select((id, p) => p.Item1[id] / p.Item3[id], param).Min();
-        }
-
-        //Returns an enumeration of the resources this part burns
-        public List<int> BurnedResources()
-        {
-            return resourceConsumptions.KeysList;
-        }
-
-        //returns whether this part contains any of the given resources
-        public bool ContainsResources(List<int> whichResources)
-        {
-            var param = new Smooth.Algebraics.Tuple<DefaultableDictionary<int, double>, double>(resources, resourceRequestRemainingThreshold);
-            //return whichResources.Any(id => resources[id] > DRAINED);
-            return whichResources.Slinq().Any((id, r) => r.Item1[id] > r.Item2, param);
-        }
-
-        public bool CanDrawNeededResources(List<FuelNode> vessel)
-        {
-            // XXX: this fix is intended to fix SRBs which have burned out but which
-            // still have an amount of fuel over the resourceRequestRemainingThreshold, which
-            // can happen in RealismOverhaul.  this targets specifically "No propellants" because
-            // we do not want flamed out jet engines to trigger this code if they just don't have
-            // enough intake air, and any other causes.
-            ModuleEngines e = part.Modules[0] as ModuleEngines;
-            if (e != null && e.flameout && e.statusL2 == "No propellants")
-                return false;
-
-            foreach (int type in resourceConsumptions.KeysList)
-            {
-                var resourceFlowMode = propellantFlows[type];
-                switch (resourceFlowMode)
-                {
-                    case ResourceFlowMode.NO_FLOW:
-                        //check if we contain the needed resource:
-                        if (resources[type] < resourceRequestRemainingThreshold) return false;
-                        break;
-
-                    case ResourceFlowMode.ALL_VESSEL:
-                    case ResourceFlowMode.ALL_VESSEL_BALANCE:
-                    case ResourceFlowMode.STAGE_PRIORITY_FLOW:
-                    case ResourceFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
-                        //check if any part contains the needed resource:
-                        if (!vessel.Slinq().Any((n, t) => n.resources[t] > n.resourceRequestRemainingThreshold, type)) return false;
-                        break;
-
-                    case ResourceFlowMode.STAGE_STACK_FLOW:
-                    case ResourceFlowMode.STAGE_STACK_FLOW_BALANCE:
-                    case ResourceFlowMode.STACK_PRIORITY_SEARCH:
-                        // check if we can get any of the needed resources
-                        if (!crossfeedSources.Slinq().Any((n, t) => n.resources[t] > n.resourceRequestRemainingThreshold, type)) return false;
-                        break;
-
-                    default: // and NULL
-                        return false;
-                }
-            }
-            return true; //we didn't find ourselves lacking for any resource
-        }
-
-        public bool CanDrawFrom(FuelNode node)
-        {
-            return crossfeedSources.Contains(node);
-        }
-
-        public void AssignResourceDrainRates(List<FuelNode> vessel)
-        {
-            foreach (int type in resourceConsumptions.KeysList)
-            {
-                if (freeResources[type])
-                    continue;
-
-                double amount = resourceConsumptions[type];
-
-                var resourceFlowMode = propellantFlows[type];
-                switch (resourceFlowMode)
-                {
-                    case ResourceFlowMode.NO_FLOW:
-                        resourceDrains[type] += amount;
-                        break;
-
-                    case ResourceFlowMode.ALL_VESSEL:
-                    case ResourceFlowMode.ALL_VESSEL_BALANCE:
-                        AssignFuelDrainRateStagePriorityFlow(type, amount, false, vessel);
-                        break;
-
-                    case ResourceFlowMode.STAGE_PRIORITY_FLOW:
-                    case ResourceFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
-                        AssignFuelDrainRateStagePriorityFlow(type, amount, true, vessel);
-                        break;
-
-                    case ResourceFlowMode.STAGE_STACK_FLOW:
-                    case ResourceFlowMode.STAGE_STACK_FLOW_BALANCE:
-                    case ResourceFlowMode.STACK_PRIORITY_SEARCH:
-                        //AssignFuelDrainRateStackPriority(type, true, amount);
-                        AssignFuelDrainRateStagePriorityFlow(type, amount, true, crossfeedSources);
-                        break;
-
-                    default:
-                        //do nothing.
-                        break;
-                }
-            }
-        }
-
-        void AssignFuelDrainRateStagePriorityFlow(int type, double amount, bool usePrio, List<FuelNode> vessel)
-        {
-            int maxPrio = int.MinValue;
-            using (var dispoSources = ListPool<FuelNode>.Instance.BorrowDisposable())
-            {
-                var sources = dispoSources.value;
-                //print("AssignFuelDrainRateStagePriorityFlow for " + partName + " searching for " + amount + " of " + PartResourceLibrary.Instance.GetDefinition(type).name + " in " + vessel.Count + " parts ");
-                for (int i = 0; i < vessel.Count; i++)
-                {
-                    FuelNode n = vessel[i];
-                    if (n.resources[type] > n.resourceRequestRemainingThreshold)
-                    {
-                        if (usePrio)
-                        {
-                            if (n.resourcePriority > maxPrio)
-                            {
-                                maxPrio = n.resourcePriority;
-                                sources.Clear();
-                                sources.Add(n);
-                            }
-                            else if (n.resourcePriority == maxPrio)
-                            {
-                                sources.Add(n);
-                            }
-                        }
-                        else
-                        {
-                            sources.Add(n);
-                        }
-                    }
-                }
-                //print(partName + " drains resource from " + sources.Count + " parts ");
-                for (int i = 0; i < sources.Count; i++)
-                {
-                    if (!freeResources[type])
-                        sources[i].resourceDrains[type] += amount / sources.Count;
-                }
-            }
-        }
-
-        // for a single EngineModule, get thrust + isp + massFlowRate
-        private void EngineValuesAtConditions(EngineInfo engineInfo, double throttle, double atmPressure, double atmDensity, double machNumber, out Vector3d thrust, out double isp, out double massFlowRate, bool cosLoss = true)
-        {
-            isp = engineInfo.engineModule.ISPAtConditions(throttle, atmPressure, atmDensity, machNumber);
-            double flowMultiplier = engineInfo.engineModule.FlowMultiplierAtConditions(atmDensity, machNumber);
-            massFlowRate = engineInfo.engineModule.FlowRateAtConditions(throttle, flowMultiplier);
-            thrust = ThrustAtConditions(engineInfo, massFlowRate, isp, cosLoss);
-            //Debug.Log("thrust = " + thrust + " isp = " + isp + " massFlowRate = " + massFlowRate);
-        }
-
-        // for a single EngineModule, get its thrust vector (use EngineModuleFlowMultiplier and EngineModuleISP below)
-        private Vector3d ThrustAtConditions(EngineInfo engineInfo, double massFlowRate, double isp, bool cosLoss = true)
-        {
-            if (massFlowRate <= 0)
-                return Vector3d.zero;
-
-            Vector3d thrustVector = engineInfo.thrustVector;
-
-            if (cosLoss)
-            {
-                thrustVector = Vector3.Dot(vesselOrientation, thrustVector) * thrustVector.normalized;
-            }
-
-            return thrustVector * massFlowRate * engineInfo.engineModule.g * engineInfo.engineModule.multIsp * isp;
         }
     }
 }

--- a/MechJeb2/FuelNode.cs
+++ b/MechJeb2/FuelNode.cs
@@ -1,0 +1,791 @@
+using System;
+using System.Collections.Generic;
+using KSP.UI;
+using KSP.UI.Screens;
+using Smooth.Pools;
+using Smooth.Slinq;
+using UnityEngine;
+using UnityToolbag;
+
+namespace MuMech
+{
+    //A FuelNode is a compact summary of a Part, containing only the information needed to run the fuel flow simulation.
+    public partial class FuelFlowSimulation
+    {
+        public class FuelNode
+        {
+            private readonly struct EngineInfo
+            {
+                public readonly ModuleEngines engineModule;
+                public readonly Vector3d      thrustVector;
+
+                public EngineInfo(ModuleEngines engineModule)
+                {
+                    this.engineModule = engineModule;
+
+                    thrustVector = Vector3d.zero;
+
+                    for (int i = 0; i < engineModule.thrustTransforms.Count; i++)
+                        thrustVector -= engineModule.thrustTransforms[i].forward * engineModule.thrustTransformMultipliers[i];
+                }
+            }
+
+            readonly DefaultableDictionary<int, double> resources = new DefaultableDictionary<int, double>(0); //the resources contained in the part
+
+            readonly KeyableDictionary<int, double>
+                resourceConsumptions =
+                    new KeyableDictionary<int, double>(); //the resources this part consumes per unit time when active at full throttle
+
+            readonly DefaultableDictionary<int, double>
+                resourceDrains =
+                    new DefaultableDictionary<int, double>(
+                        0); //the resources being drained from this part per unit time at the current simulation time
+
+            readonly DefaultableDictionary<int, bool>
+                freeResources = new DefaultableDictionary<int, bool>(false); //the resources that are "free" and assumed to be infinite like IntakeAir
+
+            // if a resource amount falls below this amount we say that the resource has been drained
+            // set to the smallest amount that the user can see is non-zero in the resource tab or by
+            // right-clicking.
+            const double DRAINED = 1E-4;
+
+            KeyableDictionary<int, ResourceFlowMode>
+                propellantFlows = new KeyableDictionary<int, ResourceFlowMode>(); //flow modes of propellants since the engine can override them
+
+            readonly List<FuelNode> crossfeedSources = new List<FuelNode>();
+
+            public int  decoupledInStage;                    //the stage in which this part will be decoupled from the rocket
+            public int  inverseStage;                        //stage in which this part is activated
+            public bool isLaunchClamp;                       //whether this part is a launch clamp
+            public bool isSepratron;                         //whether this part is a sepratron
+            public bool isEngine                    = false; //whether this part is an engine
+            public bool isthrottleLocked            = false;
+            public bool activatesEvenIfDisconnected = false;
+            public bool isDrawingResources          = true; // Is the engine actually using any resources
+
+            private double resourceRequestRemainingThreshold;
+            private int    resourcePriority;
+
+            double dryMass  = 0;          //the mass of this part, not counting resource mass
+            double crewMass = 0;          //the mass of this part crew
+            float  modulesUnstagedMass;   // the mass of the modules of this part before staging
+            float  modulesStagedMass = 0; // the mass of the modules of this part after staging
+
+            public string partName; //for debugging
+
+            Part     part;
+            bool     dVLinearThrust;
+            Vector3d vesselOrientation;
+
+            readonly List<EngineInfo> engineInfos = new List<EngineInfo>();
+
+            private static readonly Pool<FuelNode> pool = new Pool<FuelNode>(Create, Reset);
+
+            private delegate double CrewMass(ProtoCrewMember crew);
+
+            private static readonly CrewMass CrewMassDelegate;
+
+            static FuelNode()
+            {
+                if (Versioning.version_major == 1 && Versioning.version_minor < 11)
+                {
+                    CrewMassDelegate = CrewMassOld;
+                }
+                else
+                {
+                    CrewMassDelegate = CrewMassNew;
+                }
+            }
+
+            private static double CrewMassOld(ProtoCrewMember crew)
+            {
+                return PhysicsGlobals.KerbalCrewMass;
+            }
+
+            private static double CrewMassNew(ProtoCrewMember crew)
+            {
+                return PhysicsGlobals.KerbalCrewMass + crew.ResourceMass() + crew.InventoryMass();
+            }
+
+            public static int PoolSize
+            {
+                get { return pool.Size; }
+            }
+
+            private static FuelNode Create()
+            {
+                return new FuelNode();
+            }
+
+            public void Release()
+            {
+                pool.Release(this);
+            }
+
+            private static void Reset(FuelNode obj)
+            {
+            }
+
+            public static FuelNode Borrow(Part part, bool dVLinearThrust)
+            {
+                FuelNode node = pool.Borrow();
+                node.Init(part, dVLinearThrust);
+                return node;
+            }
+
+            private void Init(Part part, bool dVLinearThrust)
+            {
+                this.part           = part;
+                this.dVLinearThrust = dVLinearThrust;
+                resources.Clear();
+                resourceConsumptions.Clear();
+                resourceDrains.Clear();
+                freeResources.Clear();
+
+                crossfeedSources.Clear();
+
+                isEngine                    = false;
+                isthrottleLocked            = false;
+                activatesEvenIfDisconnected = part.ActivatesEvenIfDisconnected;
+                isLaunchClamp               = part.IsLaunchClamp();
+
+                dryMass           = 0;
+                crewMass          = 0;
+                modulesStagedMass = 0;
+
+                decoupledInStage = int.MinValue;
+
+                vesselOrientation = HighLogic.LoadedScene == GameScenes.EDITOR
+                    ? EditorLogic.VesselRotation * Vector3d.up
+                    : part.vessel.GetTransform().up;
+
+                modulesUnstagedMass = 0;
+                if (!isLaunchClamp)
+                {
+                    dryMass = part.prefabMass; // Intentionally ignore the physic flag.
+
+                    if (HighLogic.LoadedSceneIsFlight && part.protoModuleCrew != null)
+                    {
+                        for (var i = 0; i < part.protoModuleCrew.Count; i++)
+                        {
+                            ProtoCrewMember crewMember = part.protoModuleCrew[i];
+                            crewMass += CrewMassDelegate(crewMember);
+                        }
+                    }
+                    else if (HighLogic.LoadedSceneIsEditor)
+                    {
+                        if (CrewAssignmentDialog.Instance != null && CrewAssignmentDialog.Instance.CurrentManifestUnsafe != null)
+                        {
+                            PartCrewManifest partCrewManifest = CrewAssignmentDialog.Instance.CurrentManifestUnsafe.GetPartCrewManifest(part.craftID);
+                            if (partCrewManifest != null)
+                            {
+                                ProtoCrewMember[] partCrew = null;
+                                partCrewManifest.GetPartCrew(ref partCrew);
+
+                                for (var i = 0; i < partCrew.Length; i++)
+                                {
+                                    ProtoCrewMember crewMember = partCrew[i];
+                                    if (crewMember == null) continue;
+                                    crewMass += CrewMassDelegate(crewMember);
+                                }
+                            }
+                        }
+                    }
+
+                    modulesUnstagedMass = part.GetModuleMassNoAlloc((float) dryMass, ModifierStagingSituation.UNSTAGED);
+
+                    modulesStagedMass = part.GetModuleMassNoAlloc((float) dryMass, ModifierStagingSituation.STAGED);
+
+                    float currentModulesMass = part.GetModuleMassNoAlloc((float) dryMass, ModifierStagingSituation.CURRENT);
+
+                    // if it was manually staged
+                    if (currentModulesMass == modulesStagedMass)
+                    {
+                        modulesUnstagedMass = modulesStagedMass;
+                    }
+
+                    //print(part.partInfo.name.PadRight(25) + " " + part.mass.ToString("F4") + " " + part.GetPhysicslessChildMass().ToString("F4") + " " + modulesUnstagedMass.ToString("F4") + " " + modulesStagedMass.ToString("F4"));
+                }
+
+                inverseStage = part.inverseStage;
+                partName     = part.partInfo.name;
+
+                resourceRequestRemainingThreshold = Math.Max(part.resourceRequestRemainingThreshold, DRAINED);
+                resourcePriority                  = part.GetResourcePriority();
+
+                //note which resources this part has stored
+                for (int i = 0; i < part.Resources.Count; i++)
+                {
+                    PartResource r = part.Resources[i];
+                    if (r.info.density > 0)
+                    {
+                        if (r.flowState)
+                        {
+                            resources[r.info.id] = r.amount;
+                        }
+                        else
+                        {
+                            dryMass += (r.amount * r.info.density); // disabled resources are just dead weight
+                        }
+                    }
+                    else
+                    {
+                        freeResources[r.info.id] = true;
+                    }
+
+                    // Including the ressource in the CRP.
+                    if (r.info.name == "IntakeAir" || r.info.name == "IntakeLqd" || r.info.name == "IntakeAtm")
+                        freeResources[r.info.id] = true;
+                }
+
+                engineInfos.Clear();
+
+                // determine if we've got at least one useful ModuleEngine
+                // we only do these test for the first ModuleEngines in the Part, could any other ones actually differ?
+                for (int i = 0; i < part.Modules.Count; i++)
+                {
+                    if (!(part.Modules[i] is ModuleEngines e) || !e.isEnabled) continue;
+
+                    // Only count engines that either are ignited or will ignite in the future:
+                    if (!isEngine && (HighLogic.LoadedSceneIsEditor || inverseStage < StageManager.CurrentStage || e.getIgnitionState) &&
+                        (e.thrustPercentage > 0 || e.minThrust > 0))
+                    {
+                        // if an engine has been activated early, pretend it is in the current stage:
+                        if (e.getIgnitionState && inverseStage < StageManager.CurrentStage)
+                            inverseStage = StageManager.CurrentStage;
+
+                        isEngine         = true;
+                        isthrottleLocked = e.throttleLocked;
+                    }
+
+                    engineInfos.Add(new EngineInfo(e));
+                }
+            }
+
+            // We are not necessarily traversing from the root part but from any interior part, so that p.parent is just another potential child node
+            // in our traversal.  This is a helper to loop over all the children (including the "p.parent") in our traversal.
+            private void AssignChildrenDecoupledInStage(Part p, Part traversalParent, Dictionary<Part, FuelNode> nodeLookup,
+                int parentDecoupledInStage)
+            {
+                for (int i = 0; i < p.children.Count; i++)
+                {
+                    Part child = p.children[i];
+                    if (child != null && child != traversalParent)
+                        nodeLookup[child].AssignDecoupledInStage(child, p, nodeLookup, parentDecoupledInStage);
+                }
+
+                if (p.parent != null && p.parent != traversalParent)
+                    nodeLookup[p.parent].AssignDecoupledInStage(p.parent, p, nodeLookup, parentDecoupledInStage);
+            }
+
+            // Determine when this part will be decoupled given when its traversal-order parent will be decoupled.
+            // Then recurse to all of this part's "children" (including the p.parent if the traversalParent is coming from a child).
+            public void AssignDecoupledInStage(Part p, Part traversalParent, Dictionary<Part, FuelNode> nodeLookup, int parentDecoupledInStage)
+            {
+                // Already processed (this gets used where we assign the attached part, then loop over all the children and expect the
+                // one we already hit to be skipped by this)
+                if (decoupledInStage != int.MinValue)
+                    return;
+
+                bool isDecoupler = false;
+                decoupledInStage = parentDecoupledInStage;
+
+                for (int i = 0; i < p.Modules.Count; i++)
+                {
+                    PartModule m = p.Modules[i];
+
+                    ModuleDecouple mDecouple = m as ModuleDecouple;
+                    if (mDecouple != null)
+                    {
+                        if (!mDecouple.isDecoupled && mDecouple.stagingEnabled && p.stagingOn)
+                        {
+                            if (mDecouple.isOmniDecoupler)
+                            {
+                                // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
+                                isDecoupler      = true;
+                                decoupledInStage = p.inverseStage;
+                                AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
+                            }
+                            else
+                            {
+                                AttachNode attach;
+                                if (HighLogic.LoadedSceneIsEditor)
+                                {
+                                    if (mDecouple.explosiveNodeID != "srf")
+                                        attach = p.FindAttachNode(mDecouple.explosiveNodeID);
+                                    else
+                                        attach = p.srfAttachNode;
+                                }
+                                else
+                                {
+                                    attach = mDecouple.ExplosiveNode;
+                                }
+
+                                if (attach != null && attach.attachedPart != null)
+                                {
+                                    if (attach.attachedPart == traversalParent && mDecouple.staged)
+                                    {
+                                        // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
+                                        isDecoupler      = true;
+                                        decoupledInStage = p.inverseStage;
+                                        AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
+                                    }
+                                    else
+                                    {
+                                        // We are still attached to our traversalParent.  The part we decouple is dropped when we decouple.  The part and other children are dropped with the traversalParent.
+                                        isDecoupler      = true;
+                                        decoupledInStage = parentDecoupledInStage;
+                                        nodeLookup[attach.attachedPart].AssignDecoupledInStage(attach.attachedPart, p, nodeLookup, p.inverseStage);
+                                        AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
+                                    }
+                                }
+                            }
+
+                            break; // Hopefully no one made part with multiple decoupler modules ?
+                        }
+                    }
+
+                    ModuleAnchoredDecoupler mAnchoredDecoupler = m as ModuleAnchoredDecoupler;
+                    if (mAnchoredDecoupler != null)
+                    {
+                        if (!mAnchoredDecoupler.isDecoupled && mAnchoredDecoupler.stagingEnabled && p.stagingOn)
+                        {
+                            AttachNode attach;
+                            if (HighLogic.LoadedSceneIsEditor)
+                            {
+                                if (mAnchoredDecoupler.explosiveNodeID != "srf")
+                                    attach = p.FindAttachNode(mAnchoredDecoupler.explosiveNodeID);
+                                else
+                                    attach = p.srfAttachNode;
+                            }
+                            else
+                            {
+                                attach = mAnchoredDecoupler.ExplosiveNode;
+                            }
+
+                            if (attach != null && attach.attachedPart != null)
+                            {
+                                if (attach.attachedPart == traversalParent && mAnchoredDecoupler.staged)
+                                {
+                                    // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
+                                    isDecoupler      = true;
+                                    decoupledInStage = p.inverseStage;
+                                    AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
+                                }
+                                else
+                                {
+                                    // We are still attached to our traversalParent.  The part we decouple is dropped when we decouple.  The part and other children are dropped with the traversalParent.
+                                    isDecoupler      = true;
+                                    decoupledInStage = parentDecoupledInStage;
+                                    nodeLookup[attach.attachedPart].AssignDecoupledInStage(attach.attachedPart, p, nodeLookup, p.inverseStage);
+                                    AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
+                                }
+                            }
+
+                            break;
+                        }
+                    }
+
+                    ModuleDockingNode mDockingNode = m as ModuleDockingNode;
+                    if (mDockingNode != null)
+                    {
+                        if (mDockingNode.staged && mDockingNode.stagingEnabled && p.stagingOn)
+                        {
+                            Part attachedPart = mDockingNode.referenceNode.attachedPart;
+                            if (attachedPart != null)
+                            {
+                                if (attachedPart == traversalParent)
+                                {
+                                    // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
+                                    isDecoupler      = true;
+                                    decoupledInStage = p.inverseStage;
+                                    AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
+                                    isDecoupler = true;
+                                }
+                                else
+                                {
+                                    // We are still attached to our traversalParent.  The part we decouple is dropped when we decouple.  The part and other children are dropped with the traversalParent.
+                                    isDecoupler      = true;
+                                    decoupledInStage = parentDecoupledInStage;
+                                    nodeLookup[attachedPart].AssignDecoupledInStage(attachedPart, p, nodeLookup, p.inverseStage);
+                                    AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
+                                }
+                            }
+                        }
+
+                        break;
+                    }
+
+                    if (m.moduleName == "ProceduralFairingDecoupler")
+                    {
+                        if (!m.Fields["decoupled"].GetValue<bool>(m) && m.stagingEnabled && p.stagingOn)
+                        {
+                            // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
+                            isDecoupler      = true;
+                            decoupledInStage = p.inverseStage;
+                            AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
+                            isDecoupler = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (isLaunchClamp)
+                {
+                    decoupledInStage = p.inverseStage > parentDecoupledInStage ? p.inverseStage : parentDecoupledInStage;
+                }
+                else if (!isDecoupler)
+                {
+                    decoupledInStage = parentDecoupledInStage;
+                }
+
+                isSepratron = isEngine && isthrottleLocked && activatesEvenIfDisconnected && (inverseStage == decoupledInStage);
+
+                AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
+            }
+
+            public static void print(object message)
+            {
+                Dispatcher.InvokeAsync(() => MonoBehaviour.print("[MechJeb2] " + message));
+            }
+
+            public double partThrust;
+
+            public void SetConsumptionRates(float throttle, double atmospheres, double atmDensity, double machNumber)
+            {
+                if (isEngine)
+                {
+                    resourceConsumptions.Clear();
+                    propellantFlows.Clear();
+
+                    //double sumThrustOverIsp = 0;
+                    partThrust = 0;
+
+                    isDrawingResources = false;
+
+                    foreach (EngineInfo engineInfo in engineInfos)
+                    {
+                        ModuleEngines e = engineInfo.engineModule;
+                        // thrust is correct.
+                        Vector3d thrust;
+                        // note that isp and massFlowRate do not include ignoreForIsp fuels like HTP and so need to be fixed for effective isp and the
+                        // actual mdot of the rocket needs to be fixed to include HTP.
+                        //
+                        // IMHO: using ignoreForIsp is just wrong.  full stop.  engines should never set this and should set the correct effective isp in
+                        // the config for the engine.  makes everything simpler and fixes the UI to show the correct ISP.  going this direction we are going
+                        // to get bug reports that e.g. mechjeb is reporting 299s for an RD-108 when RF and KSP are displaying 308s everywhere.  which is not
+                        // going to be a bug at all.  as long as the thrust is correct, the effective isp is correct, and the fuel fractions are correct then
+                        // the rocket equation just works and HTP should not be "ignored".   keeping it out of the atmosphereCurve just makes this annoying
+                        // here and screws up the KSP API display of ISP.
+                        //
+                        double isp, massFlowRate;
+                        EngineValuesAtConditions(engineInfo, throttle, atmospheres, atmDensity, machNumber, out thrust, out isp, out massFlowRate,
+                            cosLoss: dVLinearThrust);
+                        partThrust += thrust.magnitude;
+
+                        if (massFlowRate > 0)
+                            isDrawingResources = true;
+
+                        double totalDensity = 0;
+
+                        for (int j = 0; j < e.propellants.Count; j++)
+                        {
+                            var p = e.propellants[j];
+                            double density = MuUtils.ResourceDensity(p.id);
+
+                            // zero density draws (eC, air intakes, etc) are skipped, we have to assume you open your solar panels or
+                            // air intakes or whatever it is you need for them to function.  they don't affect the mass of the vehicle
+                            // so they do not affect the rocket equation.  they are assumed to be "renewable" or effectively infinite.
+                            // (we keep them out of the propellantFlows dict here so they're just ignored by the sim later).
+                            //
+                            if (density > 0)
+                            {
+                                // hopefully different EngineModules in the same part don't have different flow modes for the same propellant
+                                if (!propellantFlows.ContainsKey(p.id))
+                                    propellantFlows.Add(p.id, p.GetFlowMode());
+                            }
+
+                            // have to ignore ignoreForIsp fuels here since we're dealing with the massflowrate of the other fuels
+                            if (!p.ignoreForIsp)
+                            {
+                                totalDensity += p.ratio * density;
+                            }
+                        }
+
+                        // this is also the volume flow rate of the non-ignoreForIsp fuels.  although this is a bit janky since the p.ratios in most
+                        // stock engines sum up to 2, not 1 (1.1 + 0.9), so this is not per-liter but per-summed-ratios (the massflowrate you get out
+                        // of the atmosphere curves (above) are also similarly adjusted by these ratios -- it is a bit of a horror show).
+                        double volumeFlowRate = massFlowRate / totalDensity;
+
+                        for (int j = 0; j < e.propellants.Count; j++)
+                        {
+                            var p = e.propellants[j];
+                            double density = MuUtils.ResourceDensity(p.id);
+
+                            // this is the individual propellant volume rate.  we are including the ignoreForIsp fuels in this loop and this will
+                            // correctly calculate the volume rates of all the propellants, in L/sec.  if you sum these it'll be larger than the
+                            // volumeFlowRate by including both the ignoreForIsp fuels and if the ratios sum up to more than one.
+                            double propVolumeRate = p.ratio * volumeFlowRate;
+
+                            // same density check here as above to keep massless propellants out of the ResourceConsumptions dict as well
+                            if (density > 0)
+                            {
+                                if (resourceConsumptions.ContainsKey(p.id))
+                                    resourceConsumptions[p.id] += propVolumeRate;
+                                else
+                                    resourceConsumptions.Add(p.id, propVolumeRate);
+                            }
+                        }
+                    }
+                }
+            }
+
+            public void AddCrossfeedSouces(HashSet<Part> parts, Dictionary<Part, FuelNode> nodeLookup)
+            {
+                using (var it = parts.GetEnumerator())
+                {
+                    while (it.MoveNext())
+                    {
+                        FuelNode fuelnode;
+                        if (nodeLookup.TryGetValue(it.Current, out fuelnode))
+                            crossfeedSources.Add(fuelnode);
+                    }
+                }
+            }
+
+            //call this when a node no longer exists, so that this node knows that it's no longer a valid source
+            public void RemoveSourceNode(FuelNode n)
+            {
+                crossfeedSources.Remove(n);
+            }
+
+            //return the mass of the simulated FuelNode. This is not the same as the mass of the Part,
+            //because the simulated node may have lost resources, and thus mass, during the simulation.
+            public double Mass(int simStage)
+            {
+                //print("\n(" + simStage + ") " + partName.PadRight(25) + " dryMass " + dryMass.ToString("F3")
+                //          + " ResMass " + (resources.Keys.Sum(id => resources[id] * MuUtils.ResourceDensity(id))).ToString("F3")
+                //          + " Fairing Mass " + (inverseStage < simStage ? fairingMass : 0).ToString("F3")
+                //          + " (" + fairingMass.ToString("F3") + ")"
+                //          + " ModuleMass " + moduleMass.ToString("F3")
+                //          );
+
+                //return dryMass + resources.Keys.Sum(id => resources[id] * MuUtils.ResourceDensity(id)) +
+                double resMass = resources.KeysList.Slinq().Select((r, rs) => rs[r] * MuUtils.ResourceDensity(r), resources).Sum();
+                return dryMass + crewMass + resMass +
+                       (inverseStage < simStage ? modulesUnstagedMass : modulesStagedMass);
+            }
+
+            public void ResetDrainRates()
+            {
+                resourceDrains.Clear();
+            }
+
+            public void DrainResources(double dt)
+            {
+                foreach (int type in resourceDrains.KeysList)
+                    if (!freeResources[type])
+                        resources[type] -= dt * resourceDrains[type];
+            }
+
+
+            public void DebugResources()
+            {
+                foreach (KeyValuePair<int, double> type in resources)
+                    print(partName + " " + PartResourceLibrary.Instance.GetDefinition(type.Key).name + " is " + type.Value);
+            }
+
+            public void DebugDrainRates()
+            {
+                foreach (int type in resourceDrains.Keys)
+                {
+                    print(partName + "'s drain rate of " + PartResourceLibrary.Instance.GetDefinition(type).name + "(" + type + ") is " +
+                          resourceDrains[type] + " free=" + freeResources[type]);
+                }
+            }
+
+            public double MaxTimeStep()
+            {
+                //DebugDrainRates();
+                var param =
+                    new Smooth.Algebraics.Tuple<DefaultableDictionary<int, double>, double, DefaultableDictionary<int, double>,
+                        DefaultableDictionary<int, bool>>(resources, resourceRequestRemainingThreshold, resourceDrains, freeResources);
+                if (!resourceDrains.KeysList.Slinq().Any((id, p) => !p.Item4[id] && p.Item1[id] > p.Item2, param)) return double.MaxValue;
+                return resourceDrains.KeysList.Slinq().Where((id, p) => !p.Item4[id] && p.Item1[id] > p.Item2, param)
+                    .Select((id, p) => p.Item1[id] / p.Item3[id], param).Min();
+            }
+
+            //Returns an enumeration of the resources this part burns
+            public List<int> BurnedResources()
+            {
+                return resourceConsumptions.KeysList;
+            }
+
+            //returns whether this part contains any of the given resources
+            public bool ContainsResources(List<int> whichResources)
+            {
+                var param = new Smooth.Algebraics.Tuple<DefaultableDictionary<int, double>, double>(resources, resourceRequestRemainingThreshold);
+                //return whichResources.Any(id => resources[id] > DRAINED);
+                return whichResources.Slinq().Any((id, r) => r.Item1[id] > r.Item2, param);
+            }
+
+            public bool CanDrawNeededResources(List<FuelNode> vessel)
+            {
+                // XXX: this fix is intended to fix SRBs which have burned out but which
+                // still have an amount of fuel over the resourceRequestRemainingThreshold, which
+                // can happen in RealismOverhaul.  this targets specifically "No propellants" because
+                // we do not want flamed out jet engines to trigger this code if they just don't have
+                // enough intake air, and any other causes.
+                // BIG FIXME: we're doing this in the thread and touching the KSP part object.
+                
+                if (part.Modules[0] is ModuleEngines {flameout: true, statusL2: "No propellants"})
+                    return false;
+
+                foreach (int type in resourceConsumptions.KeysList)
+                {
+                    var resourceFlowMode = propellantFlows[type];
+                    switch (resourceFlowMode)
+                    {
+                        case ResourceFlowMode.NO_FLOW:
+                            //check if we contain the needed resource:
+                            if (resources[type] < resourceRequestRemainingThreshold) return false;
+                            break;
+
+                        case ResourceFlowMode.ALL_VESSEL:
+                        case ResourceFlowMode.ALL_VESSEL_BALANCE:
+                        case ResourceFlowMode.STAGE_PRIORITY_FLOW:
+                        case ResourceFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
+                            //check if any part contains the needed resource:
+                            if (!vessel.Slinq().Any((n, t) => n.resources[t] > n.resourceRequestRemainingThreshold, type)) return false;
+                            break;
+
+                        case ResourceFlowMode.STAGE_STACK_FLOW:
+                        case ResourceFlowMode.STAGE_STACK_FLOW_BALANCE:
+                        case ResourceFlowMode.STACK_PRIORITY_SEARCH:
+                            // check if we can get any of the needed resources
+                            if (!crossfeedSources.Slinq().Any((n, t) => n.resources[t] > n.resourceRequestRemainingThreshold, type)) return false;
+                            break;
+
+                        default: // and NULL
+                            return false;
+                    }
+                }
+
+                return true; //we didn't find ourselves lacking for any resource
+            }
+
+            public bool CanDrawFrom(FuelNode node)
+            {
+                return crossfeedSources.Contains(node);
+            }
+
+            public void AssignResourceDrainRates(List<FuelNode> vessel)
+            {
+                foreach (int type in resourceConsumptions.KeysList)
+                {
+                    if (freeResources[type])
+                        continue;
+
+                    double amount = resourceConsumptions[type];
+
+                    var resourceFlowMode = propellantFlows[type];
+                    switch (resourceFlowMode)
+                    {
+                        case ResourceFlowMode.NO_FLOW:
+                            resourceDrains[type] += amount;
+                            break;
+
+                        case ResourceFlowMode.ALL_VESSEL:
+                        case ResourceFlowMode.ALL_VESSEL_BALANCE:
+                            AssignFuelDrainRateStagePriorityFlow(type, amount, false, vessel);
+                            break;
+
+                        case ResourceFlowMode.STAGE_PRIORITY_FLOW:
+                        case ResourceFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
+                            AssignFuelDrainRateStagePriorityFlow(type, amount, true, vessel);
+                            break;
+
+                        case ResourceFlowMode.STAGE_STACK_FLOW:
+                        case ResourceFlowMode.STAGE_STACK_FLOW_BALANCE:
+                        case ResourceFlowMode.STACK_PRIORITY_SEARCH:
+                            //AssignFuelDrainRateStackPriority(type, true, amount);
+                            AssignFuelDrainRateStagePriorityFlow(type, amount, true, crossfeedSources);
+                            break;
+
+                        default:
+                            //do nothing.
+                            break;
+                    }
+                }
+            }
+
+            void AssignFuelDrainRateStagePriorityFlow(int type, double amount, bool usePrio, List<FuelNode> vessel)
+            {
+                int maxPrio = int.MinValue;
+                using (var dispoSources = ListPool<FuelNode>.Instance.BorrowDisposable())
+                {
+                    var sources = dispoSources.value;
+                    //print("AssignFuelDrainRateStagePriorityFlow for " + partName + " searching for " + amount + " of " + PartResourceLibrary.Instance.GetDefinition(type).name + " in " + vessel.Count + " parts ");
+                    for (int i = 0; i < vessel.Count; i++)
+                    {
+                        FuelNode n = vessel[i];
+                        if (n.resources[type] > n.resourceRequestRemainingThreshold)
+                        {
+                            if (usePrio)
+                            {
+                                if (n.resourcePriority > maxPrio)
+                                {
+                                    maxPrio = n.resourcePriority;
+                                    sources.Clear();
+                                    sources.Add(n);
+                                }
+                                else if (n.resourcePriority == maxPrio)
+                                {
+                                    sources.Add(n);
+                                }
+                            }
+                            else
+                            {
+                                sources.Add(n);
+                            }
+                        }
+                    }
+
+                    //print(partName + " drains resource from " + sources.Count + " parts ");
+                    for (int i = 0; i < sources.Count; i++)
+                    {
+                        if (!freeResources[type])
+                            sources[i].resourceDrains[type] += amount / sources.Count;
+                    }
+                }
+            }
+
+            // for a single EngineModule, get thrust + isp + massFlowRate
+            private void EngineValuesAtConditions(EngineInfo engineInfo, double throttle, double atmPressure, double atmDensity, double machNumber,
+                out Vector3d thrust, out double isp, out double massFlowRate, bool cosLoss = true)
+            {
+                isp = engineInfo.engineModule.ISPAtConditions(throttle, atmPressure, atmDensity, machNumber);
+                double flowMultiplier = engineInfo.engineModule.FlowMultiplierAtConditions(atmDensity, machNumber);
+                massFlowRate = engineInfo.engineModule.FlowRateAtConditions(throttle, flowMultiplier);
+                thrust       = ThrustAtConditions(engineInfo, massFlowRate, isp, cosLoss);
+                //Debug.Log("thrust = " + thrust + " isp = " + isp + " massFlowRate = " + massFlowRate);
+            }
+
+            // for a single EngineModule, get its thrust vector (use EngineModuleFlowMultiplier and EngineModuleISP below)
+            private Vector3d ThrustAtConditions(EngineInfo engineInfo, double massFlowRate, double isp, bool cosLoss = true)
+            {
+                if (massFlowRate <= 0)
+                    return Vector3d.zero;
+
+                Vector3d thrustVector = engineInfo.thrustVector;
+
+                if (cosLoss)
+                {
+                    thrustVector = Vector3.Dot(vesselOrientation, thrustVector) * thrustVector.normalized;
+                }
+
+                return thrustVector * massFlowRate * engineInfo.engineModule.g * engineInfo.engineModule.multIsp * isp;
+            }
+        }
+    }
+}

--- a/MechJeb2/FuelStats.cs
+++ b/MechJeb2/FuelStats.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace MuMech
+{
+   public partial class FuelFlowSimulation
+    {
+        //A FuelStats struct describes the result of the simulation over a certain interval of time (e.g., one stage)
+        public struct FuelStats
+        {
+            public double StartMass;
+            public double EndMass;
+            public double StartThrust;
+            public double EndThrust;
+            public double MaxAccel;
+            public double DeltaTime;
+            public double DeltaV;
+
+            public double ResourceMass;
+            public double Isp;
+            public double StagedMass;
+
+            public double StartTWR(double geeASL)
+            {
+                return StartMass > 0 ? StartThrust / (9.80665 * geeASL * StartMass) : 0;
+            }
+
+            public double MaxTWR(double geeASL)
+            {
+                return MaxAccel / (9.80665 * geeASL);
+            }
+
+            public List<Part> Parts;
+
+            //Computes the deltaV from the other fields. Only valid when the thrust is constant over the time interval represented.
+            public void ComputeTimeStepDeltaV()
+            {
+                if (DeltaTime > 0 && StartMass > EndMass && StartMass > 0 && EndMass > 0)
+                    DeltaV = StartThrust * DeltaTime / (StartMass - EndMass) * Math.Log(StartMass / EndMass);
+                else
+                    DeltaV = 0;
+            }
+
+            //Append joins two FuelStats describing adjacent intervals of time into one describing the combined interval
+            public FuelStats Append(FuelStats s)
+            {
+                return new FuelStats
+                {
+                    StartMass    = StartMass,
+                    EndMass      = s.EndMass,
+                    ResourceMass = StartMass - s.EndMass,
+                    StartThrust  = StartThrust,
+                    EndThrust    = s.EndThrust,
+                    MaxAccel     = Math.Max(MaxAccel, s.MaxAccel),
+                    DeltaTime    = DeltaTime + (s.DeltaTime < float.MaxValue && !double.IsInfinity(s.DeltaTime) ? s.DeltaTime : 0),
+                    DeltaV       = DeltaV + s.DeltaV,
+                    Parts        = Parts,
+                    // ReSharper disable once CompareOfFloatsByEqualityOperator
+                    Isp          = StartMass == s.EndMass ? 0 : (DeltaV + s.DeltaV) / (9.80665f * Math.Log(StartMass / s.EndMass))
+                };
+            }
+        }
+    }
+}

--- a/MechJeb2/MechJeb2.csproj
+++ b/MechJeb2/MechJeb2.csproj
@@ -60,6 +60,8 @@
     <Compile Include="FlyingSim\SimulatedPart.cs" />
     <Compile Include="FlyingSim\SimulatedVessel.cs" />
     <Compile Include="FuelFlowSimulation.cs" />
+    <Compile Include="FuelNode.cs" />
+    <Compile Include="FuelStats.cs" />
     <Compile Include="GLUtils.cs" />
     <Compile Include="GoodingSolver.cs" />
     <Compile Include="GuiUtils.cs" />

--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -440,7 +440,7 @@ namespace MuMech
 
         public MechJebModuleAscentAutopilot autopilot { get { return core.GetComputerModule<MechJebModuleAscentAutopilot>(); } }
         private MechJebModuleStageStats stats { get { return core.GetComputerModule<MechJebModuleStageStats>(); } }
-        private FuelFlowSimulation.Stats[] vacStats { get { return stats.vacStats; } }
+        private FuelFlowSimulation.FuelStats[] vacStats { get { return stats.vacStats; } }
 
         public abstract bool DriveAscent(FlightCtrlState s);
 

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -24,7 +24,7 @@ namespace MuMech
         public MechJebModuleAscentPVG pvgascent { get { return core.GetComputerModule<MechJebModuleAscentPVG>(); } }
         public MechJebModuleAscentGT gtascent { get { return core.GetComputerModule<MechJebModuleAscentGT>(); } }
         private MechJebModuleStageStats stats { get { return core.GetComputerModule<MechJebModuleStageStats>(); } }
-        private FuelFlowSimulation.Stats[] atmoStats { get { return stats.atmoStats; } }
+        private FuelFlowSimulation.FuelStats[] atmoStats { get { return stats.atmoStats; } }
 
         private ascentType ascentPathIdx { get { return autopilot.ascentPathIdxPublic; } }
 
@@ -396,7 +396,7 @@ namespace MuMech
                         if ( core.guidance.last_failure_cause != null )
                         {
                             GUIStyle s = new GUIStyle(GUI.skin.label);
-                            s.normal.textColor = Color.red;
+                            s.normal.textColor = core.guidance.staleness < 2 && core.guidance.successful_converges > 0 ? Color.green : Color.red;
                             GUILayout.BeginHorizontal();
                             GUILayout.Label(Localizer.Format("#MechJeb_Ascent_label30") + core.guidance.last_failure_cause, s);//LAST FAILURE:
                             GUILayout.EndHorizontal();
@@ -404,8 +404,8 @@ namespace MuMech
 
                         if ( vessel.situation != Vessel.Situations.LANDED && vessel.situation != Vessel.Situations.PRELAUNCH && vessel.situation != Vessel.Situations.SPLASHED && atmoStats.Length > vessel.currentStage)
                         {
-                            double m0 = atmoStats[vessel.currentStage].startMass;
-                            double thrust = atmoStats[vessel.currentStage].startThrust;
+                            double m0 = atmoStats[vessel.currentStage].StartMass;
+                            double thrust = atmoStats[vessel.currentStage].EndThrust;
 
                             if (Math.Abs(vesselState.mass - m0) / m0 > 0.01)
                             {

--- a/MechJeb2/MechJebModuleInfoItems.cs
+++ b/MechJeb2/MechJebModuleInfoItems.cs
@@ -853,8 +853,8 @@ namespace MuMech
 
         private static readonly string[] StageDisplayStates = {Localizer.Format("#MechJeb_InfoItems_button1"), Localizer.Format("#MechJeb_InfoItems_button2"), Localizer.Format("#MechJeb_InfoItems_button3"), Localizer.Format("#MechJeb_InfoItems_button4") };//"Short stats""Long stats""Full stats""Custom"
 
-        private FuelFlowSimulation.Stats[] vacStats;
-        private FuelFlowSimulation.Stats[] atmoStats;
+        private FuelFlowSimulation.FuelStats[] vacStats;
+        private FuelFlowSimulation.FuelStats[] atmoStats;
         private string[] bodies;
 
         [GeneralInfoItem("#MechJeb_StageStatsAll", InfoItem.Category.Vessel, showInEditor = true)]//Stage stats (all)
@@ -877,7 +877,7 @@ namespace MuMech
             Profiler.BeginSample("AllStageStats.UI1");
 
             int numStages = atmoStats.Length;
-            var stages = Enumerable.Range(0, numStages).Where(s => showEmpty || atmoStats[s].deltaV > 0).ToArray();
+            var stages = Enumerable.Range(0, numStages).Where(s => showEmpty || atmoStats[s].DeltaV > 0).ToArray();
 
             GUILayout.BeginVertical();
 
@@ -973,23 +973,23 @@ namespace MuMech
             Profiler.BeginSample("AllStageStats.UI3");
 
             bool noChange = true;
-            if (showInitialMass) noChange &= showInitialMass = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn1"), stages.Select(s => atmoStats[s].startMass.ToString("F3") + " t"));//"Start Mass"
+            if (showInitialMass) noChange &= showInitialMass = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn1"), stages.Select(s => atmoStats[s].StartMass.ToString("F3") + " t"));//"Start Mass"
 
             Profiler.EndSample();
 
             Profiler.BeginSample("AllStageStats.UI4");
 
-            if (showFinalMass) noChange &= showFinalMass = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn2"), stages.Select(s => atmoStats[s].endMass.ToString("F3") + " t"));//"End mass"
-            if (showStagedMass) noChange &= showStagedMass = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn3"), stages.Select(s => atmoStats[s].stagedMass.ToString("F3") + " t"));//"Staged Mass"
-            if (showBurnedMass) noChange &= showBurnedMass = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn4"), stages.Select(s => atmoStats[s].resourceMass.ToString("F3") + " t"));//"Burned Mass"
+            if (showFinalMass) noChange &= showFinalMass = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn2"), stages.Select(s => atmoStats[s].EndMass.ToString("F3") + " t"));//"End mass"
+            if (showStagedMass) noChange &= showStagedMass = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn3"), stages.Select(s => atmoStats[s].StagedMass.ToString("F3") + " t"));//"Staged Mass"
+            if (showBurnedMass) noChange &= showBurnedMass = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn4"), stages.Select(s => atmoStats[s].ResourceMass.ToString("F3") + " t"));//"Burned Mass"
             if (showVacInitialTWR) noChange &= showVacInitialTWR = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn5"), stages.Select(s => vacStats[s].StartTWR(geeASL).ToString("F2")));//"TWR"
             if (showVacMaxTWR) noChange &= showVacMaxTWR = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn6"), stages.Select(s => vacStats[s].MaxTWR(geeASL).ToString("F2")));//"Max TWR"
             if (showAtmoInitialTWR) noChange &= showAtmoInitialTWR = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn7"), stages.Select(s => atmoStats[s].StartTWR(geeASL).ToString("F2")));//"SLT"
             if (showAtmoMaxTWR) noChange &= showAtmoMaxTWR = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn8"), stages.Select(s => atmoStats[s].MaxTWR(geeASL).ToString("F2")));//"Max SLT"
-            if (showISP) noChange &= showISP = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn9"), stages.Select(s => atmoStats[s].isp.ToString("F2")));//"ISP"
-            if (showAtmoDeltaV) noChange &= showAtmoDeltaV = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn10"), stages.Select(s => atmoStats[s].deltaV.ToString("F0") + " m/s"));//"Atmo ΔV"
-            if (showVacDeltaV) noChange &= showVacDeltaV = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn11"), stages.Select(s => vacStats[s].deltaV.ToString("F0") + " m/s"));//"Vac ΔV"
-            if (showTime) noChange &= showTime = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn12"), stages.Select(s => timeSeconds ? MuUtils.ToSI(atmoStats[s].deltaTime, 2) + " s": GuiUtils.TimeToDHMS(atmoStats[s].deltaTime, 1)));//"Time"
+            if (showISP) noChange &= showISP = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn9"), stages.Select(s => atmoStats[s].Isp.ToString("F2")));//"ISP"
+            if (showAtmoDeltaV) noChange &= showAtmoDeltaV = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn10"), stages.Select(s => atmoStats[s].DeltaV.ToString("F0") + " m/s"));//"Atmo ΔV"
+            if (showVacDeltaV) noChange &= showVacDeltaV = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn11"), stages.Select(s => vacStats[s].DeltaV.ToString("F0") + " m/s"));//"Vac ΔV"
+            if (showTime) noChange &= showTime = !DrawStageStatsColumn(Localizer.Format("#MechJeb_InfoItems_StatsColumn12"), stages.Select(s => timeSeconds ? MuUtils.ToSI(atmoStats[s].DeltaTime, 2) + " s": GuiUtils.TimeToDHMS(atmoStats[s].DeltaTime, 1)));//"Time"
 
             if (!noChange)
                 StageDisplayState = 3;
@@ -1046,7 +1046,7 @@ namespace MuMech
 
             if (stats.vacStats.Length == 0) return 0;
 
-            return stats.vacStats[stats.vacStats.Length - 1].deltaV;
+            return stats.vacStats[stats.vacStats.Length - 1].DeltaV;
         }
 
         [ValueInfoItem("#MechJeb_StageDV_atmo", InfoItem.Category.Vessel, format = "F0", units = "m/s", showInEditor = true)]//Stage ΔV (atmo)
@@ -1057,7 +1057,7 @@ namespace MuMech
 
             if (stats.atmoStats.Length == 0) return 0;
 
-            return stats.atmoStats[stats.atmoStats.Length - 1].deltaV;
+            return stats.atmoStats[stats.atmoStats.Length - 1].DeltaV;
         }
 
         [ValueInfoItem("#MechJeb_StageDV_atmo_vac", InfoItem.Category.Vessel, units = "m/s", showInEditor = true)]//Stage ΔV (atmo, vac)
@@ -1066,8 +1066,8 @@ namespace MuMech
             MechJebModuleStageStats stats = core.GetComputerModule<MechJebModuleStageStats>();
             stats.RequestUpdate(this);
 
-            double atmDv = (stats.atmoStats.Length == 0) ? 0 : stats.atmoStats[stats.atmoStats.Length - 1].deltaV;
-            double vacDv = (stats.vacStats.Length == 0) ? 0 : stats.vacStats[stats.vacStats.Length - 1].deltaV;
+            double atmDv = (stats.atmoStats.Length == 0) ? 0 : stats.atmoStats[stats.atmoStats.Length - 1].DeltaV;
+            double vacDv = (stats.vacStats.Length == 0) ? 0 : stats.vacStats[stats.vacStats.Length - 1].DeltaV;
 
             return String.Format("{0:F0}, {1:F0}", atmDv, vacDv);
         }
@@ -1080,8 +1080,8 @@ namespace MuMech
 
             if (stats.vacStats.Length == 0 || stats.atmoStats.Length == 0) return 0;
 
-            float vacTimeLeft = (float)stats.vacStats[stats.vacStats.Length - 1].deltaTime;
-            float atmoTimeLeft = (float)stats.atmoStats[stats.atmoStats.Length - 1].deltaTime;
+            float vacTimeLeft = (float)stats.vacStats[stats.vacStats.Length - 1].DeltaTime;
+            float atmoTimeLeft = (float)stats.atmoStats[stats.atmoStats.Length - 1].DeltaTime;
             float timeLeft = Mathf.Lerp(vacTimeLeft, atmoTimeLeft, Mathf.Clamp01((float)FlightGlobals.getStaticPressure()));
 
             return timeLeft;
@@ -1111,7 +1111,7 @@ namespace MuMech
         {
             MechJebModuleStageStats stats = core.GetComputerModule<MechJebModuleStageStats>();
             stats.RequestUpdate(this);
-            return stats.vacStats.Sum(s => s.deltaV);
+            return stats.vacStats.Sum(s => s.DeltaV);
         }
 
         [ValueInfoItem("#MechJeb_TotalDV_atmo", InfoItem.Category.Vessel, format = "F0", units = "m/s", showInEditor = true)]//Total ΔV (atmo)
@@ -1119,7 +1119,7 @@ namespace MuMech
         {
             MechJebModuleStageStats stats = core.GetComputerModule<MechJebModuleStageStats>();
             stats.RequestUpdate(this);
-            return stats.atmoStats.Sum(s => s.deltaV);
+            return stats.atmoStats.Sum(s => s.DeltaV);
         }
 
         [ValueInfoItem("#MechJeb_TotalDV_atmo_vac", InfoItem.Category.Vessel, units = "m/s", showInEditor = true)]//Total ΔV (atmo, vac)
@@ -1128,8 +1128,8 @@ namespace MuMech
             MechJebModuleStageStats stats = core.GetComputerModule<MechJebModuleStageStats>();
             stats.RequestUpdate(this);
 
-            double atmDv = stats.atmoStats.Sum(s => s.deltaV);
-            double vacDv = stats.vacStats.Sum(s => s.deltaV);
+            double atmDv = stats.atmoStats.Sum(s => s.DeltaV);
+            double vacDv = stats.vacStats.Sum(s => s.DeltaV);
 
             return String.Format("{0:F0}, {1:F0}", atmDv, vacDv);
         }

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -207,7 +207,7 @@ namespace MuMech
             for (int i = stats.vacStats.Length - 1; i >= 0 && dvLeft > 0; i--)
             {
                 var s = stats.vacStats[i];
-                if (s.deltaV <= 0 || s.startThrust <= 0)
+                if (s.DeltaV <= 0 || s.StartThrust <= 0)
                 {
                     if (core.staging.enabled)
                     {
@@ -221,10 +221,10 @@ namespace MuMech
                     continue;
                 }
 
-                double stageBurnDv = Math.Min(s.deltaV, dvLeft);
+                double stageBurnDv = Math.Min(s.DeltaV, dvLeft);
                 dvLeft -= stageBurnDv;
 
-                double stageBurnFraction = stageBurnDv / s.deltaV;
+                double stageBurnFraction = stageBurnDv / s.DeltaV;
 
                 // Delta-V is proportional to ln(m0 / m1) (where m0 is initial
                 // mass and m1 is final mass). We need to know the final mass
@@ -232,8 +232,8 @@ namespace MuMech
                 //      ln(m0 / m1) * stageBurnFraction = ln(m0 / m1b)
                 //      exp(ln(m0 / m1) * stageBurnFraction) = m0 / m1b
                 //      m1b = m0 / (exp(ln(m0 / m1) * stageBurnFraction))
-                double stageBurnFinalMass = s.startMass / Math.Exp(Math.Log(s.startMass / s.endMass) * stageBurnFraction);
-                double stageAvgAccel = s.startThrust / ((s.startMass + stageBurnFinalMass) / 2d);
+                double stageBurnFinalMass = s.StartMass / Math.Exp(Math.Log(s.StartMass / s.EndMass) * stageBurnFraction);
+                double stageAvgAccel = s.StartThrust / ((s.StartMass + stageBurnFinalMass) / 2d);
 
                 // Right now, for simplicity, we're ignoring throttle limits for
                 // all but the current stage. This is wrong, but hopefully it's

--- a/MechJeb2/MechJebModuleStageStats.cs
+++ b/MechJeb2/MechJebModuleStageStats.cs
@@ -17,14 +17,14 @@ namespace MuMech
         [ToggleInfoItem("#MechJeb_DVincludecosinelosses", InfoItem.Category.Thrust, showInEditor = true)]//ΔV include cosine losses
         public bool dVLinearThrust = true;
 
-        public FuelFlowSimulation.Stats[] atmoStats = { };
-        public FuelFlowSimulation.Stats[] vacStats = { };
+        public FuelFlowSimulation.FuelStats[] atmoStats = { };
+        public FuelFlowSimulation.FuelStats[] vacStats = { };
 
 
         // Those are used to store the next result from the thread since we must move result 
         // to atmoStats/vacStats only in the main thread.
-        private FuelFlowSimulation.Stats[] newAtmoStats;
-        private FuelFlowSimulation.Stats[] newVacStats;
+        private FuelFlowSimulation.FuelStats[] newAtmoStats;
+        private FuelFlowSimulation.FuelStats[] newVacStats;
         private bool resultReady = false;
 
         public void RequestUpdate(object controller, bool wait = false)

--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -50,7 +50,7 @@ namespace MuMech
         private readonly List<ModuleEngines> activeModuleEngines = new List<ModuleEngines>();
         private readonly List<int> burnedResources = new List<int>();
         private MechJebModuleStageStats stats { get { return core.GetComputerModule<MechJebModuleStageStats>(); } }
-        private FuelFlowSimulation.Stats[] vacStats { get { return stats.vacStats; } }
+        private FuelFlowSimulation.FuelStats[] vacStats { get { return stats.vacStats; } }
 
         private enum RemoteStagingState
         {
@@ -270,8 +270,8 @@ namespace MuMech
         public double LastNonZeroDVStageBurnTime()
         {
             for ( int i = vacStats.Length-1; i >= 0; i-- )
-                if ( vacStats[i].deltaTime > 0 )
-                    return vacStats[i].deltaTime;
+                if ( vacStats[i].DeltaTime > 0 )
+                    return vacStats[i].DeltaTime;
             return 0;
         }
 

--- a/MechJeb2/Pontryagin/Arc.cs
+++ b/MechJeb2/Pontryagin/Arc.cs
@@ -1,5 +1,22 @@
+using System.Collections.Generic;
+using System.Text;
+
 namespace MuMech
 {
+    public class ArcList : List<Arc>
+    {
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            foreach (Arc arc in this)
+            {
+                sb.AppendLine(arc.ToString());
+            }
+
+            return sb.ToString();
+        }
+    }
+    
     public class Arc
     {
         private readonly PontryaginBase                          p;
@@ -56,7 +73,7 @@ namespace MuMech
             if (stage != null)
             {
                 Isp          = stage.Isp;
-                Thrust       = stage.StartThrust;
+                Thrust       = stage.EffectiveThrust; // use the effective thrust to deal with ullage motors
                 M0           = stage.StartMass;
                 AvailDV      = stage.DeltaV;
                 MaxBt        = stage.DeltaTime;

--- a/MechJeb2/Pontryagin/PontryaginLaunch.cs
+++ b/MechJeb2/Pontryagin/PontryaginLaunch.cs
@@ -417,7 +417,7 @@ namespace MuMech {
             int stageCount = numStages > 0 ? numStages : stages.Count;
 
             // build arcs off of ksp stages, with coasts
-            List<Arc> arcs = new List<Arc>();
+            ArcList arcs = new ArcList();
             for(int i = 0; i < stageCount; i++)
             {
                 arcs.Add(new Arc(this, stage: stages[i], t0: t0));
@@ -429,9 +429,9 @@ namespace MuMech {
             // allocate y0
             y0 = new double[arcIndex(arcs, arcs.Count)];
 
-            // update initial position and guess for first arc
+            // update initial position and guess for first arc (uses effective thrust to deal with ullage motors)
             double ve = g0 * stages[0].Isp;
-            tgo = ve * stages[0].StartMass / stages[0].StartThrust * ( 1 - Math.Exp(-dV/ve) );
+            tgo = ve * stages[0].StartMass / stages[0].EffectiveThrust * ( 1 - Math.Exp(-dV/ve) );
             tgo_bar = tgo / t_scale;
 
             // initialize overall burn time
@@ -554,6 +554,8 @@ namespace MuMech {
 
             yf = new double[arcs.Count*13];
             multipleIntegrate(y0, yf, arcs);
+            
+            DebugLog($"PVG: arcs in solution after bootstrapping launch: {arcs}");
         }
 
         /*

--- a/MechJeb2/Pontryagin/PontryaginNode.cs
+++ b/MechJeb2/Pontryagin/PontryaginNode.cs
@@ -108,7 +108,7 @@ namespace MuMech {
             vT = rot * (vf.xzy / v_scale);
 
             // build arcs off of ksp stages, with coasts
-            List<Arc> arcs = new List<Arc>();
+            ArcList arcs = new ArcList();
 
             arcs.Add(new Arc(this, t0: t0, coast: true));
 


### PR DESCRIPTION
This adds EndThrust and switches MaxTWR to use it, switches
PVG over to using an EffectiveThrust calculation which is
effectively the average thrust over a stage.

Can't see how to easily chop up MechJeb stages into
sub-stages.

Also turn the last-failure notification green if the staleness is low.

This'll probably still flicker when we hit the staging delays, but its a bit better communication that the failure is no longer relevant.
