### PR TITLE
Tweak tranfer planner SQP settings

### DIFF
--- a/MechJeb2/Maneuver/TransferCalculator.cs
+++ b/MechJeb2/Maneuver/TransferCalculator.cs
@@ -267,7 +267,7 @@ namespace MuMech
         private void FindSOI(ManeuverParameters maneuver, ref double utArrival)
         {
             const int VARS = 5;
-            const double DIFFSTEP = 1e-6;
+            const double DIFFSTEP = 1e-10;
             const double EPSX = 1e-4;
             const int MAXITS = 1000;
             const int EQUALITYCONSTRAINTS = 3;
@@ -334,8 +334,8 @@ namespace MuMech
         private void AdjustPeriapsis(ManeuverParameters maneuver, ref double utArrival)
         {
             const int VARS = 3;
-            const double DIFFSTEP = 1e-8;
-            const double EPSX = 1e-7;
+            const double DIFFSTEP = 1e-10;
+            const double EPSX = 1e-4;
             const int MAXITS = 1000;
             const int EQUALITYCONSTRAINTS = 1;
             const int INEQUALITYCONSTRAINTS = 0;


### PR DESCRIPTION
Adjust the diffstep way down, experimentation with Matlab indicates this
may not hinder convergence as much as the alglib author suggests.

Adjust EPSX upwards so stopping conditions are more lenient.

This worked on my one test so far with a high level of accuracy on a
target from a horrible parking orbit on Earth to Saturn with a periapsis
altitude of 2010km (2,010,006m actual).

This may address or partially address #1533 