### PR TITLE
More attitude control buttons

### DIFF
--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -23,10 +23,10 @@ namespace MuMech
         // this is the public API for ascentPathIdx which is enum type and does wiring
         public ascentType ascentPathIdxPublic {
             get {
-                return (ascentType) this.ascentPathIdx;
+                return (ascentType) ascentPathIdx;
             }
             set {
-                this.ascentPathIdx = (int) value;
+                ascentPathIdx = (int) value;
                 doWiring();
             }
         }
@@ -76,7 +76,7 @@ namespace MuMech
                 _autostage = value;
                 if (changed)
                 {
-                    if (_autostage && this.enabled) core.staging.users.Add(this);
+                    if (_autostage && enabled) core.staging.users.Add(this);
                     if (!_autostage) core.staging.users.Remove(this);
                 }
             }
@@ -334,7 +334,7 @@ namespace MuMech
         {
             if (!vessel.patchedConicsUnlocked() || skipCircularization)
             {
-                this.users.Clear();
+                users.Clear();
                 return;
             }
 
@@ -349,7 +349,7 @@ namespace MuMech
                     if (recorder != null) launchLANDifference = vesselState.orbitLAN - recorder.markLAN;
 
                     //finished circularize
-                    this.users.Clear();
+                    users.Clear();
                     return;
                 }
             }
@@ -423,8 +423,8 @@ namespace MuMech
         {
             if ( type == ascentType.CLASSIC )
                 return core.GetComputerModule<MechJebModuleAscentClassicMenu>();
-            else
-                return null;
+
+            return null;
         }
 
     }
@@ -436,13 +436,11 @@ namespace MuMech
 
     public abstract class MechJebModuleAscentBase : ComputerModule
     {
-        public MechJebModuleAscentBase(MechJebCore core) : base(core) { }
+        protected MechJebModuleAscentBase(MechJebCore core) : base(core) { }
 
-        public string status { get; set; }
+        public string status { get; protected set; }
 
-        public MechJebModuleAscentAutopilot autopilot { get { return core.GetComputerModule<MechJebModuleAscentAutopilot>(); } }
-        private MechJebModuleStageStats stats { get { return core.GetComputerModule<MechJebModuleStageStats>(); } }
-        private FuelFlowSimulation.FuelStats[] vacStats { get { return stats.vacStats; } }
+        protected MechJebModuleAscentAutopilot autopilot => core.GetComputerModule<MechJebModuleAscentAutopilot>();
 
         public abstract bool DriveAscent(FlightCtrlState s);
 

--- a/MechJeb2/MechJebModuleAscentPVG.cs
+++ b/MechJeb2/MechJebModuleAscentPVG.cs
@@ -1,5 +1,6 @@
 using System;
 using KSP.Localization;
+using UnityEngine;
 
 /*
  * Optimized launches for RSS/RO
@@ -184,7 +185,10 @@ namespace MuMech
 
             bool liftedOff = vessel.LiftedOff() && !vessel.Landed && vesselState.altitudeBottom > 5;
 
+            core.attitude.SetActuationControl(liftedOff, liftedOff, liftedOff);
             core.attitude.SetAxisControl(liftedOff, liftedOff, liftedOff && vesselState.altitudeBottom > autopilot.rollAltitude);
+
+            Debug.Log($"actuation control: {core.attitude.ActuationControl}");
 
             if (!liftedOff)
             {

--- a/MechJeb2/MechJebModuleAttitudeController.cs
+++ b/MechJeb2/MechJebModuleAttitudeController.cs
@@ -42,7 +42,9 @@ namespace MuMech
 
         private AttitudeReference _attitudeReference = AttitudeReference.INERTIAL;
 
-        public Vector3d AxisControl { get; private set; } = Vector3d.one;
+        public Vector3d AxisControl        { get; private set; } = Vector3d.one;
+        public Vector3d ActuationControl   { get; private set; } = Vector3d.one;
+        public Vector3d OmegaTarget        { get; private set; } = new Vector3d(double.NaN, double.NaN, double.NaN);
 
         public           BaseAttitudeController       Controller { get; private set; }
         private readonly List<BaseAttitudeController> _controllers = new List<BaseAttitudeController>();
@@ -59,6 +61,9 @@ namespace MuMech
         public override void OnModuleEnabled()
         {
             timeCount = 50;
+            SetAxisControl(true, true, true);
+            SetActuationControl(true, true, true);
+            SetOmegaTarget();
             Controller.OnModuleEnabled();
         }
 
@@ -144,8 +149,17 @@ namespace MuMech
 
         public void SetAxisControl(bool pitch, bool yaw, bool roll)
         {
-            AxisControl = new Vector3d(pitch ? 1 : 0, roll ? 1 : 0, yaw ? 1 : 0
-            );
+            AxisControl = new Vector3d(pitch ? 1 : 0, roll ? 1 : 0, yaw ? 1 : 0);
+        }
+
+        public void SetActuationControl(bool pitch, bool yaw, bool roll)
+        {
+            ActuationControl = new Vector3d(pitch ? 1 : 0, roll ? 1 : 0, yaw ? 1 : 0);
+        }
+
+        public void SetOmegaTarget(double pitch = double.NaN, double yaw = double.NaN, double roll = double.NaN)
+        {
+            OmegaTarget = new Vector3d(pitch, yaw, roll);
         }
 
         public Quaternion attitudeGetReferenceRotation(AttitudeReference reference)
@@ -368,6 +382,8 @@ namespace MuMech
                 Vector3d act;
                 Vector3d deltaEuler;
                 Controller.DrivePre(s, out act, out deltaEuler);
+
+                act.Scale(ActuationControl);
 
                 SetFlightCtrlState(act, deltaEuler, s, 1);
 


### PR DESCRIPTION
Adds the ability to completely suppress actuation on any axis.

When actuation is suppressed the BetterController doesn't windup
on that axis.

Also adds the (presently unused) ability for external modules to
set a manual target omega (to be used for spin-up).

Also re-fixes launch wobblies.  There's now small wobble that happens
when steering kicks in at 5m above the pad, but there's no windup and
we should have lots of torque by then.

I don't want to fly completely unguided until we clear the pad and
roll because asymmetric thrust vehicles will probably start to flip
on launch (they may start to flip a bit already as it is).