### PR TITLE
Simpler PVG stage tracking

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -417,7 +417,7 @@ namespace MuMech
                                 GUILayout.EndHorizontal();
                             }
 
-                            if (Math.Abs(vesselState.thrustCurrent - thrust) / thrust > 0.01)
+                            if (Math.Abs(vesselState.thrustCurrent - thrust) / thrust > 0.10)
                             {
                                 GUIStyle s = new GUIStyle(GUI.skin.label);
                                 s.normal.textColor = Color.yellow;

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -417,7 +417,9 @@ namespace MuMech
                                 GUILayout.EndHorizontal();
                             }
 
-                            if (Math.Abs(vesselState.thrustCurrent - thrust) / thrust > 0.10)
+                            double thrustfrac = Math.Abs(vesselState.thrustCurrent - thrust) / thrust;
+
+                            if (thrustfrac > 0.10 && thrustfrac < 99.9)
                             {
                                 GUIStyle s = new GUIStyle(GUI.skin.label);
                                 s.normal.textColor = Color.yellow;

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -104,9 +104,6 @@ namespace MuMech
 
         public override void OnFixedUpdate()
         {
-            // FIXME: pretty sure we can make this module dependent upon the stage tracking module running first?  dependency management sucks.
-            core.stageTracking.Update();
-            
             update_pitch_and_heading();
 
             if (VesselState.isLoadedPrincipia )
@@ -188,7 +185,6 @@ namespace MuMech
             handle_throttle();
 
             converge();
-
         }
 
         /*
@@ -576,6 +572,11 @@ namespace MuMech
                 if ( vesselState.time < last_stage_time + 4 )
                     return;
             }
+
+            // run stage tracking right before the optimizer to synch stats and decide if we dropped a stage or not
+            // NOTE: by doing this we make sure we're not running near staging events where the delta-V display might get wonky
+            // that also means the stage information may not be perfectly up to date tick by tick.
+            core.stageTracking.Update();
 
             p.threadStart(vesselState.time);
             //if ( p.threadStart(vesselState.time) )

--- a/MechJeb2/Pontryagin/PontryaginBase.cs
+++ b/MechJeb2/Pontryagin/PontryaginBase.cs
@@ -14,19 +14,19 @@ namespace MuMech
         FLIGHTANGLE4,
         FLIGHTANGLE5
     }
-    
+
     public abstract class PontryaginBase
     {
         /* dead code but kept as it can be useful for debugging
         protected double LAN(Vector3d r, Vector3d v)
         {
-            var n = new Vector3d(0, -1, 0); // angular momentum vectors point south in KSP and we're in xzy coords 
+            var n = new Vector3d(0, -1, 0); // angular momentum vectors point south in KSP and we're in xzy coords
             Vector3d h = Vector3d.Cross(r, v);
             Vector3d an = -Vector3d.Cross(n, h); // needs to be negative (or swapped) in left handed coordinate system
             return an[2] >= 0 ? Math.Acos(an[0] / an.magnitude) : 2.0 * Math.PI - Math.Acos(an[0] / an.magnitude);
         }
         */
-        
+
         // metrics
         public int    successful_converges;
         public int    max_lm_iteration_count;
@@ -36,7 +36,7 @@ namespace MuMech
         public string last_failure_cause;
         public double last_success_time;
 
-        protected    List<MechJebModuleLogicalStageTracking.Stage> stages => core.stageTracking.Stages;
+        protected    MechJebModuleLogicalStageTracking.StageContainer stages => core.stageTracking.Stages;
         public       double mu;
         public       BCType bctype;
         public       Action<double[], double[], bool> bcfun;
@@ -726,7 +726,7 @@ namespace MuMech
         }
 
         protected abstract void Bootstrap(double t0);
-        
+
         private void Optimize(double t0)
         {
             ArcList last_arcs = null;
@@ -814,6 +814,8 @@ namespace MuMech
                         if (last_arcs.Count < stages.Count)
                         {
                             DebugLog("PVG: adding another available stage to the solution");
+                            DebugLog($"PVG: arcs currently in solution: {last_arcs}");
+                            DebugLog($"PVG: stages in rocket: {stages}");
                             last_arcs.Add(new Arc(this, stage: stages[last_arcs.Count], t0: t0));
                             double[] y0_new = new double[arcIndex(last_arcs, last_arcs.Count)];
                             Array.Copy(y0, 0, y0_new, 0, y0.Length);


### PR DESCRIPTION
Back to a very simple "if we lose a non-zero stage in the delta-V stats then we
dropped a stage" formula.

We no longer even bother with discriminating ullage stages and just let
PVG run on them.

The problem with the whole approach that PVG attempted to do in the past
is that the "running out of deltav in a stage" event is not going to
happen on the same tick as the actual staging event or even request.

It is all complicated by pre and post stage event delays.  And even
something as simple as a heuristic to watch for a stage that is about to
drain and then assuming the subsequent staging event / zero dV stage was
due to a staging event is complicated by Test Flight which may make a
stage suddenly go to zero when it is very far away from its planned
stage time.

This basically drops support for reconfiguration of staging during
flight pretty much entirely.  If you do that, PVG will probably wig out
and need guidance to be reset.

At this point I'm very okay with eating your rocket if you mess with
staging during ascent.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>