### PR TITLE
Fix detection of RCS for PVG terminal RCS

### DIFF
--- a/MechJeb2/MathExtensions.cs
+++ b/MechJeb2/MathExtensions.cs
@@ -25,6 +25,11 @@ namespace MuMech
             return new Vector3d(Math.Sqrt(vector.x), Math.Sqrt(vector.y), Math.Sqrt(vector.z));
         }
 
+        public static double MaxMagnitude(this Vector3d vector)
+        {
+            return Math.Max(Math.Max(Math.Abs(vector.x),Math.Abs(vector.y)),Math.Abs(vector.z));
+        }
+
         public static Vector3d Reorder(this Vector3d vector, int order)
         {
             switch (order)

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -140,7 +140,9 @@ namespace MuMech
 
             if ( p != null && p.Solution != null && isTerminalGuidance() )
             {
-                bool has_rcs = vessel.hasEnabledRCSModules(); // && ( vesselState.rcsThrustAvailable.up > 0 );
+                // We might have wonky transforms and have a tiny bit of fore RCS, so require at least 10% of the max RCS thrust to be
+                // in the pointy direction (which should be "up" / y-axis per KSP/Unity semantics).
+                bool has_rcs = vessel.hasEnabledRCSModules() && vesselState.rcsThrustAvailable.up > 0.1 * vesselState.rcsThrustAvailable.MaxMagnitude();
 
                 // stopping one tick short is more accurate for rockets without RCS, but sometimes we overshoot with only one tick
                 int ticks = 1;
@@ -156,6 +158,7 @@ namespace MuMech
                 // bit of a hack to predict velocity + position in the next tick or two
                 // FIXME: what exactly does KSP do to integrate over timesteps?
                 Vector3d a0 = vessel.acceleration_immediate;
+
                 double dt = ticks * TimeWarp.fixedDeltaTime;
                 Vector3d v1 = vesselState.orbitalVelocity + a0 * dt;
                 Vector3d x1 = vesselState.orbitalPosition + vesselState.orbitalVelocity * dt + 1/2 * a0 * dt * dt;

--- a/MechJeb2/Vector6.cs
+++ b/MechJeb2/Vector6.cs
@@ -107,6 +107,11 @@ namespace MuMech
             return Math.Sqrt(sqrMagnitude);
         }
 
+        public double MaxMagnitude()
+        {
+            return Math.Max(positive.MaxMagnitude(),negative.MaxMagnitude());
+        }
+
         public void Load(ConfigNode node)
         {
             if (node.HasValue("positive"))


### PR DESCRIPTION
This check is relative to the maximum RCS in any one direction so
that slightly misaligned transforms won't register as the RCS axis
that we need.

Hopefully people don't have massive pitch/yaw/roll thrusters with
only tiny ullage RCS.