### PR TITLE
Fix autostaging on shutdown engines

### DIFF
--- a/MechJeb2/PartExtensions.cs
+++ b/MechJeb2/PartExtensions.cs
@@ -48,8 +48,8 @@ namespace MuMech
             {
                 PartModule m = p.Modules[i];
                 ModuleEngines eng = m as ModuleEngines;
-                if (eng != null) return !eng.getFlameoutState;
-
+                if (eng != null)
+                    return !eng.getFlameoutState && !eng.engineShutdown;
             }
             return false;
         }


### PR DESCRIPTION
Shutdown engines need to get autostaged through in order to avoid
having TF failed engines prevent autostaging.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>