### PR TITLE
Cached deployable handler

### DIFF
--- a/MechJeb2/ComputerModule.cs
+++ b/MechJeb2/ComputerModule.cs
@@ -94,6 +94,14 @@ namespace MuMech
         {
         }
 
+        public virtual void OnVesselWasModified(Vessel v)
+        {
+        }
+
+        public virtual void OnVesselStandardModification(Vessel v)
+        {
+        }
+
         public virtual void OnStart(PartModule.StartState state)
         {
         }

--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -509,6 +509,8 @@ namespace MuMech
             GameEvents.onShowUI.Add(OnShowGUI);
             GameEvents.onHideUI.Add(OnHideGUI);
             GameEvents.onVesselChange.Add(UnlockControl);
+            GameEvents.onVesselWasModified.Add(OnVesselWasModified);
+            GameEvents.onVesselStandardModification.Add(OnVesselStandardModification);
 
             lastSettingsSaveTime = Time.time;
 
@@ -1045,6 +1047,8 @@ namespace MuMech
             GameEvents.onShowUI.Remove(OnShowGUI);
             GameEvents.onHideUI.Remove(OnHideGUI);
             GameEvents.onVesselChange.Remove(UnlockControl);
+            GameEvents.onVesselWasModified.Remove(OnVesselWasModified);
+            GameEvents.onVesselStandardModification.Remove(OnVesselStandardModification);
 
             if (weLockedInputs)
             {
@@ -1241,6 +1245,52 @@ namespace MuMech
             weLockedInputs = false;
         }
 
+        private void OnVesselWasModified(Vessel v)
+        {
+            if (v == vessel && this == vessel.GetMasterMechJeb())
+            {
+                string name = "MechJebCore.OnVesselWasModified";
+                Profiler.BeginSample(name);
+                foreach (ComputerModule module in GetComputerModules<ComputerModule>().Where(x => x.enabled))
+                {
+                    Profiler.BeginSample(module.profilerName);
+                    try
+                    {
+                        module.OnVesselWasModified(v);
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogError($"MechJeb module {module.GetType().Name} threw an exception in {name}: {e}");
+                    }
+                    Profiler.EndSample();
+                }
+                Profiler.EndSample();
+            }
+        }
+
+        // Copy-pasta, but preferred over a Reflection-based approach (pass MethodInfos around)
+        private void OnVesselStandardModification(Vessel v)
+        {
+            if (v == vessel && this == vessel.GetMasterMechJeb())
+            {
+                string name = "MechJebCore.OnVesselStandardModification";
+                Profiler.BeginSample(name);
+                foreach (ComputerModule module in GetComputerModules<ComputerModule>().Where(x => x.enabled))
+                {
+                    Profiler.BeginSample(module.profilerName);
+                    try
+                    {
+                        module.OnVesselStandardModification(v);
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogError($"MechJeb module {module.GetType().Name} threw an exception in {name}: {e}");
+                    }
+                    Profiler.EndSample();
+                }
+                Profiler.EndSample();
+            }
+        }
 
         public static new void print(object message)
         {

--- a/MechJeb2/MechJebModuleDeployableController.cs
+++ b/MechJeb2/MechJebModuleDeployableController.cs
@@ -111,11 +111,11 @@ namespace MuMech
                 prev_autoDeploy = false;
             }
 
-            bool allRetracted = AllRetracted();
-            if (extended != !allRetracted)  //State changed?
-                buttonText=getButtonText(allRetracted ? DeployablePartState.RETRACTED : DeployablePartState.EXTENDED);
+            bool extendedThisPass = !AllRetracted();
+            if (extended != extendedThisPass)
+                buttonText = getButtonText(extendedThisPass ? DeployablePartState.EXTENDED : DeployablePartState.RETRACTED);
 
-            extended = !allRetracted;
+            extended = extendedThisPass;
         }
 
         protected bool ExtendingOrRetracting()

--- a/MechJeb2/MechJebModuleDeployableController.cs
+++ b/MechJeb2/MechJebModuleDeployableController.cs
@@ -25,7 +25,17 @@ namespace MuMech
         public bool prev_autoDeploy = true;
 
         protected string type = "";
-        
+
+        protected List<ModuleDeployablePart> cachedPartModules = new List<ModuleDeployablePart>(16);
+        protected void DiscoverDeployablePartModules()
+        {
+            cachedPartModules.Clear();
+            foreach (Part p in vessel.Parts)
+                foreach (PartModule pm in p.Modules)
+                    if (pm != null && pm is ModuleDeployablePart mdp && isModules(mdp))
+                        cachedPartModules.Add(mdp);
+        }
+
         protected bool isDeployable(ModuleDeployablePart sa)
         {
             return (sa.Events["Extend"].active || sa.Events["Retract"].active);
@@ -33,59 +43,22 @@ namespace MuMech
 
         public void ExtendAll()
         {
-            List<Part> vp = vessel.parts;
-            for (int i = 0; i < vp.Count; i++)
-            {
-                Part p = vp[i];
-
-                if (p.ShieldedFromAirstream)
-                    return;
-                
-                for (int j = 0; j < p.Modules.Count; j++)
-                {
-                    ModuleDeployablePart mdp = p.Modules[j] as ModuleDeployablePart;
-                    if (mdp != null && isModules(mdp) && isDeployable(mdp))
-                    {
-                        mdp.Extend();
-                    }
-                }
-            };
+            foreach (ModuleDeployablePart mdp in cachedPartModules)
+                if (mdp != null && isDeployable(mdp) && !mdp.part.ShieldedFromAirstream)
+                    mdp.Extend();
         }
         
         public void RetractAll()
         {
-            List<Part> vp = vessel.parts;
-            for (int i = 0; i < vp.Count; i++) {
-                Part p = vp[i];
-
-                if (p.ShieldedFromAirstream)
-                    return;
-
-                for (int j = 0; j < p.Modules.Count; j++)
-                {
-                    ModuleDeployablePart mdp = p.Modules[j] as ModuleDeployablePart;
-                    if (mdp != null && isModules(mdp) && isDeployable(mdp))
-                    {
-                        mdp.Retract();
-                    }
-                }
-            }
+            foreach (ModuleDeployablePart mdp in cachedPartModules)
+                if (mdp != null && isDeployable(mdp) && !mdp.part.ShieldedFromAirstream)
+                    mdp.Retract();
         }
-
         public bool AllRetracted()
         {
-            for (int i = 0; i < vessel.parts.Count; i++)
-            {
-                Part p = vessel.parts[i];
-                for (int j = 0; j < p.Modules.Count; j++)
-                {
-                    ModuleDeployablePart mdp = p.Modules[j] as ModuleDeployablePart;
-                    if (mdp != null && isModules(mdp) && isDeployable(mdp) && mdp.deployState != ModuleDeployablePart.DeployState.RETRACTED)
-                    {
-                        return false;
-                    }
-                }
-            }
+            foreach (ModuleDeployablePart mdp in cachedPartModules)
+                if (mdp != null && isDeployable(mdp) && mdp.deployState != ModuleDeployablePart.DeployState.RETRACTED)
+                    return false;
             return true;
         }
 
@@ -139,31 +112,18 @@ namespace MuMech
             }
 
             bool allRetracted = AllRetracted();
-            if (allRetracted)
-                buttonText = getButtonText(DeployablePartState.RETRACTED);
-            else
-                buttonText = getButtonText(DeployablePartState.EXTENDED);
+            if (extended != !allRetracted)  //State changed?
+                buttonText=getButtonText(allRetracted ? DeployablePartState.RETRACTED : DeployablePartState.EXTENDED);
 
             extended = !allRetracted;
         }
 
         protected bool ExtendingOrRetracting()
         {
-            for (int i = 0; i < vessel.parts.Count; i++)
-            {
-                Part p = vessel.parts[i];
-                for (int j = 0; j < p.Modules.Count; j++)
-                {
-                    ModuleDeployablePart mdp = p.Modules[j] as ModuleDeployablePart;
-
-                    if (mdp != null && isModules(mdp) && isDeployable(mdp)
-                        && (mdp.deployState == ModuleDeployablePart.DeployState.EXTENDING
-                         || mdp.deployState == ModuleDeployablePart.DeployState.RETRACTING))
-                    {
-                        return true;
-                    }
-                }
-            }
+            foreach (ModuleDeployablePart mdp in cachedPartModules)
+                if (mdp != null && isDeployable(mdp) 
+                    && (mdp.deployState == ModuleDeployablePart.DeployState.EXTENDING || mdp.deployState == ModuleDeployablePart.DeployState.RETRACTING))
+                    return true;
             return false;
         }
 
@@ -177,5 +137,20 @@ namespace MuMech
         }
 
         protected abstract string getButtonText(DeployablePartState deployablePartState);
+        public override void OnStart(PartModule.StartState state)
+        {
+            base.OnStart(state);
+            if (HighLogic.LoadedSceneIsFlight)
+            {
+                DiscoverDeployablePartModules();
+                GameEvents.onVesselWasModified.Add(OnVesselModified);
+            }
+        }
+        public override void OnDestroy()
+        {
+            if (HighLogic.LoadedSceneIsFlight) GameEvents.onVesselWasModified.Remove(OnVesselModified);
+            base.OnDestroy();
+        }
+        public void OnVesselModified(Vessel v) => DiscoverDeployablePartModules();
     }
 }

--- a/MechJeb2/MechJebModuleDeployableController.cs
+++ b/MechJeb2/MechJebModuleDeployableController.cs
@@ -141,16 +141,8 @@ namespace MuMech
         {
             base.OnStart(state);
             if (HighLogic.LoadedSceneIsFlight)
-            {
                 DiscoverDeployablePartModules();
-                GameEvents.onVesselWasModified.Add(OnVesselModified);
-            }
         }
-        public override void OnDestroy()
-        {
-            if (HighLogic.LoadedSceneIsFlight) GameEvents.onVesselWasModified.Remove(OnVesselModified);
-            base.OnDestroy();
-        }
-        public void OnVesselModified(Vessel v) => DiscoverDeployablePartModules();
+        public override void OnVesselWasModified(Vessel v) => DiscoverDeployablePartModules();
     }
 }


### PR DESCRIPTION
Don't iterate every frame over every Part&PartModule.  Instead, discover the list of valid ones and maintain that cache.  Invalidate the cache in response to OnVesselModified
Bugfix: Don't abort ExtendAll and RetractAll mid-way when *any* part is found to be shielded.
Rewrite ExtendAll/RetractAll/ExtendingOrRetracting/AllRetracted to use the cache