### PR TITLE
Fix PVG with upper stage solids (Castor 30XL)

### DIFF
--- a/Localization/en-us.cfg
+++ b/Localization/en-us.cfg
@@ -1021,6 +1021,7 @@ Localization
         #MechJeb_InfoItems_StatsColumn10 = Atmo ΔV
         #MechJeb_InfoItems_StatsColumn11 = Vac ΔV
         #MechJeb_InfoItems_StatsColumn12 = Time
+        #MechJeb_InfoItems_StatsColumn13 = Max Thrust
 
 
     //Ascent Path Editor

--- a/MechJeb2/CachedLocalizer.cs
+++ b/MechJeb2/CachedLocalizer.cs
@@ -44,12 +44,11 @@ namespace MuMech
         public string MechJeb_InfoItems_StatsColumn0;
         public string MechJeb_InfoItems_StatsColumn1, MechJeb_InfoItems_StatsColumn2, MechJeb_InfoItems_StatsColumn3, MechJeb_InfoItems_StatsColumn4, MechJeb_InfoItems_StatsColumn5;
         public string MechJeb_InfoItems_StatsColumn6, MechJeb_InfoItems_StatsColumn7, MechJeb_InfoItems_StatsColumn8, MechJeb_InfoItems_StatsColumn9, MechJeb_InfoItems_StatsColumn10;
-        public string MechJeb_InfoItems_StatsColumn11, MechJeb_InfoItems_StatsColumn12;
+        public string MechJeb_InfoItems_StatsColumn11, MechJeb_InfoItems_StatsColumn12, MechJeb_InfoItems_StatsColumn13;
 
         public string MechJeb_Ascent_title, MechJeb_WindowEd_title;
         public string MechJeb_WindowEd_CustomInfoWindow_Label1;
 
-        private static WaitForSeconds _WaitForSeconds;
         public static void Bootstrap()
         {
             if (Instance != null) return;
@@ -148,7 +147,7 @@ namespace MuMech
             MechJeb_Ascent_status9 = Localizer.Format("#MechJeb_Ascent_status9");
             MechJeb_Ascent_status10 = Localizer.Format("#MechJeb_Ascent_status10");
             MechJeb_Ascent_status11 = Localizer.Format("#MechJeb_Ascent_status11");
-                
+
 
             MechJeb_Ascent_attachAlt = Localizer.Format("#MechJeb_Ascent_attachAlt");
             MechJeb_Ascent_warnAttachAltHigh = Localizer.Format("#MechJeb_Ascent_warnAttachAltHigh");
@@ -170,19 +169,20 @@ namespace MuMech
             MechJeb_InfoItems_button5 = Localizer.Format("#MechJeb_InfoItems_button5");
             MechJeb_InfoItems_button6 = Localizer.Format("#MechJeb_InfoItems_button6");
 
-            MechJeb_InfoItems_StatsColumn0 = Localizer.Format("#MechJeb_InfoItems_StatsColumn0");
-            MechJeb_InfoItems_StatsColumn1 = Localizer.Format("#MechJeb_InfoItems_StatsColumn1");
-            MechJeb_InfoItems_StatsColumn2 = Localizer.Format("#MechJeb_InfoItems_StatsColumn2");
-            MechJeb_InfoItems_StatsColumn3 = Localizer.Format("#MechJeb_InfoItems_StatsColumn3");
-            MechJeb_InfoItems_StatsColumn4 = Localizer.Format("#MechJeb_InfoItems_StatsColumn4");
-            MechJeb_InfoItems_StatsColumn5 = Localizer.Format("#MechJeb_InfoItems_StatsColumn5");
-            MechJeb_InfoItems_StatsColumn6 = Localizer.Format("#MechJeb_InfoItems_StatsColumn6");
-            MechJeb_InfoItems_StatsColumn7 = Localizer.Format("#MechJeb_InfoItems_StatsColumn7");
-            MechJeb_InfoItems_StatsColumn8 = Localizer.Format("#MechJeb_InfoItems_StatsColumn8");
-            MechJeb_InfoItems_StatsColumn9 = Localizer.Format("#MechJeb_InfoItems_StatsColumn9");
+            MechJeb_InfoItems_StatsColumn0  = Localizer.Format("#MechJeb_InfoItems_StatsColumn0");
+            MechJeb_InfoItems_StatsColumn1  = Localizer.Format("#MechJeb_InfoItems_StatsColumn1");
+            MechJeb_InfoItems_StatsColumn2  = Localizer.Format("#MechJeb_InfoItems_StatsColumn2");
+            MechJeb_InfoItems_StatsColumn3  = Localizer.Format("#MechJeb_InfoItems_StatsColumn3");
+            MechJeb_InfoItems_StatsColumn4  = Localizer.Format("#MechJeb_InfoItems_StatsColumn4");
+            MechJeb_InfoItems_StatsColumn5  = Localizer.Format("#MechJeb_InfoItems_StatsColumn5");
+            MechJeb_InfoItems_StatsColumn6  = Localizer.Format("#MechJeb_InfoItems_StatsColumn6");
+            MechJeb_InfoItems_StatsColumn7  = Localizer.Format("#MechJeb_InfoItems_StatsColumn7");
+            MechJeb_InfoItems_StatsColumn8  = Localizer.Format("#MechJeb_InfoItems_StatsColumn8");
+            MechJeb_InfoItems_StatsColumn9  = Localizer.Format("#MechJeb_InfoItems_StatsColumn9");
             MechJeb_InfoItems_StatsColumn10 = Localizer.Format("#MechJeb_InfoItems_StatsColumn10");
             MechJeb_InfoItems_StatsColumn11 = Localizer.Format("#MechJeb_InfoItems_StatsColumn11");
             MechJeb_InfoItems_StatsColumn12 = Localizer.Format("#MechJeb_InfoItems_StatsColumn12");
+            MechJeb_InfoItems_StatsColumn13 = Localizer.Format("#MechJeb_InfoItems_StatsColumn13");
 
             MechJeb_InfoItems_showEmpty = Localizer.Format("#MechJeb_InfoItems_showEmpty");
             MechJeb_InfoItems_hideEmpty = Localizer.Format("#MechJeb_InfoItems_hideEmpty");

--- a/MechJeb2/FuelNode.cs
+++ b/MechJeb2/FuelNode.cs
@@ -44,10 +44,13 @@ namespace MuMech
                 public readonly Vector3d      thrustVector;
                 public readonly double        moduleResiduals;
                 public readonly double        moduleSpoolupTime;
+                public readonly double        maxThrust;
 
                 public EngineInfo(ModuleEngines engineModule)
                 {
                     this.engineModule = engineModule;
+
+                    maxThrust = engineModule.maxThrust;
 
                     thrustVector = Vector3d.zero;
 
@@ -102,14 +105,15 @@ namespace MuMech
 
             private readonly List<FuelNode> crossfeedSources = new List<FuelNode>();
 
-            public int  decoupledInStage; //the stage in which this part will be decoupled from the rocket
-            public int  inverseStage;     //stage in which this part is activated
-            public bool isLaunchClamp;    //whether this part is a launch clamp
-            public bool isSepratron;      //whether this part is a sepratron
-            public bool isEngine;         //whether this part is an engine
-            public bool isthrottleLocked;
-            public bool activatesEvenIfDisconnected;
-            public bool isDrawingResources = true; // Is the engine actually using any resources
+            public int    decoupledInStage; //the stage in which this part will be decoupled from the rocket
+            public int    inverseStage;     //stage in which this part is activated
+            public bool   isLaunchClamp;    //whether this part is a launch clamp
+            public bool   isSepratron;      //whether this part is a sepratron
+            public bool   isEngine;         //whether this part is an engine
+            public bool   isthrottleLocked;
+            public bool   activatesEvenIfDisconnected;
+            public bool   isDrawingResources = true; // Is the engine actually using any resources
+            public double maxThrust;
 
             private double resourceRequestRemainingThreshold;
             private int    resourcePriority;
@@ -300,9 +304,13 @@ namespace MuMech
                     engineInfos.Add(new EngineInfo(e));
                 }
 
+                maxThrust = 0;
                 // find our max maxEngineResiduals for this engine part from all the modules
                 foreach (EngineInfo e in engineInfos)
-                    maxEngineResiduals = Math.Max(maxEngineResiduals, e.moduleResiduals);
+                {
+                    maxEngineResiduals =  Math.Max(maxEngineResiduals,e.moduleResiduals);
+                    maxThrust          += e.maxThrust;
+                }
             }
 
             // We are not necessarily traversing from the root part but from any interior part, so that p.parent is just another potential child node

--- a/MechJeb2/FuelStats.cs
+++ b/MechJeb2/FuelStats.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace MuMech
 {
@@ -20,6 +19,7 @@ namespace MuMech
             public double ResourceMass;
             public double Isp;
             public double StagedMass;
+            public double MaxThrust;
 
             public double StartTWR(double geeASL)
             {
@@ -30,8 +30,6 @@ namespace MuMech
             {
                 return MaxAccel / (9.80665 * geeASL);
             }
-
-            public List<Part> Parts;
 
             //Computes the deltaV from the other fields. Only valid when the thrust is constant over the time interval represented.
             public void ComputeTimeStepDeltaV()
@@ -56,7 +54,8 @@ namespace MuMech
                     MaxAccel     = Math.Max(MaxAccel, s.MaxAccel),
                     DeltaTime    = DeltaTime + (s.DeltaTime < float.MaxValue && !double.IsInfinity(s.DeltaTime) ? s.DeltaTime : 0),
                     DeltaV       = DeltaV + s.DeltaV,
-                    Parts        = Parts,
+                    // this is deliberately the max thrust of the last segment in order to not count burned out ullage motors
+                    MaxThrust    = s.MaxThrust > 0 ? s.MaxThrust : MaxThrust,
                     // ReSharper disable once CompareOfFloatsByEqualityOperator
                     Isp          = StartMass == s.EndMass ? 0 : (DeltaV + s.DeltaV) / (9.80665f * Math.Log(StartMass / s.EndMass))
                 };

--- a/MechJeb2/MechJebModuleInfoItems.cs
+++ b/MechJeb2/MechJebModuleInfoItems.cs
@@ -814,6 +814,8 @@ namespace MuMech
         [Persistent(pass = (int)Pass.Global)]
         public bool showFinalMass = false;
         [Persistent(pass = (int)Pass.Global)]
+        public bool showMaxThrust = false;
+        [Persistent(pass = (int)Pass.Global)]
         public bool showVacInitialTWR = true;
         [Persistent(pass = (int)Pass.Global)]
         public bool showAtmoInitialTWR = false; // NK
@@ -844,10 +846,10 @@ namespace MuMech
         [Persistent(pass = (int)Pass.Global)]
         public bool timeSeconds = false;
         private MechJebStageStatsHelper stageStatsHelper = null;
-        
+
         // Leave this stub here until I figure out how to properly target in the new class
         [GeneralInfoItem("#MechJeb_StageStatsAll",InfoItem.Category.Vessel,showInEditor = true)]//Stage stats (all)
-        public void AllStageStats() 
+        public void AllStageStats()
         {
             if (stageStatsHelper == null)
                 stageStatsHelper = new MechJebStageStatsHelper(this);

--- a/MechJeb2/MechJebModuleLogicalStageTracking.cs
+++ b/MechJeb2/MechJebModuleLogicalStageTracking.cs
@@ -132,7 +132,7 @@ namespace MuMech
             public double DeltaV;
 
             // burntime left in the stage in secs
-            public double DeltaTime;
+            //public double DeltaTime;
 
             // effective isp of the stage (this is derived from the total mass loss and the total ∆v)
             public double Isp;
@@ -140,14 +140,8 @@ namespace MuMech
             // effective exhaust velocity of the stage
             public double Ve => Isp * 9.80665;
 
-            // starting thrust of the stage
-            public double StartThrust;
-
-            // ending thrust (this should be the same, except for burned out ullage motors)
-            public double EndThrust;
-
             // effective thrust (the "average thrust" derived from the total mdot and the v_e)
-            public double EffectiveThrust => Ve * (StartMass - EndMass) / DeltaTime;
+            //public double EffectiveThrust => Ve * (StartMass - EndMass) / DeltaTime;
 
             // starting mass of the stage
             public double StartMass;
@@ -155,8 +149,13 @@ namespace MuMech
             // ending mass of the stage
             public double EndMass;
 
+            // max thrust of the stage
+            public double MaxThrust;
+
+            public double DeltaTime => Ve * (StartMass - EndMass) / MaxThrust;
+
             // starting acceleration of the stage (use EndThrust to avoid counting ullage motors)
-            private double A0 => EndThrust / StartMass;
+            private double A0 => MaxThrust / StartMass;
 
             // ideal time to consume the rocket completely
             public double Tau => Ve / A0;
@@ -165,7 +164,6 @@ namespace MuMech
             public int RocketStage;
 
             // the last parts list
-            private readonly List<Part> _parts = new List<Part>();
 
             private FuelFlowSimulation.FuelStats _vacFuelStats;
 
@@ -176,20 +174,16 @@ namespace MuMech
 
                 _vacFuelStats = _parent.core.stageStats.vacStats[KspStage];
                 DeltaV        = _vacFuelStats.DeltaV;
-                DeltaTime     = _vacFuelStats.DeltaTime;
-                Isp           = _vacFuelStats.Isp;
-                StartThrust   = _vacFuelStats.StartThrust * 1000;
-                EndThrust     = _vacFuelStats.EndThrust * 1000;
-                StartMass     = _vacFuelStats.StartMass * 1000;
-                EndMass       = _vacFuelStats.EndMass * 1000;
-
-                _parts.Clear();
-                for (int i = 0; i < _vacFuelStats.Parts.Count; i++) _parts.Add(_vacFuelStats.Parts[i]);
+                //DeltaTime     = _vacFuelStats.DeltaTime;
+                Isp       = _vacFuelStats.Isp;
+                MaxThrust = _vacFuelStats.MaxThrust * 1000;
+                StartMass = _vacFuelStats.StartMass * 1000;
+                EndMass   = _vacFuelStats.EndMass * 1000;
             }
 
             public override string ToString()
             {
-                return "ksp_stage: " + KspStage + " rocket_stage: " + RocketStage + " isp:" + Isp + " thrust:" + StartThrust + " m0: " + StartMass +
+                return "ksp_stage: " + KspStage + " rocket_stage: " + RocketStage + " isp:" + Isp + " thrust:" + MaxThrust + " m0: " + StartMass +
                        " maxt:" + DeltaTime;
             }
 

--- a/MechJeb2/MechJebStageStatsHelper.cs
+++ b/MechJeb2/MechJebStageStatsHelper.cs
@@ -17,37 +17,38 @@ namespace MuMech
     // Eventually, we should figure out how to not need that store at all.
     public class MechJebStageStatsHelper
     {
-        private bool showStagedMass, showBurnedMass, showInitialMass, showFinalMass, showVacInitialTWR, showAtmoInitialTWR;
-        private bool showAtmoMaxTWR, showVacMaxTWR, showAtmoDeltaV, showVacDeltaV, showTime, showISP, showEmpty, timeSeconds, liveSLT;
-        private int TWRBody;
-        private float altSLTScale, machScale;
-        private int StageDisplayState { get => infoItems.StageDisplayState; set => infoItems.StageDisplayState = value; }
+        private          bool showStagedMass, showBurnedMass, showInitialMass, showFinalMass, showMaxThrust, showVacInitialTWR, showAtmoInitialTWR;
+        private          bool showAtmoMaxTWR, showVacMaxTWR, showAtmoDeltaV, showVacDeltaV, showTime, showISP, showEmpty, timeSeconds, liveSLT;
+        private          int TWRBody;
+        private          float altSLTScale, machScale;
+        private          int StageDisplayState { get => infoItems.StageDisplayState; set => infoItems.StageDisplayState = value; }
         private readonly MechJebModuleInfoItems infoItems;
         private readonly MechJebCore core;
         private readonly MechJebModuleStageStats stats;
         public MechJebStageStatsHelper(MechJebModuleInfoItems items)
         {
-            infoItems = items;
-            core = items.core;
-            stats = core.GetComputerModule<MechJebModuleStageStats>();
-            showStagedMass = items.showStagedMass;
-            showBurnedMass = items.showBurnedMass;
-            showInitialMass = items.showInitialMass;
-            showFinalMass = items.showFinalMass;
-            showVacInitialTWR = items.showVacInitialTWR;
+            infoItems          = items;
+            core               = items.core;
+            stats              = core.GetComputerModule<MechJebModuleStageStats>();
+            showStagedMass     = items.showStagedMass;
+            showBurnedMass     = items.showBurnedMass;
+            showInitialMass    = items.showInitialMass;
+            showFinalMass      = items.showFinalMass;
+            showVacInitialTWR  = items.showVacInitialTWR;
             showAtmoInitialTWR = items.showAtmoInitialTWR;
-            showAtmoMaxTWR = items.showAtmoMaxTWR;
-            showVacMaxTWR = items.showVacMaxTWR;
-            showAtmoDeltaV = items.showAtmoDeltaV;
-            showVacDeltaV = items.showVacDeltaV;
-            showTime = items.showTime;
-            showISP = items.showISP;
-            showEmpty = items.showEmpty;
-            timeSeconds = items.timeSeconds;
-            liveSLT = items.liveSLT;
-            altSLTScale = items.altSLTScale;
-            machScale = items.machScale;
-            TWRBody = items.TWRBody;
+            showAtmoMaxTWR     = items.showAtmoMaxTWR;
+            showVacMaxTWR      = items.showVacMaxTWR;
+            showAtmoDeltaV     = items.showAtmoDeltaV;
+            showVacDeltaV      = items.showVacDeltaV;
+            showTime           = items.showTime;
+            showISP            = items.showISP;
+            showMaxThrust      = items.showMaxThrust;
+            showEmpty          = items.showEmpty;
+            timeSeconds        = items.timeSeconds;
+            liveSLT            = items.liveSLT;
+            altSLTScale        = items.altSLTScale;
+            machScale          = items.machScale;
+            TWRBody            = items.TWRBody;
 
             bodies = (HighLogic.LoadedSceneIsFlight || HighLogic.LoadedSceneIsEditor) ? FlightGlobals.Bodies.ConvertAll(b => b.GetName()).ToArray() : new [] { "None" };
             InitializeStageInfo();
@@ -56,11 +57,11 @@ namespace MuMech
 
         private enum StageData
         {
-            InitialMass, FinalMass, StagedMass, BurnedMass, VacInitialTWR, VacMaxTWR, AtmoInitialTWR, AtmoMaxTWR, Isp, AtmoDeltaV, VacDeltaV, Time
+            InitialMass, FinalMass, StagedMass, BurnedMass, MaxThrust, VacInitialTWR, VacMaxTWR, AtmoInitialTWR, AtmoMaxTWR, Isp, AtmoDeltaV, VacDeltaV, Time
         };
         private static readonly List<StageData> AllStages = new List<StageData>
-        { 
-            StageData.InitialMass, StageData.FinalMass, StageData.StagedMass, StageData.BurnedMass, StageData.VacInitialTWR, StageData.VacMaxTWR, StageData.AtmoInitialTWR, StageData.AtmoMaxTWR, StageData.Isp, StageData.AtmoDeltaV, StageData.VacDeltaV, StageData.Time
+        {
+            StageData.InitialMass, StageData.FinalMass, StageData.StagedMass, StageData.BurnedMass, StageData.MaxThrust, StageData.VacInitialTWR, StageData.VacMaxTWR, StageData.AtmoInitialTWR, StageData.AtmoMaxTWR, StageData.Isp, StageData.AtmoDeltaV, StageData.VacDeltaV, StageData.Time
         };
         private static readonly string[] StageDisplayStates = { Localizer.Format("#MechJeb_InfoItems_button1"),Localizer.Format("#MechJeb_InfoItems_button2"),Localizer.Format("#MechJeb_InfoItems_button3"),Localizer.Format("#MechJeb_InfoItems_button4") };//"Short stats""Long stats""Full stats""Custom"
 
@@ -89,6 +90,7 @@ namespace MuMech
             stageHeaderData.Add(StageData.FinalMass,CachedLocalizer.Instance.MechJeb_InfoItems_StatsColumn2 + SPACING);
             stageHeaderData.Add(StageData.StagedMass, CachedLocalizer.Instance.MechJeb_InfoItems_StatsColumn3 + SPACING);
             stageHeaderData.Add(StageData.BurnedMass, CachedLocalizer.Instance.MechJeb_InfoItems_StatsColumn4 + SPACING);
+            stageHeaderData.Add(StageData.MaxThrust, CachedLocalizer.Instance.MechJeb_InfoItems_StatsColumn13 + SPACING);
             stageHeaderData.Add(StageData.VacInitialTWR, CachedLocalizer.Instance.MechJeb_InfoItems_StatsColumn5 + SPACING);
             stageHeaderData.Add(StageData.VacMaxTWR, CachedLocalizer.Instance.MechJeb_InfoItems_StatsColumn6 + SPACING);
             stageHeaderData.Add(StageData.AtmoInitialTWR, CachedLocalizer.Instance.MechJeb_InfoItems_StatsColumn7 + SPACING);
@@ -117,6 +119,7 @@ namespace MuMech
                 if (stageVisibility[StageData.FinalMass]) stageDisplayInfo[StageData.FinalMass].Add($"{stats.atmoStats[index].EndMass:F3} t   ");
                 if (stageVisibility[StageData.StagedMass]) stageDisplayInfo[StageData.StagedMass].Add($"{stats.atmoStats[index].StagedMass:F3} t   ");
                 if (stageVisibility[StageData.BurnedMass]) stageDisplayInfo[StageData.BurnedMass].Add($"{stats.atmoStats[index].ResourceMass:F3} t   ");
+                if (stageVisibility[StageData.MaxThrust]) stageDisplayInfo[StageData.MaxThrust].Add($"{stats.atmoStats[index].MaxThrust:F3} kN   ");
                 if (stageVisibility[StageData.VacInitialTWR]) stageDisplayInfo[StageData.VacInitialTWR].Add($"{stats.vacStats[index].StartTWR(geeASL):F2}   ");
                 if (stageVisibility[StageData.VacMaxTWR]) stageDisplayInfo[StageData.VacMaxTWR].Add($"{stats.vacStats[index].MaxTWR(geeASL):F2}   ");
                 if (stageVisibility[StageData.AtmoInitialTWR]) stageDisplayInfo[StageData.AtmoInitialTWR].Add($"{stats.atmoStats[index].StartTWR(geeASL):F2}   ");
@@ -262,34 +265,36 @@ namespace MuMech
 
         private void LoadStageVisibility()
         {
-            stageVisibility[StageData.StagedMass] = showStagedMass;
-            stageVisibility[StageData.BurnedMass] = showBurnedMass;
-            stageVisibility[StageData.InitialMass] = showInitialMass;
-            stageVisibility[StageData.FinalMass] = showFinalMass;
-            stageVisibility[StageData.VacInitialTWR] = showVacInitialTWR;
+            stageVisibility[StageData.StagedMass]     = showStagedMass;
+            stageVisibility[StageData.BurnedMass]     = showBurnedMass;
+            stageVisibility[StageData.InitialMass]    = showInitialMass;
+            stageVisibility[StageData.FinalMass]      = showFinalMass;
+            stageVisibility[StageData.MaxThrust]      = showMaxThrust;
+            stageVisibility[StageData.VacInitialTWR]  = showVacInitialTWR;
             stageVisibility[StageData.AtmoInitialTWR] = showAtmoInitialTWR;
-            stageVisibility[StageData.AtmoMaxTWR] = showAtmoMaxTWR;
-            stageVisibility[StageData.VacMaxTWR] = showVacMaxTWR;
-            stageVisibility[StageData.AtmoDeltaV] = showAtmoDeltaV;
-            stageVisibility[StageData.VacDeltaV] = showVacDeltaV;
-            stageVisibility[StageData.Time] = showTime;
-            stageVisibility[StageData.Isp] = showISP;
+            stageVisibility[StageData.AtmoMaxTWR]     = showAtmoMaxTWR;
+            stageVisibility[StageData.VacMaxTWR]      = showVacMaxTWR;
+            stageVisibility[StageData.AtmoDeltaV]     = showAtmoDeltaV;
+            stageVisibility[StageData.VacDeltaV]      = showVacDeltaV;
+            stageVisibility[StageData.Time]           = showTime;
+            stageVisibility[StageData.Isp]            = showISP;
         }
 
         private void SaveStageVisibility()
         {
-            showStagedMass = infoItems.showStagedMass = stageVisibility[StageData.StagedMass];
-            showBurnedMass = infoItems.showBurnedMass = stageVisibility[StageData.BurnedMass];
-            showInitialMass = infoItems.showInitialMass = stageVisibility[StageData.InitialMass];
-            showFinalMass = infoItems.showFinalMass = stageVisibility[StageData.FinalMass];
-            showVacInitialTWR = infoItems.showVacInitialTWR = stageVisibility[StageData.VacInitialTWR];
+            showStagedMass     = infoItems.showStagedMass     = stageVisibility[StageData.StagedMass];
+            showBurnedMass     = infoItems.showBurnedMass     = stageVisibility[StageData.BurnedMass];
+            showInitialMass    = infoItems.showInitialMass    = stageVisibility[StageData.InitialMass];
+            showFinalMass      = infoItems.showFinalMass      = stageVisibility[StageData.FinalMass];
+            showMaxThrust      = infoItems.showMaxThrust      = stageVisibility[StageData.MaxThrust];
+            showVacInitialTWR  = infoItems.showVacInitialTWR  = stageVisibility[StageData.VacInitialTWR];
             showAtmoInitialTWR = infoItems.showAtmoInitialTWR = stageVisibility[StageData.AtmoInitialTWR];
-            showAtmoMaxTWR = infoItems.showAtmoMaxTWR = stageVisibility[StageData.AtmoMaxTWR];
-            showVacMaxTWR = infoItems.showVacMaxTWR = stageVisibility[StageData.VacMaxTWR];
-            showAtmoDeltaV = infoItems.showAtmoDeltaV = stageVisibility[StageData.AtmoDeltaV];
-            showVacDeltaV = infoItems.showVacDeltaV = stageVisibility[StageData.VacDeltaV];
-            showTime = infoItems.showTime = stageVisibility[StageData.Time];
-            showISP = infoItems.showISP = stageVisibility[StageData.Isp];
+            showAtmoMaxTWR     = infoItems.showAtmoMaxTWR     = stageVisibility[StageData.AtmoMaxTWR];
+            showVacMaxTWR      = infoItems.showVacMaxTWR      = stageVisibility[StageData.VacMaxTWR];
+            showAtmoDeltaV     = infoItems.showAtmoDeltaV     = stageVisibility[StageData.AtmoDeltaV];
+            showVacDeltaV      = infoItems.showVacDeltaV      = stageVisibility[StageData.VacDeltaV];
+            showTime           = infoItems.showTime           = stageVisibility[StageData.Time];
+            showISP            = infoItems.showISP            = stageVisibility[StageData.Isp];
         }
 
         private void SetVisibility(int state)
@@ -298,17 +303,19 @@ namespace MuMech
             {
                 case 0:
                     SetAllStageVisibility(false);
-                    stageVisibility[StageData.VacInitialTWR] = true;
+                    stageVisibility[StageData.MaxThrust]      = false;
+                    stageVisibility[StageData.VacInitialTWR]  = true;
                     stageVisibility[StageData.AtmoInitialTWR] = true;
-                    stageVisibility[StageData.VacDeltaV] = true;
-                    stageVisibility[StageData.AtmoDeltaV] = true;
-                    stageVisibility[StageData.Time] = true;
+                    stageVisibility[StageData.VacDeltaV]      = true;
+                    stageVisibility[StageData.AtmoDeltaV]     = true;
+                    stageVisibility[StageData.Time]           = true;
                     break;
                 case 1:
                     SetAllStageVisibility(true);
+                    stageVisibility[StageData.MaxThrust]  = false;
                     stageVisibility[StageData.StagedMass] = false;
                     stageVisibility[StageData.BurnedMass] = false;
-                    stageVisibility[StageData.Isp] = false;
+                    stageVisibility[StageData.Isp]        = false;
                     break;
                 case 2:
                     SetAllStageVisibility(true);

--- a/MechJeb2/Pontryagin/Arc.cs
+++ b/MechJeb2/Pontryagin/Arc.cs
@@ -16,7 +16,7 @@ namespace MuMech
             return sb.ToString();
         }
     }
-    
+
     public class Arc
     {
         private readonly PontryaginBase                          p;
@@ -73,7 +73,7 @@ namespace MuMech
             if (stage != null)
             {
                 Isp          = stage.Isp;
-                Thrust       = stage.EffectiveThrust; // use the effective thrust to deal with ullage motors
+                Thrust       = stage.MaxThrust; // use the effective thrust to deal with ullage motors
                 M0           = stage.StartMass;
                 AvailDV      = stage.DeltaV;
                 MaxBt        = stage.DeltaTime;

--- a/MechJeb2/Pontryagin/PontryaginLaunch.cs
+++ b/MechJeb2/Pontryagin/PontryaginLaunch.cs
@@ -431,7 +431,7 @@ namespace MuMech {
 
             // update initial position and guess for first arc (uses effective thrust to deal with ullage motors)
             double ve = g0 * stages[0].Isp;
-            tgo = ve * stages[0].StartMass / stages[0].EffectiveThrust * ( 1 - Math.Exp(-dV/ve) );
+            tgo = ve * stages[0].StartMass / stages[0].MaxThrust * ( 1 - Math.Exp(-dV/ve) );
             tgo_bar = tgo / t_scale;
 
             // initialize overall burn time


### PR DESCRIPTION
- Adds a new MaxThrust field to the stage stats display

This is computed as the MaxThrust of all the engines burning
at the end of the stage.  This is deliberately to avoid counting
ullage solids that burnout after a few seconds.  It may, however,
be viewed as being slightly misleading.  But the purpose of this
field is really for PVG to have a single number for the thrust of the
stage which is more realistic than the current behavior where it
gets the initial thrust of the engine including the thrust curve.

- Converts PVG to use MaxThrust + ISP + MassDelta to get total
burntime instead of the other way around.  PVGs computed burntime
for a Castor 30 XL is now 2mins instead of 8 mins.

- The displayed burntime, TWRs and SLTs are still wildly off, those
need to be fixed more deeply in the code which analyzes the
engine and produces the mass flow rate at conditions.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>