### PR TITLE
Basic Caching for StageController

### DIFF
--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -319,7 +319,7 @@ namespace MuMech
         public bool InverseStageDecouplesActiveOrIdleEngineOrTank(int inverseStage, List<int> tankResources, List<ModuleEngines> activeModuleEngines)
         {
             foreach (PartModule pm in allDecouplers)
-                if (pm.part.inverseStage == inverseStage && pm.part.IsUnfiredDecoupler(out Part decoupledPart) && HasActiveOrIdleEngineOrTankDescendant(decoupledPart, tankResources, activeModuleEngines))
+                if (pm.part.inverseStage == inverseStage && pm.IsUnfiredDecoupler(out Part decoupledPart) && HasActiveOrIdleEngineOrTankDescendant(decoupledPart, tankResources, activeModuleEngines))
                     return true;
             return false;
         }
@@ -436,7 +436,7 @@ namespace MuMech
         public bool InverseStageDecouplesDeactivatedEngineOrTank(int inverseStage)
         {
             foreach (PartModule pm in allDecouplers)
-                if (pm.part.inverseStage == inverseStage && pm.part.IsUnfiredDecoupler(out Part decoupledPart) && HasDeactivatedEngineOrTankDescendant(decoupledPart))
+                if (pm.part.inverseStage == inverseStage && pm.IsUnfiredDecoupler(out Part decoupledPart) && HasDeactivatedEngineOrTankDescendant(decoupledPart))
                     return true;
             return false;
         }

--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -4,6 +4,7 @@ using KSP.UI.Screens;
 using Smooth.Slinq;
 using UnityEngine;
 using KSP.Localization;
+using System.Linq;
 
 namespace MuMech
 {
@@ -47,8 +48,14 @@ namespace MuMech
         // this is for other modules to temporarily disable autostaging (e.g. PVG coast phases)
         public int autostageLimitInternal = 0;
 
-        private readonly List<ModuleEngines> activeModuleEngines = new List<ModuleEngines>();
-        private readonly List<int> burnedResources = new List<int>();
+        private readonly List<ModuleEngines> activeModuleEngines = new List<ModuleEngines>(16);
+        private readonly List<ModuleEngines> allModuleEngines = new List<ModuleEngines>(16);
+        private readonly List<int> burnedResources = new List<int>(16);
+        private readonly Dictionary<int, bool> inverseStageHasEngines = new Dictionary<int, bool>(16);
+        private readonly Dictionary<int, bool> inverseStageFiresDecouplerCache = new Dictionary<int, bool>(16);
+        private readonly Dictionary<int, bool> inverseStageReleasesClampsCache = new Dictionary<int, bool>(16);
+        private readonly Dictionary<int, bool> hasStayingChutesCache = new Dictionary<int, bool>(16);
+        private readonly Dictionary<int, bool> hasFairingCache = new Dictionary<int, bool>(16);
         private MechJebModuleStageStats stats { get { return core.GetComputerModule<MechJebModuleStageStats>(); } }
         private FuelFlowSimulation.FuelStats[] vacStats { get { return stats.vacStats; } }
 
@@ -68,6 +75,36 @@ namespace MuMech
 
             GameEvents.onStageActivate.Add(stageActivate);
             GameEvents.onVesselResumeStaging.Add(VesselResumeStage);
+            if (HighLogic.LoadedSceneIsFlight)
+                GameEvents.onVesselWasModified.Add(OnVesselModified);
+        }
+
+        private void OnVesselModified(Vessel v)
+        {
+            if (vessel == v)
+            {
+                ClearCaches();
+                BuildEnginesCache(allModuleEngines);
+            }
+        }
+
+        private void BuildEnginesCache(List<ModuleEngines> engines)
+        {
+            engines.Clear();
+            foreach (Part p in vessel.Parts)
+                if (p.IsEngine() && !p.IsSepratron())
+                    foreach (PartModule pm in p.Modules)
+                        if (pm is ModuleEngines eng)
+                            engines.Add(eng);
+        }
+
+        private void ClearCaches()
+        {
+            inverseStageHasEngines.Clear();
+            inverseStageFiresDecouplerCache.Clear();
+            inverseStageReleasesClampsCache.Clear();
+            hasStayingChutesCache.Clear();
+            hasFairingCache.Clear();
         }
 
         private void VesselResumeStage(Vessel data)
@@ -82,6 +119,7 @@ namespace MuMech
         {
             GameEvents.onStageActivate.Remove(stageActivate);
             GameEvents.onVesselResumeStaging.Remove(VesselResumeStage);
+            GameEvents.onVesselWasModified.Remove(OnVesselModified);
         }
 
         private void stageActivate(int data)
@@ -177,17 +215,17 @@ namespace MuMech
                 return;
 
             //don't decouple active or idle engines or tanks
-            UpdateActiveModuleEngines();
+            UpdateActiveModuleEngines(allModuleEngines);
             UpdateBurnedResources();
-            if (InverseStageDecouplesActiveOrIdleEngineOrTank(vessel.currentStage - 1, vessel, burnedResources, activeModuleEngines) && !InverseStageReleasesClamps(vessel.currentStage - 1, vessel))
+            if (InverseStageDecouplesActiveOrIdleEngineOrTank(vessel.currentStage - 1, vessel, burnedResources, activeModuleEngines) && !InverseStageReleasesClamps(vessel.currentStage - 1))
                 return;
 
             // prevent staging when the current stage has active engines and the next stage has any engines (but not decouplers or clamps)
-            if (hotStaging && InverseStageHasActiveEngines(vessel.currentStage, vessel) && InverseStageHasEngines(vessel.currentStage - 1, vessel) && !InverseStageFiresDecoupler(vessel.currentStage - 1, vessel) && !InverseStageReleasesClamps(vessel.currentStage - 1, vessel) && LastNonZeroDVStageBurnTime() > hotStagingLeadTime)
+            if (hotStaging && InverseStageHasActiveEngines(vessel.currentStage) && InverseStageHasEngines(vessel.currentStage - 1) && !InverseStageFiresDecoupler(vessel.currentStage - 1) && !InverseStageReleasesClamps(vessel.currentStage - 1) && LastNonZeroDVStageBurnTime() > hotStagingLeadTime)
                 return;
 
             //Don't fire a stage that will activate a parachute, unless that parachute gets decoupled:
-            if (HasStayingChutes(vessel.currentStage - 1, vessel))
+            if (HasStayingChutes(vessel.currentStage - 1))
                 return;
 
             //Always drop deactivated engines or tanks
@@ -195,12 +233,12 @@ namespace MuMech
             {
                 //only decouple fairings if the dynamic pressure, altitude, and aerothermal flux conditions are respected
                 if ((core.vesselState.dynamicPressure > fairingMaxDynamicPressure || core.vesselState.altitudeASL < fairingMinAltitude || core.vesselState.freeMolecularAerothermalFlux > fairingMaxAerothermalFlux) &&
-                    HasFairing(vessel.currentStage - 1, vessel))
+                    HasFairing(vessel.currentStage - 1))
                     return;
 
                 //only release launch clamps if we're at nearly full thrust
                 if (vesselState.thrustCurrent / vesselState.thrustAvailable < clampAutoStageThrustPct &&
-                    InverseStageReleasesClamps(vessel.currentStage - 1, vessel))
+                    InverseStageReleasesClamps(vessel.currentStage - 1))
                     return;
             }
 
@@ -210,7 +248,7 @@ namespace MuMech
             {
                 if (vesselState.time - stageCountdownStart > autostagePreDelay)
                 {
-                    if (InverseStageFiresDecoupler(vessel.currentStage - 1, vessel))
+                    if (InverseStageFiresDecoupler(vessel.currentStage - 1))
                     {
                         //if we decouple things, delay the next stage a bit to avoid exploding the debris
                         lastStageTime = vesselState.time;
@@ -275,53 +313,33 @@ namespace MuMech
             return 0;
         }
 
-        public static bool InverseStageHasActiveEngines(int inverseStage, Vessel v)
+        // allModuleEngines => IsEngine() && !IsSepratron()
+        public bool InverseStageHasActiveEngines(int inverseStage)
         {
-            for (int i = 0; i < v.parts.Count; i++)
-            {
-                Part p = v.parts[i];
-                if (p.inverseStage == inverseStage && p.IsEngine() && p.EngineHasFuel() && !p.IsSepratron())
-                {
+            foreach (ModuleEngines engine in allModuleEngines)
+                if (engine.part.inverseStage == inverseStage && engine.EngineHasFuel())
                     return true;
-                }
-            }
             return false;
         }
 
-        public static bool InverseStageHasEngines(int inverseStage, Vessel v)
+        public bool InverseStageHasEngines(int inverseStage)
         {
-            for (int i = 0; i < v.parts.Count; i++)
-            {
-                Part p = v.parts[i];
-                if (p.inverseStage == inverseStage && p.IsEngine() && !p.IsSepratron())
-                {
-                    return true;
-                }
-            }
-            return false;
+            if (inverseStageHasEngines.TryGetValue(inverseStage, out bool result))
+                return result;
+            result = allModuleEngines.FirstOrDefault(me => me.part.inverseStage == inverseStage) != null;
+            inverseStageHasEngines.Add(inverseStage, result);
+            return result;
         }
 
-        public void UpdateActiveModuleEngines()
+        public void UpdateActiveModuleEngines(List<ModuleEngines> allEngines)
         {
             activeModuleEngines.Clear();
-            var activeEngines = vessel.parts.Slinq().Where(p => p.inverseStage >= vessel.currentStage && p.IsEngine() && !p.IsSepratron() &&
-                                                        !p.IsDecoupledInStage(vessel.currentStage - 1));
-            // Part Modules lacks of List access shows the limits of slinq...
-            while (activeEngines.current.isSome)
+            foreach (ModuleEngines engine in allEngines)
             {
-                Part p = activeEngines.current.value;
-
-                for (int i = 0; i < p.Modules.Count; i++)
-                {
-                    ModuleEngines eng = p.Modules[i] as ModuleEngines;
-                    if (eng != null && eng.isEnabled)
-                    {
-                        activeModuleEngines.Add(eng);
-                    }
-                }
-                activeEngines.Skip();
+                Part p = engine.part;
+                if (p.inverseStage >= vessel.currentStage && p.IsEngine() && !p.IsSepratron() && !p.IsDecoupledInStage(vessel.currentStage - 1) && engine.isEnabled)
+                    activeModuleEngines.Add(engine);
             }
-            activeEngines.Dispose();
         }
 
         // Find resources burned by engines that will remain after staging (so we wait until tanks are empty before releasing drop tanks)
@@ -376,29 +394,23 @@ namespace MuMech
 
         //determine whether activating inverseStage will fire any sort of decoupler. This
         //is used to tell whether we should delay activating the next stage after activating inverseStage
-        public static bool InverseStageFiresDecoupler(int inverseStage, Vessel v)
+        public bool InverseStageFiresDecoupler(int inverseStage)
         {
-            for (int i = 0; i < v.parts.Count; i++)
-            {
-                Part p = v.parts[i];
-                if (p.inverseStage == inverseStage && p.IsUnfiredDecoupler(out Part decoupled))
-                    return true;
-            }
-            return false;
+            if (inverseStageFiresDecouplerCache.TryGetValue(inverseStage, out bool result))
+                return result;
+            result = vessel.Parts.FirstOrDefault(p => p.inverseStage == inverseStage && p.IsUnfiredDecoupler(out Part _)) != null;
+            inverseStageFiresDecouplerCache.Add(inverseStage, result);
+            return result;
         }
 
         //determine whether activating inverseStage will release launch clamps
-        public static bool InverseStageReleasesClamps(int inverseStage, Vessel v)
+        public bool InverseStageReleasesClamps(int inverseStage)
         {
-            for (int i = 0; i < v.parts.Count; i++)
-            {
-                Part p = v.parts[i];
-                if (p.inverseStage == inverseStage && p.IsLaunchClamp())
-                {
-                    return true;
-                }
-            }
-            return false;
+            if (inverseStageReleasesClampsCache.TryGetValue(inverseStage, out bool result))
+                return result;
+            result = vessel.Parts.FirstOrDefault(p => p.inverseStage == inverseStage && p.IsLaunchClamp()) != null;
+            inverseStageReleasesClampsCache.Add(inverseStage, result);
+            return result;
         }
 
         //determine whether inverseStage sheds a dead engine
@@ -447,28 +459,24 @@ namespace MuMech
         }
 
         //determine if there are chutes being fired that wouldn't also get decoupled
-        public static bool HasStayingChutes(int inverseStage, Vessel v)
+        public bool HasStayingChutes(int inverseStage)
         {
-            var chutes = v.parts.FindAll(p => p.inverseStage == inverseStage && p.IsParachute());
-
-            for (int i = 0; i < chutes.Count; i++)
-            {
-                Part p = chutes[i];
-                if (!p.IsDecoupledInStage(inverseStage))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            if (hasStayingChutesCache.TryGetValue(inverseStage, out bool result))
+                return result;
+            result = vessel.Parts.FirstOrDefault(p => p.inverseStage == inverseStage && p.IsParachute() && !p.IsDecoupledInStage(inverseStage)) != null;
+            hasStayingChutesCache.Add(inverseStage, result);
+            return result;
         }
 
         // determine if there is a fairing to be deployed
-        public static bool HasFairing(int inverseStage, Vessel v)
+        public bool HasFairing(int inverseStage)
         {
-            return v.parts.Slinq().Any((p,_inverseStage) =>
-                p.inverseStage == _inverseStage &&
-                (p.HasModule<ModuleProceduralFairing>() || (VesselState.isLoadedProceduralFairing && p.Modules.Contains("ProceduralFairingDecoupler"))), inverseStage);
+            if (hasFairingCache.TryGetValue(inverseStage, out bool result))
+                return result;
+            result = vessel.Parts.FirstOrDefault(p => p.inverseStage == inverseStage && p.IsParachute() 
+                                                && (p.HasModule<ModuleProceduralFairing>() || (VesselState.isLoadedProceduralFairing && p.Modules.Contains("ProceduralFairingDecoupler")))) != null;
+            hasFairingCache.Add(inverseStage, result);
+            return result;
         }
     }
 }

--- a/MechJeb2/PartExtensions.cs
+++ b/MechJeb2/PartExtensions.cs
@@ -42,16 +42,12 @@ namespace MuMech
             return mass;
         }
 
+        public static bool EngineHasFuel(this ModuleEngines me) => !me.getFlameoutState && !me.engineShutdown;
+
         public static bool EngineHasFuel(this Part p)
         {
-            for (int i = 0; i < p.Modules.Count; i++)
-            {
-                PartModule m = p.Modules[i];
-                ModuleEngines eng = m as ModuleEngines;
-                if (eng != null)
-                    return !eng.getFlameoutState && !eng.engineShutdown;
-            }
-            return false;
+            ModuleEngines eng = p.FindModuleImplementing<ModuleEngines>();
+            return eng != null && eng.EngineHasFuel();
         }
 
         public static double FlowRateAtConditions(this ModuleEngines e, double throttle, double flowMultiplier)

--- a/MechJeb2/PartExtensions.cs
+++ b/MechJeb2/PartExtensions.cs
@@ -102,7 +102,7 @@ namespace MuMech
         {
             return p != null && (p.FindModuleImplementing<ModuleDecouplerBase>() != null || 
                                  p.FindModuleImplementing<ModuleDockingNode>() != null || 
-                                 p.Modules["ProceduralFairingDecoupler"] != null);
+                                 p.Modules.Contains("ProceduralFairingDecoupler"));
         }
 
         public static bool IsUnfiredDecoupler(this ModuleDecouplerBase decoupler, out Part decoupledPart)

--- a/MechJeb2/PartExtensions.cs
+++ b/MechJeb2/PartExtensions.cs
@@ -4,27 +4,8 @@ namespace MuMech
 {
     public static class PartExtensions
     {
-        public static bool HasModule<T>(this Part part) where T : PartModule
-        {
-            for (int i = 0; i < part.Modules.Count; i++)
-            {
-                if (part.Modules[i] is T)
-                    return true;
-            }
-            return false;
-        }
-
-        public static T GetModule<T>(this Part part) where T : PartModule
-        {
-            for (int i = 0; i < part.Modules.Count; i++)
-            {
-                PartModule pm = part.Modules[i];
-                T module = pm as T;
-                if (module != null)
-                    return module;
-            }
-            return null;
-        }
+        public static bool HasModule<T>(this Part part) where T : PartModule => part.FindModuleImplementing<T>() != null;
+        public static T GetModule<T>(this Part part) where T : PartModule => part.FindModuleImplementing<T>();
 
         // An allocation free version of GetModuleMass
         public static float GetModuleMassNoAlloc(this Part p, float defaultMass, ModifierStagingSituation sit)
@@ -187,45 +168,18 @@ namespace MuMech
                 && p.isControlSource == Vessel.ControlLevel.NONE;
         }
 
-        public static bool IsEngine(this Part p)
-        {
-            for (int i = 0; i < p.Modules.Count; i++)
-            {
-                PartModule m = p.Modules[i];
-                if (m is ModuleEngines) return true;
-            }
-            return false;
-        }
+        public static bool IsEngine(this Part p) => p.FindModuleImplementing<ModuleEngines>() != null; 
 
         public static bool IsThrottleLockedEngine(this Part p)
         {
-            for (int i = 0; i < p.Modules.Count; i++)
-            {
-                PartModule m = p.Modules[i];
-                if (m is ModuleEngines engines && engines.throttleLocked) return true;
-            }
-            return false;
+            ModuleEngines me = p.FindModuleImplementing<ModuleEngines>();
+            return (me != null && me.throttleLocked);
         }
 
-        public static bool IsParachute(this Part p)
-        {
-            for (int i = 0; i < p.Modules.Count; i++)
-            {
-                if (p.Modules[i] is ModuleParachute) return true;
-            }
-            return false;
-        }
+        public static bool IsParachute(this Part p) => p.FindModulesImplementing<ModuleParachute>() != null;
 
-        // TODO add some kind of cache ? This is called a lot but reply false 99.9999% oif the time
-        public static bool IsLaunchClamp(this Part p)
-        {
-            for (int i = 0; i < p.Modules.Count; i++)
-            {
-                if (p.Modules[i] is LaunchClamp) return true;
-            }
-            return false;
-        }
-
+        public static bool IsLaunchClamp(this Part p) => p.FindModuleImplementing<LaunchClamp>() != null;
+        
         public static bool IsDecoupledInStage(this Part p, int stage)
         {
             Part decoupledPart;
@@ -241,17 +195,8 @@ namespace MuMech
 
             // part.PhysicsSignificance is not initialized in the Editor for all part. but physicallySignificant is useful there.
             if (HighLogic.LoadedSceneIsEditor)
-            {
-                physicallySignificant = physicallySignificant && p.PhysicsSignificance != 1;
+                physicallySignificant &= p.PhysicsSignificance != 1 && !p.IsLaunchClamp();
 
-                // Testing for launch clamp only in the Editor helps with the frame rate.
-                // TODO : cache which part are LaunchClamp ?
-                if (p.HasModule<LaunchClamp>())
-                {
-                    //Launch clamp mass should be ignored.
-                    physicallySignificant = false;
-                }
-            }
             return physicallySignificant;
         }
 

--- a/MechJeb2/PartExtensions.cs
+++ b/MechJeb2/PartExtensions.cs
@@ -98,6 +98,13 @@ namespace MuMech
             return isp;
         }
 
+        public static bool IsDecoupler(this Part p)
+        {
+            return p != null && (p.FindModuleImplementing<ModuleDecouplerBase>() != null || 
+                                 p.FindModuleImplementing<ModuleDockingNode>() != null || 
+                                 p.Modules["ProceduralFairingDecoupler"] != null);
+        }
+
         public static bool IsUnfiredDecoupler(this Part p, out Part decoupledPart)
         {
             for (int i = 0; i < p.Modules.Count; i++)

--- a/MechJeb2/PartExtensions.cs
+++ b/MechJeb2/PartExtensions.cs
@@ -176,7 +176,7 @@ namespace MuMech
             return (me != null && me.throttleLocked);
         }
 
-        public static bool IsParachute(this Part p) => p.FindModulesImplementing<ModuleParachute>() != null;
+        public static bool IsParachute(this Part p) => p.FindModuleImplementing<ModuleParachute>() != null;
 
         public static bool IsLaunchClamp(this Part p) => p.FindModuleImplementing<LaunchClamp>() != null;
         


### PR DESCRIPTION
Implement caches for: inverseStageHasEngines, inverseStageFiresDecoupler, inverseStageReleasesClamps, hasStayingChutes, hasFairing
Cache all vessel engines, to rapidly rebuild active-engines list each cycle
Cache all decoupler PartModules, iterate over them instead of searching entire vessel
Invalidate caches via OnVesselWasModified handler or when user changes staging sequence
Add EngineHasFuel convenience method for ModuleEngine param, not just Part.
Add multiple IsDecoupler and IsUnfiredDecoupler convenience methods
Convert to using part.FindModuleImplementing<T> since KSP's implementation [in 1.12] automatically caches its result
Note: EngineHasFuel(Part) does not properly support multiple ModuleEngines PMs, it will always return the fuel access state of the first PM.