### PR TITLE
Better support for Principia node burning and RF spoolup time

### DIFF
--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -326,6 +326,7 @@ namespace MuMech
         private double VesselThrustAndSpoolup(out double sumSpoolup)
         {
             double sumThrust = 0;
+            double sumSpoolupThrust = 0;
             sumSpoolup = 0;
 
             using Disposable<List<FuelNode>> activeEngines = FindActiveEngines();
@@ -334,10 +335,14 @@ namespace MuMech
             {
                 double thrust = activeEngines.value[i].partThrust;
                 sumThrust += thrust;
-                sumSpoolup += activeEngines.value[i].partSpoolupTime * thrust;
+                if (_simStage == activeEngines.value[i].inverseStage)
+                {
+                    sumSpoolupThrust += thrust;
+                    sumSpoolup += activeEngines.value[i].partSpoolupTime * thrust;
+                }
             }
-            if (sumThrust > 0)
-                sumSpoolup /= sumThrust;
+            if (sumSpoolupThrust > 0)
+                sumSpoolup /= sumSpoolupThrust;
 
             return sumThrust;
         }

--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -114,6 +114,7 @@ namespace MuMech
             fuelStats.StartMass    = VesselMass(_simStage);
             fuelStats.StartThrust  = VesselThrust();
             fuelStats.EndThrust    = VesselThrust();
+            fuelStats.SpoolUpTime  = VesselSpoolupTime();
             fuelStats.EndMass      = fuelStats.StartMass;
             fuelStats.ResourceMass = 0;
             fuelStats.MaxAccel     = fuelStats.EndMass > 0 ? fuelStats.EndThrust / fuelStats.EndMass : 0;
@@ -166,6 +167,7 @@ namespace MuMech
             fuelStats.StartMass = VesselMass(_simStage);
             // over a single timestep the thrust is considered constant, we don't support thrust curves.
             fuelStats.StartThrust = fuelStats.EndThrust = VesselThrust();
+            fuelStats.SpoolUpTime = VesselSpoolupTime();
 
             using (Disposable<List<FuelNode>> engines = FindActiveEngines())
             {
@@ -325,6 +327,25 @@ namespace MuMech
             for (int i = 0; i < activeEngines.value.Count; i++) sumThrust += activeEngines.value[i].partThrust;
 
             return sumThrust;
+        }
+
+        private double VesselSpoolupTime()
+        {
+            double sumThrust = 0;
+            double sumSpoolup = 0;
+
+            using Disposable<List<FuelNode>> activeEngines = FindActiveEngines();
+
+            for (int i = 0; i < activeEngines.value.Count; i++)
+            {
+                double thrust = activeEngines.value[i].partThrust;
+                sumThrust += thrust;
+                sumSpoolup += activeEngines.value[i].partSpoolupTime * thrust;
+            }
+            if (sumThrust > 0)
+                sumSpoolup /= sumThrust;
+
+            return sumSpoolup;
         }
 
         //Returns a list of engines that fire during the current simulated stage.

--- a/MechJeb2/FuelNode.cs
+++ b/MechJeb2/FuelNode.cs
@@ -69,19 +69,20 @@ namespace MuMech
                     }
                     moduleResiduals = temp ?? 0;
 
-                    temp = 0;
+                    float? temp2 = 0;
                     if (RFspoolUpTime != null)
                     {
                         try
                         {
-                            temp = RFspoolUpTime.GetValue(engineModule) as double?;
+                            temp2 = RFspoolUpTime.GetValue(engineModule) as float?;
                         }
                         catch (ArgumentException)
                         {
-                            temp = 0;
+                            //FuelFlowSimulation.print("For engine " + engineModule.part.partName + " failed to find spoolup time field!");
+                            temp2 = 0;
                         }
                     }
-                    moduleSpoolupTime = temp ?? 0;
+                    moduleSpoolupTime = temp2 ?? 0;
                 }
             }
 
@@ -569,6 +570,7 @@ namespace MuMech
                     }
                     if (partThrust > 0)
                         partSpoolupTime /= partThrust;
+                    //FuelFlowSimulation.print("For all engines, found spoolup time " + partSpoolupTime + " (with total thrust " + partThrust);
                 }
             }
 

--- a/MechJeb2/FuelStats.cs
+++ b/MechJeb2/FuelStats.cs
@@ -52,7 +52,7 @@ namespace MuMech
                     ResourceMass = StartMass - s.EndMass,
                     StartThrust  = StartThrust,
                     EndThrust    = s.EndThrust,
-                    SpoolUpTime  = s.SpoolUpTime,
+                    SpoolUpTime  = Math.Max(SpoolUpTime, s.SpoolUpTime),
                     MaxAccel     = Math.Max(MaxAccel, s.MaxAccel),
                     DeltaTime    = DeltaTime + (s.DeltaTime < float.MaxValue && !double.IsInfinity(s.DeltaTime) ? s.DeltaTime : 0),
                     DeltaV       = DeltaV + s.DeltaV,

--- a/MechJeb2/FuelStats.cs
+++ b/MechJeb2/FuelStats.cs
@@ -15,6 +15,7 @@ namespace MuMech
             public double MaxAccel;
             public double DeltaTime;
             public double DeltaV;
+            public double SpoolUpTime;
 
             public double ResourceMass;
             public double Isp;
@@ -51,6 +52,7 @@ namespace MuMech
                     ResourceMass = StartMass - s.EndMass,
                     StartThrust  = StartThrust,
                     EndThrust    = s.EndThrust,
+                    SpoolUpTime  = s.SpoolUpTime,
                     MaxAccel     = Math.Max(MaxAccel, s.MaxAccel),
                     DeltaTime    = DeltaTime + (s.DeltaTime < float.MaxValue && !double.IsInfinity(s.DeltaTime) ? s.DeltaTime : 0),
                     DeltaV       = DeltaV + s.DeltaV,

--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -124,21 +124,33 @@ namespace MuMech
             {
                 if (anyNodeExists && !core.node.enabled)
                 {
-                    if (GUILayout.Button(Localizer.Format("#MechJeb_Maneu_button4")))//Execute next node
+                    if (VesselState.isLoadedPrincipia)
                     {
-                        core.node.ExecuteOneNode(this);
-                    }
-
-                    if (VesselState.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
-                    {
-                        core.node.ExecuteOnePNode(this);
-                    }
-
-                    if (vessel.patchedConicSolver.maneuverNodes.Count > 1)
-                    {
-                        if (GUILayout.Button(Localizer.Format("#MechJeb_Maneu_button5")))//Execute all nodes
+                        if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
                         {
-                            core.node.ExecuteAllNodes(this);
+                            core.node.ExecuteOnePNode(this);
+                        }
+                        else if (core.node.enabled)
+                        {
+                            if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button6")))//"Abort node execution"
+                            {
+                                core.node.Abort();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (GUILayout.Button(Localizer.Format("#MechJeb_Maneu_button4")))//Execute next node
+                        {
+                            core.node.ExecuteOneNode(this);
+                        }
+
+                        if (vessel.patchedConicSolver.maneuverNodes.Count > 1)
+                        {
+                            if (GUILayout.Button(Localizer.Format("#MechJeb_Maneu_button5")))//Execute all nodes
+                            {
+                                core.node.ExecuteAllNodes(this);
+                            }
                         }
                     }
                 }

--- a/MechJeb2/MechJebModuleNodeEditor.cs
+++ b/MechJeb2/MechJebModuleNodeEditor.cs
@@ -225,21 +225,26 @@ namespace MuMech
             {
                 if (vessel.patchedConicSolver.maneuverNodes.Count > 0 && !core.node.enabled)
                 {
-                    if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button4")))//"Execute next node"
+                    if (VesselState.isLoadedPrincipia)
                     {
-                        core.node.ExecuteOneNode(this);
-                    }
-
-                    if (VesselState.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
-                    {
-                        core.node.ExecuteOnePNode(this);
-                    }
-
-                    if (vessel.patchedConicSolver.maneuverNodes.Count > 1)
-                    {
-                        if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button5")))//"Execute all nodes"
+                        if (VesselState.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
                         {
-                            core.node.ExecuteAllNodes(this);
+                            core.node.ExecuteOnePNode(this);
+                        }
+                    }
+                    else
+                    {
+                        if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button4")))//"Execute next node"
+                        {
+                            core.node.ExecuteOneNode(this);
+                        }
+
+                        if (vessel.patchedConicSolver.maneuverNodes.Count > 1)
+                        {
+                            if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button5")))//"Execute all nodes"
+                            {
+                                core.node.ExecuteAllNodes(this);
+                            }
                         }
                     }
                 }

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -170,11 +170,13 @@ namespace MuMech
                 //autowarp, but only if we're already aligned with the node
                 if (autowarp && !burnTriggered)
                 {
-                    if ((core.attitude.attitudeAngleFromTarget() < 1 && core.vessel.angularVelocity.magnitude < 0.001) || (!MuUtils.PhysicsRunning() && ( timeToNode > 600 || core.attitude.attitudeAngleFromTarget() < 10)))
+                    if (timeToNode > 600 || (MuUtils.PhysicsRunning()
+                        ? core.attitude.attitudeAngleFromTarget() < 1 && core.vessel.angularVelocity.magnitude < 0.001
+                        : core.attitude.attitudeAngleFromTarget() < 10))
                     {
                         core.warp.WarpToUT(node.UT - spool - leadTime);
                     }
-                    else if (!MuUtils.PhysicsRunning() && core.attitude.attitudeAngleFromTarget() >= 10 && timeToNode <= 600)
+                    else
                     {
                         //realign
                         core.warp.MinimumWarp();

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -18,12 +18,23 @@ namespace MuMech
         [ValueInfoItem("#MechJeb_NodeBurnLength", InfoItem.Category.Thrust)]//Node Burn Length
         public string NextNodeBurnTime()
         {
-            if (!vessel.patchedConicsUnlocked() || vessel.patchedConicSolver.maneuverNodes.Count == 0)
+            if (!vessel.patchedConicsUnlocked())
                 return "-";
-            ManeuverNode node = vessel.patchedConicSolver.maneuverNodes[0];
-            double dV = node.GetBurnVector(orbit).magnitude;
-            double halfBurnTIme;
-            return GuiUtils.TimeToDHMS(BurnTime(dV, out halfBurnTIme));
+
+            double dV;
+            if (VesselState.isLoadedPrincipia && remainingDeltaV > 0)
+            {
+                dV = remainingDeltaV;
+            }
+            else
+            {
+                if (vessel.patchedConicSolver.maneuverNodes.Count == 0)
+                    return "-";
+                ManeuverNode node = vessel.patchedConicSolver.maneuverNodes[0];
+                dV = node.GetBurnVector(orbit).magnitude;
+            }
+            double halfBurnTime, spool;
+            return GuiUtils.TimeToDHMS(BurnTime(dV, out halfBurnTime, out spool));
         }
 
         [ValueInfoItem("#MechJeb_NodeBurnCountdown", InfoItem.Category.Thrust)]//Node Burn Countdown
@@ -32,10 +43,25 @@ namespace MuMech
             if (!vessel.patchedConicsUnlocked() || vessel.patchedConicSolver.maneuverNodes.Count == 0)
                 return "-";
             ManeuverNode node = vessel.patchedConicSolver.maneuverNodes[0];
-            double dV = node.GetBurnVector(orbit).magnitude;
-            double halfBurnTIme;
-            BurnTime(dV, out halfBurnTIme);
-            return GuiUtils.TimeToDHMS(node.UT - halfBurnTIme - vesselState.time);
+            double dV;
+            bool isPrincipia = VesselState.isLoadedPrincipia;
+            if (isPrincipia)
+            {
+                dV = remainingDeltaV;
+            }
+            else
+            {
+                dV = node.GetBurnVector(orbit).magnitude;
+            }
+            double UT = node.UT;
+            double halfBurnTIme, spool;
+            BurnTime(dV, out halfBurnTIme, out spool);
+            if (isPrincipia)
+                UT -= spool;
+            else
+                UT -= halfBurnTIme; // already takes spoolup into account
+
+            return GuiUtils.TimeToDHMS(UT - vesselState.time);
         }
 
         public void ExecuteOneNode(object controller)
@@ -44,6 +70,7 @@ namespace MuMech
             users.Add(controller);
             burnTriggered = false;
             alignedForBurn = false;
+            remainingDeltaV = 0;
         }
 
         public void ExecuteOnePNode(object controller) //Principia Node
@@ -52,6 +79,8 @@ namespace MuMech
             users.Add(controller);
             burnTriggered = false;
             alignedForBurn = false;
+
+            remainingDeltaV = vessel.patchedConicSolver.maneuverNodes[0].GetBurnVector(orbit).magnitude;
         }
 
         public void ExecuteAllNodes(object controller)
@@ -60,12 +89,14 @@ namespace MuMech
             users.Add(controller);
             burnTriggered = false;
             alignedForBurn = false;
+            remainingDeltaV = 0;
         }
 
         public void Abort()
         {
             core.warp.MinimumWarp();
             users.Clear();
+            remainingDeltaV = 0;
         }
 
         public override void OnModuleEnabled()
@@ -79,6 +110,7 @@ namespace MuMech
             core.attitude.attitudeDeactivate();
             core.thrust.ThrustOff();
             core.thrust.users.Remove(this);
+            remainingDeltaV = 0;
         }
 
         protected enum Mode { ONE_NODE,ONE_PNODE, ALL_NODES };
@@ -86,116 +118,193 @@ namespace MuMech
 
         public bool burnTriggered = false;
         public bool alignedForBurn = false;
+        protected double remainingDeltaV = 0; // for Principia
 
         public override void OnFixedUpdate()
         {
-            if (!vessel.patchedConicsUnlocked() || vessel.patchedConicSolver.maneuverNodes.Count == 0)
+            bool hasPrincipia = VesselState.isLoadedPrincipia;
+            if (!vessel.patchedConicsUnlocked()
+                || (!hasPrincipia && vessel.patchedConicSolver.maneuverNodes.Count == 0))
             {
                 Abort();
                 return;
             }
 
-            //check if we've finished a node:
-            ManeuverNode node = vessel.patchedConicSolver.maneuverNodes[0];
-            double dVLeft = node.GetBurnVector(orbit).magnitude;
-
-            if (dVLeft < tolerance && core.attitude.attitudeAngleFromTarget() > 5)
+            if (hasPrincipia)
             {
-                burnTriggered = false;
-
-                node.RemoveSelf();
-
-                if (mode == Mode.ONE_NODE)
+                if (remainingDeltaV < tolerance)
                 {
+                    if (vessel.patchedConicSolver.maneuverNodes.Count > 0)
+                        vessel.patchedConicSolver.maneuverNodes[0].RemoveSelf();
+                
                     Abort();
                     return;
                 }
-                else if (mode == Mode.ALL_NODES)
+                //aim along the node
+                bool hasNode = vessel.patchedConicSolver.maneuverNodes.Count > 0;
+                ManeuverNode node = hasNode ? vessel.patchedConicSolver.maneuverNodes[0] : null;
+                if (hasNode)
                 {
-                    if (vessel.patchedConicSolver.maneuverNodes.Count == 0)
+                    core.attitude.attitudeTo(Vector3d.forward,AttitudeReference.MANEUVER_NODE_COT,this);
+                }
+                else
+                {
+                    if (!core.attitude.attitudeKILLROT)
                     {
-                        Abort();
-                        return;
-                    }
-                    else
-                    {
-                        node = vessel.patchedConicSolver.maneuverNodes[0];
+                        core.attitude.attitudeTo(UnityEngine.Quaternion.LookRotation(vessel.GetTransform().up,-vessel.GetTransform().forward),AttitudeReference.INERTIAL,this);
+                        core.attitude.attitudeKILLROT = true;
                     }
                 }
-            }
 
-            //aim along the node
-            core.attitude.attitudeTo(Vector3d.forward, AttitudeReference.MANEUVER_NODE_COT, this);
+                double halfBurnTime, spool;
+                BurnTime(remainingDeltaV,out halfBurnTime,out spool);
 
-            double halfBurnTime;
-            BurnTime(dVLeft, out halfBurnTime);
-
-            double timeToNode = node.UT - vesselState.time;
-            //(!double.IsInfinity(num) && num > 0.0 && num2 < num) || num2 <= 0.0
-            if (mode == Mode.ONE_NODE || mode == Mode.ALL_NODES)
-            {
-                if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode < halfBurnTime) || timeToNode < 0)
-                {
-                    burnTriggered = true;
-                    if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
-                }
-            }
-            else if (mode == Mode.ONE_PNODE)
-            {
+                double timeToNode = hasNode ? node.UT - vesselState.time - spool : -1;
                 if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode <= 0.0225) || timeToNode < 0)
                 {
                     burnTriggered = true;
                     if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
                 }
-            }
 
-            //autowarp, but only if we're already aligned with the node
-            if (autowarp && !burnTriggered)
-            {
-                if ((core.attitude.attitudeAngleFromTarget() < 1 && core.vessel.angularVelocity.magnitude < 0.001) || (core.attitude.attitudeAngleFromTarget() < 10 && !MuUtils.PhysicsRunning()))
+                //autowarp, but only if we're already aligned with the node
+                if (autowarp && !burnTriggered)
                 {
-                    core.warp.WarpToUT(node.UT - halfBurnTime - leadTime);
-                }
-                else if (!MuUtils.PhysicsRunning() && core.attitude.attitudeAngleFromTarget() > 10 && timeToNode < 600)
-                {
-                    //realign
-                    core.warp.MinimumWarp();
-                }
-            }
-
-            core.thrust.targetThrottle = 0;
-
-            if (burnTriggered)
-            {
-                if (alignedForBurn)
-                {
-                    if (core.attitude.attitudeAngleFromTarget() < 90)
+                    if ((core.attitude.attitudeAngleFromTarget() < 1 && core.vessel.angularVelocity.magnitude < 0.001) || (!MuUtils.PhysicsRunning() && ( timeToNode > 600 || core.attitude.attitudeAngleFromTarget() < 10)))
                     {
-                        double timeConstant = (dVLeft > 10 || vesselState.minThrustAccel > 0.25 * vesselState.maxThrustAccel ? 0.5 : 2);
-                        core.thrust.ThrustForDV(dVLeft + tolerance, timeConstant);
+                        core.warp.WarpToUT(node.UT - spool - leadTime);
+                    }
+                    else if (!MuUtils.PhysicsRunning() && core.attitude.attitudeAngleFromTarget() >= 10 && timeToNode <= 600)
+                    {
+                        //realign
+                        core.warp.MinimumWarp();
+                    }
+                }
+
+                core.thrust.targetThrottle = 0;
+
+                if (burnTriggered)
+                {
+                    if (alignedForBurn)
+                    {
+                        if (core.attitude.attitudeAngleFromTarget() < 90)
+                        {
+                            double timeConstant = (remainingDeltaV > 10 || vesselState.minThrustAccel > 0.25 * vesselState.maxThrustAccel ? 0.5 : 2);
+                            core.thrust.ThrustForDV(remainingDeltaV + tolerance,timeConstant);
+                            remainingDeltaV -= vesselState.deltaT * vesselState.currentThrustAccel;
+                        }
+                        else
+                        {
+                            alignedForBurn = false;
+                        }
                     }
                     else
                     {
-                        alignedForBurn = false;
+                        if (core.attitude.attitudeAngleFromTarget() < 2)
+                        {
+                            alignedForBurn = true;
+                        }
                     }
                 }
-                else
+            }
+            else
+            {
+                //check if we've finished a node:
+                ManeuverNode node = vessel.patchedConicSolver.maneuverNodes[0];
+                double dVLeft = node.GetBurnVector(orbit).magnitude;
+
+                if (dVLeft < tolerance && core.attitude.attitudeAngleFromTarget() > 5)
                 {
-                    if (core.attitude.attitudeAngleFromTarget() < 2)
+                    burnTriggered = false;
+
+                    node.RemoveSelf();
+
+                    if (mode == Mode.ONE_NODE)
                     {
-                        alignedForBurn = true;
+                        Abort();
+                        return;
+                    }
+                    else if (mode == Mode.ALL_NODES)
+                    {
+                        if (vessel.patchedConicSolver.maneuverNodes.Count == 0)
+                        {
+                            Abort();
+                            return;
+                        }
+                        else
+                        {
+                            node = vessel.patchedConicSolver.maneuverNodes[0];
+                        }
+                    }
+                }
+
+                //aim along the node
+                core.attitude.attitudeTo(Vector3d.forward,AttitudeReference.MANEUVER_NODE_COT,this);
+
+                double halfBurnTime, spool;
+                BurnTime(dVLeft, out halfBurnTime, out spool);
+
+                double timeToNode = node.UT - vesselState.time;
+                //(!double.IsInfinity(num) && num > 0.0 && num2 < num) || num2 <= 0.0
+                if (mode == Mode.ONE_NODE || mode == Mode.ALL_NODES)
+                {
+                    if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode < halfBurnTime) || timeToNode < 0)
+                    {
+                        burnTriggered = true;
+                        if (!MuUtils.PhysicsRunning()) core.warp.MinimumWarp();
+                    }
+                }
+
+                //autowarp, but only if we're already aligned with the node
+                if (autowarp && !burnTriggered)
+                {
+                    if ((core.attitude.attitudeAngleFromTarget() < 1 && core.vessel.angularVelocity.magnitude < 0.001) || (core.attitude.attitudeAngleFromTarget() < 10 && !MuUtils.PhysicsRunning()))
+                    {
+                        core.warp.WarpToUT(node.UT - halfBurnTime - leadTime);
+                    }
+                    else if (!MuUtils.PhysicsRunning() && core.attitude.attitudeAngleFromTarget() > 10 && timeToNode < 600)
+                    {
+                        //realign
+                        core.warp.MinimumWarp();
+                    }
+                }
+
+                core.thrust.targetThrottle = 0;
+
+                if (burnTriggered)
+                {
+                    if (alignedForBurn)
+                    {
+                        if (core.attitude.attitudeAngleFromTarget() < 90)
+                        {
+                            double timeConstant = (dVLeft > 10 || vesselState.minThrustAccel > 0.25 * vesselState.maxThrustAccel ? 0.5 : 2);
+                            core.thrust.ThrustForDV(dVLeft + tolerance,timeConstant);
+                        }
+                        else
+                        {
+                            alignedForBurn = false;
+                        }
+                    }
+                    else
+                    {
+                        if (core.attitude.attitudeAngleFromTarget() < 2)
+                        {
+                            alignedForBurn = true;
+                        }
                     }
                 }
             }
         }
 
-        private double BurnTime(double dv, out double halfBurnTime)
+        
+
+        private double BurnTime(double dv, out double halfBurnTime, out double spoolupTime)
         {
             double dvLeft = dv;
             double halfDvLeft = dv / 2;
 
             double burnTime = 0;
             halfBurnTime = 0;
+            spoolupTime = 0;
 
             // Old code:
             //      burnTime = dv / vesselState.limitedMaxThrustAccel;
@@ -249,6 +358,9 @@ namespace MuMech
 
                 burnTime += stageBurnDv / stageAvgAccel;
 
+                halfBurnTime += s.SpoolUpTime;
+                burnTime += s.SpoolUpTime;
+                spoolupTime += s.SpoolUpTime;
             }
 
             /* infinity means acceleration is zero for some reason, which is dangerous nonsense, so use zero instead */

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -174,7 +174,7 @@ namespace MuMech
                         ? core.attitude.attitudeAngleFromTarget() < 1 && core.vessel.angularVelocity.magnitude < 0.001
                         : core.attitude.attitudeAngleFromTarget() < 10))
                     {
-                        core.warp.WarpToUT(node.UT - spool - leadTime);
+                        core.warp.WarpToUT(timeToNode - spool - leadTime);
                     }
                     else
                     {

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -134,9 +134,8 @@ namespace MuMech
             {
                 if (remainingDeltaV < tolerance)
                 {
-                    if (vessel.patchedConicSolver.maneuverNodes.Count > 0)
-                        vessel.patchedConicSolver.maneuverNodes[0].RemoveSelf();
-                
+                    burnTriggered = false;
+
                     Abort();
                     return;
                 }
@@ -160,6 +159,8 @@ namespace MuMech
                 BurnTime(remainingDeltaV,out halfBurnTime,out spool);
 
                 double timeToNode = hasNode ? node.UT - vesselState.time - spool : -1;
+                //print("$$$$$$$ Executor: Node UT " + node.UT.ToString("F3") + ", spool " + spool.ToString("F3")
+                //    + " with vessel time " + vesselState.time.ToString("F3") + " , so time to node " + timeToNode.ToString("F3") + ". ===half= " + halfBurnTime.ToString("F3"));
                 if ((!double.IsInfinity(halfBurnTime) && halfBurnTime > 0 && timeToNode <= 0.0225) || timeToNode < 0)
                 {
                     burnTriggered = true;
@@ -361,6 +362,7 @@ namespace MuMech
                 halfBurnTime += s.SpoolUpTime;
                 burnTime += s.SpoolUpTime;
                 spoolupTime += s.SpoolUpTime;
+                //print("** Execute: For stage " + i + ", found spoolup " + s.SpoolUpTime);
             }
 
             /* infinity means acceleration is zero for some reason, which is dangerous nonsense, so use zero instead */
@@ -373,6 +375,8 @@ namespace MuMech
             {
                 burnTime = 0.0;
             }
+
+            //print("******** Found total spoolup time " + spoolupTime);
 
             return burnTime;
         }

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -97,6 +97,7 @@ namespace MuMech
             core.warp.MinimumWarp();
             users.Clear();
             remainingDeltaV = 0;
+            burnTriggered = false;
         }
 
         public override void OnModuleEnabled()
@@ -159,8 +160,7 @@ namespace MuMech
                 BurnTime(remainingDeltaV,out halfBurnTime,out spool);
 
                 double timeToNode = hasNode ? node.UT - vesselState.time : -1;
-                //print("$$$$$$$ Executor: Node UT " + node.UT.ToString("F3") + ", spool " + spool.ToString("F3")
-                //    + " with vessel time " + vesselState.time.ToString("F3") + " , so time to node " + timeToNode.ToString("F3") + ". ===half= " + halfBurnTime.ToString("F3"));
+                //print("$$$$$$$ Executor: Node in " + timeToNode + ", spool " + spool.ToString("F3"));
                 if ((halfBurnTime > 0 && timeToNode <= spool) || timeToNode < 0)
                 {
                     burnTriggered = true;


### PR DESCRIPTION
This PR does two things:
* It fixes Principia node burning to actually burn the required delta V (which involves still burning even after Principia nukes the associated node).
* It handles RF engines having spoolup times (by starting burns early). Spool time weighted by thrust is stored in stage stats.