### PR TITLE
Fix transfer planner maneuver placement

### DIFF
--- a/MechJeb2.sln.DotSettings
+++ b/MechJeb2.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SOI/@EntryIndexedValue">SOI</s:String></wpf:ResourceDictionary>

--- a/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
+++ b/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
@@ -87,7 +87,7 @@ namespace MuMech
                 return;
 
             if (worker != null)
-                worker.stop = true;
+                worker.Stop = true;
             plot = null;
 
             switch (selectionMode)
@@ -143,13 +143,13 @@ namespace MuMech
             string dv = " - ";
             string departure = " - ";
             string duration = " - ";
-            if (worker.Finished && worker.computed.GetLength(1) == porkchop_Height)
+            if (worker.Finished && worker.Computed.GetLength(1) == porkchop_Height)
             {
                 if (plot == null && Event.current.type == EventType.Layout)
                 {
 
-                    int width = worker.computed.GetLength(0);
-                    int height = worker.computed.GetLength(1);
+                    int width = worker.Computed.GetLength(0);
+                    int height = worker.Computed.GetLength(1);
 
                     if (texture != null && (texture.width != width || texture.height != height))
                     {
@@ -160,13 +160,13 @@ namespace MuMech
                     if (texture == null)
                         texture = new Texture2D(width, height, TextureFormat.RGB24, false);
 
-                    Porkchop.RefreshTexture(worker.computed, texture);
+                    Porkchop.RefreshTexture(worker.Computed, texture);
 
                     plot = new PlotArea(
-                        worker.minDepartureTime,
-                        worker.maxDepartureTime,
-                        worker.minTransferTime,
-                        worker.maxTransferTime,
+                        worker.MinDepartureTime,
+                        worker.MaxDepartureTime,
+                        worker.MinTransferTime,
+                        worker.MaxTransferTime,
                         texture,
                         (xmin, xmax, ymin, ymax) => {
                             minDepartureTime = Math.Max(xmin, universalTime);
@@ -175,7 +175,7 @@ namespace MuMech
                             maxTransferTime = ymax;
                             GUI.changed = true;
                         });
-                    plot.selectedPoint = new int[]{worker.bestDate, worker.bestDuration};
+                    plot.selectedPoint = new int[]{worker.BestDate, worker.BestDuration};
                 }
             }
             if (plot != null)
@@ -184,7 +184,7 @@ namespace MuMech
                 if (plot.hoveredPoint != null)
                     point = plot.hoveredPoint;
 
-                var p = worker.computed[point[0], point[1]];
+                var p = worker.Computed[point[0], point[1]];
                 if (p > 0)
                 {
                     dv = MuUtils.ToSI(p) + "m/s";
@@ -238,16 +238,16 @@ namespace MuMech
             GUILayout.FlexibleSpace();
             if (GUILayout.Button(Localizer.Format("#MechJeb_adv_button1")))//Lowest ΔV
             {
-                plot.selectedPoint = new int[]{ worker.bestDate, worker.bestDuration };
+                plot.selectedPoint = new int[]{ worker.BestDate, worker.BestDuration };
                 GUI.changed = false;
             }
 
             if (GUILayout.Button(Localizer.Format("#MechJeb_adv_button2")))//ASAP
             {
                 int bestDuration = 0;
-                for (int i = 1; i < worker.computed.GetLength(1); i++)
+                for (int i = 1; i < worker.Computed.GetLength(1); i++)
                 {
-                    if (worker.computed[0, bestDuration] > worker.computed[0, i])
+                    if (worker.Computed[0, bestDuration] > worker.Computed[0, i])
                         bestDuration = i;
                 }
                 plot.selectedPoint = new int[]{ 0, bestDuration };
@@ -266,7 +266,7 @@ namespace MuMech
             _draggable = true;
             if (worker != null && !target.NormalTargetExists && Event.current.type == EventType.Layout)
             {
-                worker.stop = true;
+                worker.Stop = true;
                 worker = null;
                 plot = null;
             }
@@ -287,10 +287,10 @@ namespace MuMech
                 break;
             }
 
-            if (worker == null || worker.destinationOrbit != target.TargetOrbit || worker.originOrbit != o)
+            if (worker == null || worker.DestinationOrbit != target.TargetOrbit || worker.OriginOrbit != o)
                 ComputeTimes(o, target.TargetOrbit, universalTime);
 
-            if (GUI.changed || worker == null || worker.destinationOrbit != target.TargetOrbit || worker.originOrbit != o)
+            if (GUI.changed || worker == null || worker.DestinationOrbit != target.TargetOrbit || worker.OriginOrbit != o)
                 ComputeStuff(o, universalTime, target);
         }
 
@@ -310,7 +310,7 @@ namespace MuMech
                 throw new OperationException(Localizer.Format("#MechJeb_adv_Exception2"));//Started computation
             }
 
-            if (worker.arrivalDate < 0 )
+            if (worker.ArrivalDate < 0 )
             {
                 throw new OperationException(Localizer.Format("#MechJeb_adv_Exception3"));//Computation failed
             }
@@ -323,15 +323,15 @@ namespace MuMech
                     throw new OperationException(Localizer.Format("#MechJeb_adv_Exception4"));//Invalid point selected.
                 return worker.OptimizeEjection(
                     worker.DateFromIndex(plot.selectedPoint[0]),
-                    o, worker.destinationOrbit, target.Target as CelestialBody,
+                    o, target.Target as CelestialBody,
                     worker.DateFromIndex(plot.selectedPoint[0]) + worker.DurationFromIndex(plot.selectedPoint[1]),
                     UT, target_PeR, includeCaptureBurn);
             }
 
             return worker.OptimizeEjection(
-                    worker.DateFromIndex(worker.bestDate),
-                    o, worker.destinationOrbit, target.Target as CelestialBody,
-                    worker.DateFromIndex(worker.bestDate) + worker.DurationFromIndex(worker.bestDuration),
+                    worker.DateFromIndex(worker.BestDate),
+                    o, target.Target as CelestialBody,
+                    worker.DateFromIndex(worker.BestDate) + worker.DurationFromIndex(worker.BestDuration),
                     UT, target_PeR, includeCaptureBurn);
         }
     }

--- a/MechJeb2/MechJebModuleAscentAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentAutopilot.cs
@@ -599,7 +599,6 @@ namespace MuMech
                 core.attitude.attitudeTo(desiredThrustVector, AttitudeReference.INERTIAL_COT, this);
             }
 
-
             core.attitude.SetAxisControl(liftedOff, liftedOff, liftedOff && (vesselState.altitudeBottom > autopilot.rollAltitude));
         }
     }

--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -1171,7 +1171,7 @@ namespace MuMech
         // Global OrbitPool for re-using Orbit objects
         //
 
-        private static readonly Pool<Orbit> OrbitPool = new Pool<Orbit>(createOrbit, resetOrbit);
+        public static readonly Pool<Orbit> OrbitPool = new Pool<Orbit>(createOrbit, resetOrbit);
         private static Orbit createOrbit() { return new Orbit(); }
         private static void resetOrbit(Orbit o) { }
 

--- a/MechJeb2/SpaceMath.cs
+++ b/MechJeb2/SpaceMath.cs
@@ -60,26 +60,21 @@ namespace MuMech
         /// <param name="mu">Gravitational parameter of central body.</param>
         /// <param name="r0">Reference position on the parking orbit.</param>
         /// <param name="v0">Reference velocity on the parking orbit.</param>
-        /// <param name="v_inf">Target hyperbolic v-infinity vector.</param>
-        /// <param name="vneg">Velocity on the parking orbit before the burn.</param>
-        /// <param name="vpos">Velocity on the hyperboliic ejection orbit after the burn.</param>
+        /// <param name="vInf">Target hyperbolic v-infinity vector.</param>
+        /// <param name="vNeg">Velocity on the parking orbit before the burn.</param>
+        /// <param name="vPos">Velocity on the hyperboliic ejection orbit after the burn.</param>
         /// <param name="r">Position of the burn.</param>
         /// <param name="dt">Coasting time on the parking orbit from the reference to the burn.</param>
         ///
-        public static void singleImpulseHyperbolicBurn(double mu, Vector3d r0, Vector3d v0, Vector3d v_inf,
-                ref Vector3d vneg, ref Vector3d vpos, ref Vector3d r, ref double dt, bool debug = false)
+        public static void singleImpulseHyperbolicBurn(double mu, Vector3d r0, Vector3d v0, Vector3d vInf,
+                out Vector3d vNeg, out Vector3d vPos, out Vector3d r, out double dt, bool debug = false)
         {
-            double rot, dv;
             Func<double, object?, double> f = delegate(double testrot, object ign) {
-                double dt = 0;
-                Vector3d vneg = new Vector3d();
-                Vector3d vpos = new Vector3d();
-                Vector3d r = new Vector3d();
-                singleImpulseHyperbolicBurn(mu, r0, v0, v_inf, ref vneg, ref vpos, ref r, ref dt, (float)testrot, debug);
+                singleImpulseHyperbolicBurn(mu, r0, v0, vInf, out Vector3d vneg, out Vector3d vpos, out _, out _, (float)testrot, debug);
                 return (vpos - vneg).magnitude;
             };
-            BrentMin.Minimize(f, -30, 30, 1e-6, out rot, out dv, null);
-            singleImpulseHyperbolicBurn(mu, r0, v0, v_inf, ref vneg, ref vpos, ref r, ref dt, (float)rot, debug);
+            BrentMin.Minimize(f, -30, 30, 1e-6, out double rot, out double _, null);
+            singleImpulseHyperbolicBurn(mu, r0, v0, vInf, out vNeg, out vPos, out r, out dt, (float)rot, debug);
         }
 
         /// <summary>
@@ -92,35 +87,58 @@ namespace MuMech
         /// <param name="mu">Gravitational parameter of central body.</param>
         /// <param name="r0">Reference position on the parking orbit.</param>
         /// <param name="v0">Reference velocity on the parking orbit.</param>
-        /// <param name="v_inf">Target hyperbolic v-infinity vector.</param>
+        /// <param name="vInf">Target hyperbolic v-infinity vector.</param>
         /// <param name="vneg">Velocity on the parking orbit before the burn.</param>
         /// <param name="vpos">Velocity on the hyperboliic ejection orbit after the burn.</param>
         /// <param name="r">Position of the burn.</param>
         /// <param name="dt">Coasting time on the parking orbit from the reference to the burn.</param>
         /// <param name="rot">Rotation of hf_hat around v_inf_hat (or r1_hat around h0_hat) [degrees].</param>
         ///
-        public static void singleImpulseHyperbolicBurn(double mu, Vector3d r0, Vector3d v0, Vector3d v_inf,
-                ref Vector3d vneg, ref Vector3d vpos, ref Vector3d r, ref double dt, float rot, bool debug = false)
+        public static void singleImpulseHyperbolicBurn(double mu, Vector3d r0, Vector3d v0, Vector3d vInf, out Vector3d vpos, out Vector3d r, out double dt, float rot, bool debug = false)
+        {
+            singleImpulseHyperbolicBurn(mu, r0, v0, vInf, out _, out vpos, out r, out dt, rot, debug);
+        }
+
+        /// <summary>
+        /// This is the implementation function of the single impulse transfer from an elliptical, non-coplanar parking orbit.
+        ///
+        /// It could be called directly with e.g. rotation of zero to bypass the line search for the rotation which wil be nearly
+        /// optimal in many cases, but fails in the kinds of nearly coplanar conditions which are common in KSP.
+        /// </summary>
+        ///
+        /// <param name="mu">Gravitational parameter of central body.</param>
+        /// <param name="r0">Reference position on the parking orbit (right handed).</param>
+        /// <param name="v0">Reference velocity on the parking orbit (right handed).</param>
+        /// <param name="vInf">Target hyperbolic v-infinity vector (right handed).</param>
+        /// <param name="vNeg">Velocity on the parking orbit before the burn (right handed).</param>
+        /// <param name="vPos">Velocity on the hyperboliic ejection orbit after the burn (right handed).</param>
+        /// <param name="r">Position of the burn. (right handed)</param>
+        /// <param name="dt">Coasting time on the parking orbit from the reference to the burn.</param>
+        /// <param name="rot">Rotation of hf_hat around v_inf_hat. or r1_hat around h0_hat (degrees, right handed).</param>
+        /// <param name="debug">Flag to debug log the parameters this function is called with</param>
+        ///
+        public static void singleImpulseHyperbolicBurn(double mu, Vector3d r0, Vector3d v0, Vector3d vInf,
+                out Vector3d vNeg, out Vector3d vPos, out Vector3d r, out double dt, float rot, bool debug = false)
         {
             if (debug)
             {
-                Debug.Log("[MechJeb] singleImpulseHyperbolicBurn mu = " + mu + " r0 = " + r0 + " v0 = " + v0 + " v_inf = " + v_inf);
+                Debug.Log("[MechJeb] singleImpulseHyperbolicBurn mu = " + mu + " r0 = " + r0 + " v0 = " + v0 + " vInf = " + vInf + " rot = " + rot);
             }
 
             // angular momentum of the parking orbit
-            Vector3d h0 = Vector3d.Cross(r0, v0);
+            Vector3d h0 = RCross(r0, v0);
 
             // semi major axis of parking orbit
             double a0 = 1.0 / (2.0 / r0.magnitude - v0.sqrMagnitude / mu);
 
             // sma of hyperbolic ejection orbit
-            double af = - mu / v_inf.sqrMagnitude;
+            double af = - mu / vInf.sqrMagnitude;
 
             // parking orbit angular momentum unit
             Vector3d h0_hat = h0/h0.magnitude;
 
             // eccentricity vector of the parking orbit
-            Vector3d ecc = Vector3d.Cross(v0,h0)/mu - r0/r0.magnitude;
+            Vector3d ecc = RCross(v0,h0)/mu - r0/r0.magnitude;
 
             // eccentricity of the parking orbit.
             double e0 = ecc.magnitude;
@@ -135,24 +153,29 @@ namespace MuMech
             else
                 rp0_hat = r0/r0.magnitude;
 
+            if (debug)
+            {
+                Debug.Log("rp0hat: " + rp0_hat + " e0: " + Math.Abs(e0));
+            }
+
             // parking orbit periapsis velocity unit vector
-            Vector3d vp0_hat = Vector3d.Cross(h0, rp0_hat).normalized;
+            Vector3d vp0_hat = RCross(h0, rp0_hat).normalized;
 
             // direction of hyperbolic v-infinity vector
-            Vector3d v_inf_hat = v_inf.normalized;
+            Vector3d v_inf_hat = vInf.normalized;
 
             // 2 cases for finding hf_hat
             Vector3d hf_hat;
             if ( Math.Abs(Vector3d.Dot(h0_hat, v_inf_hat)) == 1 )
             {
                 // 90 degree plane change case
-                hf_hat = Vector3d.Cross(rp0_hat, v_inf_hat);
+                hf_hat = RCross(rp0_hat, v_inf_hat);
                 hf_hat = hf_hat.normalized;
             }
             else
             {
                 // general case
-                hf_hat = Vector3d.Cross(v_inf_hat, Vector3d.Cross(h0_hat, v_inf_hat));
+                hf_hat = RCross(v_inf_hat, RCross(h0_hat, v_inf_hat));
                 hf_hat = hf_hat.normalized;
             }
 
@@ -161,20 +184,20 @@ namespace MuMech
             if ( Math.Abs(Vector3d.Dot(h0_hat, v_inf_hat)) > 2.22044604925031e-16 )
             {
                 // if the planes are not coincident, rotate hf_hat by applying rodriguez formula around v_inf_hat
-                hf_hat = Quaternion.AngleAxis(rot, v_inf_hat) * hf_hat;
+                hf_hat = Quaternion.AngleAxis(-rot, v_inf_hat) * hf_hat;
                 // unit vector pointing at the position of the burn on the parking orbit
-                r1_hat = Math.Sign(Vector3d.Dot(h0_hat, v_inf_hat)) * Vector3d.Cross(h0_hat, hf_hat).normalized;
+                r1_hat = Math.Sign(Vector3d.Dot(h0_hat, v_inf_hat)) * RCross(h0_hat, hf_hat).normalized;
             }
             else
             {
                 // unit vector pointing at the position of the burn on the parking orbit
-                r1_hat = Vector3d.Cross(v_inf_hat, hf_hat).normalized;
+                r1_hat = RCross(v_inf_hat, hf_hat).normalized;
                 // if the planes are coincident, rotate r1_hat by applying rodriguez formula around h0_hat
-                r1_hat = Quaternion.AngleAxis(rot, h0_hat) * r1_hat;
+                r1_hat = Quaternion.AngleAxis(-rot, h0_hat) * r1_hat;
             }
 
             // true anomaly of r1 on the parking orbit
-            double nu_10 = Math.Sign(Vector3d.Dot(h0_hat, Vector3d.Cross(rp0_hat, r1_hat))) * Math.Acos(Vector3d.Dot(rp0_hat,r1_hat));
+            double nu_10 = Math.Sign(Vector3d.Dot(h0_hat, RCross(rp0_hat, r1_hat))) * Math.Acos(Vector3d.Dot(rp0_hat,r1_hat));
 
             // length of the position vector of the burn on the parking orbit
             double r1 = p0 / ( 1 + e0 * Math.Cos(nu_10) );
@@ -182,10 +205,15 @@ namespace MuMech
             // position of the burn
             r = r1 * r1_hat;
 
+            if (debug)
+            {
+                Debug.Log("position of burn: " + r);
+            }
+
             // constant
             double k = - af / r1;
 
-            // angle between v_inf and the r1 burn
+            // angle between vInf and the r1 burn
             double delta_nu = Math.Acos(MuUtils.Clamp(Vector3d.Dot(r1_hat, v_inf_hat), -1, 1));
 
             // eccentricity of the hyperbolic ejection orbit
@@ -197,7 +225,7 @@ namespace MuMech
             // semilatus rectum of hyperbolic ejection orbit
             double pf = af * ( 1 - ef*ef );
 
-            // true anomaly of the v_inf on the hyperbolic ejection orbit
+            // true anomaly of the vInf on the hyperbolic ejection orbit
             double nu_inf = Math.Acos(-1/ef);
 
             // true anomaly of the burn on the hyperbolic ejection orbit
@@ -207,7 +235,7 @@ namespace MuMech
             double delta = 2 * Math.Asin(1/ef);
 
             // incoming hyperbolic velocity unit vector
-            Vector3d v_inf_minus_hat = Math.Cos(delta) * v_inf_hat + Math.Sin(delta) * Vector3d.Cross(v_inf_hat, hf_hat);
+            Vector3d v_inf_minus_hat = Math.Cos(delta) * v_inf_hat + Math.Sin(delta) * RCross(v_inf_hat, hf_hat);
 
             // periapsis position and velocity vectors of the hyperbolic ejection orbit
             Vector3d rpf_hat = v_inf_minus_hat - v_inf_hat;
@@ -216,23 +244,31 @@ namespace MuMech
             vpf_hat = vpf_hat / vpf_hat.magnitude;
 
             // compute the velocity on the hyperbola and the parking orbit
-            vpos = Math.Sqrt(mu/pf) * ( -Math.Sin(nu_1f) * rpf_hat + ( ef + Math.Cos(nu_1f) ) * vpf_hat );
-            vneg = Math.Sqrt(mu/p0) * ( -Math.Sin(nu_10) * rp0_hat + ( e0 + Math.Cos(nu_10) ) * vp0_hat );
+            vPos = Math.Sqrt(mu/pf) * ( -Math.Sin(nu_1f) * rpf_hat + ( ef + Math.Cos(nu_1f) ) * vpf_hat );
+            vNeg = Math.Sqrt(mu/p0) * ( -Math.Sin(nu_10) * rp0_hat + ( e0 + Math.Cos(nu_10) ) * vp0_hat );
 
             // compute nu of the reference position on the parking orbit
             Vector3d r0_hat = r0/r0.magnitude;
-            double nu0 = Math.Sign(Vector3d.Dot(h0_hat, Vector3d.Cross(rp0_hat, r0_hat))) * Math.Acos(Vector3d.Dot(rp0_hat,r0_hat));
+            double nu0 = Math.Sign(Vector3d.Dot(h0_hat, RCross(rp0_hat, r0_hat))) * Math.Acos(Vector3d.Dot(rp0_hat,r0_hat));
 
-            // mean angular motion of the parking orbit
+            // mean angular motion of the parking orbit (rad/time)
             double n = 1/Math.Sqrt( a0*a0*a0 / mu );
 
-            // eccentric anomalies of reference position and r1 on the parking orbit
+            // eccentric anomalies of reference position and r1 on the parking orbit (rad)
             double E0 = Math.Atan2(Math.Sqrt(1 - e0*e0) * Math.Sin(nu0), e0 + Math.Cos(nu0));
             double E1 = Math.Atan2(Math.Sqrt(1 - e0*e0) * Math.Sin(nu_10), e0 + Math.Cos(nu_10));
 
-            // mean anomalies of reference position and r1 on the parking orbit
+            // mean anomalies of reference position and r1 on the parking orbit (rad)
             double M0 = E0 - e0 * Math.Sin( E0 );
             double M1 = E1 - e0 * Math.Sin( E1 );
+
+            if (debug)
+            {
+                Debug.Log("mean motion: " + n);
+                Debug.Log("true anomaly of ref position: " + nu0 + " true anomaly of burn: " + nu_10);
+                Debug.Log("eccentric anomaly of ref position: " + E0 + " eccentric anomaly of burn: " + E1);
+                Debug.Log("mean anomaly of ref posotion: " + M0 + " mean anomaly of burn: " + M1);
+            }
 
             // coast time on the parking orbit
             dt = ( M1 - M0 ) / n;
@@ -243,8 +279,14 @@ namespace MuMech
 
             if (debug)
             {
-                Debug.Log("[MechJeb] singleImpulseHyperbolicBurn vneg = " + vneg + " vpos = " + vpos + " r = " + r + " dt = " + dt);
+                Debug.Log("[MechJeb] singleImpulseHyperbolicBurn vNeg = " + vNeg + " vPos = " + vPos + " r = " + r + " dt = " + dt);
             }
+        }
+
+        // right handed cross product
+        private static Vector3d RCross(Vector3d one, Vector3d two)
+        {
+            return -Vector3d.Cross(one, two);
         }
     }
 }


### PR DESCRIPTION
1.  Fixes yet another painful annoying inverse rotation bug in
ComputeEjectionManeuver by converting from GetStateVectorsAtUT to
getRelativePositionAtUT and getOrbitalVelocityAtUT.  I've forgotten
which way is which but the latter two agree with the coordinate system
of the rest of the code in the transfer planner.

2. Converts to using a proper NLP optimizer with a cost function and
a periapsis constraint.  There's two NLPs here, one to nudge the
intercept into the SOI if the initial guess is too far away and one
to do the periapsis constraint.  After 1.12.x is the only supported
KSP version Orbit.NextCloseApproachTime() could be used for trajectories
which do not intersect the SOI to create a smooth NLP against the
periapsis radius to combine the NLPs into a single one.

The NLP solver works under all the use cases I've tried so far, but it
is slow and beachballs for awhile.  It is also not quite as accurate as
I'd like.  There may be room for perf improvements in how the NLP
solvers in alglib are used, but its the first time I've tried them in
"production".

This may not work well at all in KSP 1.10.x on RSS/RO due to the single
precision floating point operations in the maneuver planner.  Sorta
don't care though, it all needs to be upgraded.

Bunch of unrelated cleanup.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>