### PR TITLE
Fix much Torquestuff

### DIFF
--- a/MechJeb2/AttitudeControllers/BetterController.cs
+++ b/MechJeb2/AttitudeControllers/BetterController.cs
@@ -214,7 +214,7 @@ namespace MuMech.AttitudeControllers
             // lowpass filter on the error input
             _error0 = _error1.IsFinite() ? _error1 + PosSmoothIn * (_error0 - _error1) : _error0;
 
-            Vector3d controlTorque = ac.torque;
+            Vector3 controlTorque = ac.torque.SelectAxis(_error0);
 
             // needed to stop wiggling at higher phys warp
             double warpFactor = Math.Pow(ac.vesselState.deltaT / 0.02, 0.90); // the power law here comes ultimately from the simulink PID tuning app
@@ -277,7 +277,7 @@ namespace MuMech.AttitudeControllers
                 if (Math.Abs(_actuation[i]) < EPS || double.IsNaN(_actuation[i]))
                     _actuation[i] = 0;
 
-                _targetTorque[i] = _actuation[i] / ac.torque[i];
+                _targetTorque[i] = _actuation[i] / controlTorque[i];
 
                 if (ac.ActuationControl[i] == 0)
                     Reset(i);

--- a/MechJeb2/AttitudeControllers/BetterController.cs
+++ b/MechJeb2/AttitudeControllers/BetterController.cs
@@ -214,7 +214,7 @@ namespace MuMech.AttitudeControllers
             // lowpass filter on the error input
             _error0 = _error1.IsFinite() ? _error1 + PosSmoothIn * (_error0 - _error1) : _error0;
 
-            Vector3 controlTorque = ac.torque.SelectAxis(_error0);
+            Vector3d controlTorque = ac.torque.SelectAxis(_error0);
 
             // needed to stop wiggling at higher phys warp
             double warpFactor = Math.Pow(ac.vesselState.deltaT / 0.02, 0.90); // the power law here comes ultimately from the simulink PID tuning app

--- a/MechJeb2/AttitudeControllers/HybridController.cs
+++ b/MechJeb2/AttitudeControllers/HybridController.cs
@@ -39,7 +39,7 @@ namespace MuMech.AttitudeControllers
         /* max angular rotation */
         private Vector3d MaxOmega = Vector3d.zero;
 
-        private Vector3d ControlTorque { get { return ac.torque; } }
+        private Vector3d ControlTorque { get { return ac.torque.ToVector3d(); } }
 
         public HybridController(MechJebModuleAttitudeController controller) : base(controller)
         {

--- a/MechJeb2/AttitudeControllers/KosAttitudeController.cs
+++ b/MechJeb2/AttitudeControllers/KosAttitudeController.cs
@@ -22,7 +22,7 @@ namespace MuMech.AttitudeControllers
         public KosPIDLoop pitchRatePI = new KosPIDLoop(1, 0.1, 0, extraUnwind: true);
         public KosPIDLoop yawRatePI = new KosPIDLoop(1, 0.1, 0, extraUnwind: true);
         public KosPIDLoop rollRatePI = new KosPIDLoop(1, 0.1, 0, extraUnwind: true);
-        
+
         private Vector3d Actuation = Vector3d.zero;
         private Vector3d TargetTorque = Vector3d.zero;
         private Vector3d Omega = Vector3d.zero;
@@ -36,7 +36,7 @@ namespace MuMech.AttitudeControllers
         /* max angular rotation */
         private Vector3d MaxOmega = Vector3d.zero;
 
-        private Vector3d ControlTorque { get { return ac.torque; } }
+        private Vector3d ControlTorque { get { return ac.torque.ToVector3d(); } }
 
         public KosAttitudeController(MechJebModuleAttitudeController controller) : base(controller)
         {
@@ -52,7 +52,7 @@ namespace MuMech.AttitudeControllers
             deltaEuler = phiVector * Mathf.Rad2Deg;
             act = Actuation;
         }
-        
+
         /* temporary state vectors */
         private Quaternion vesselRotation;
         private Vector3d vesselForward;
@@ -60,7 +60,7 @@ namespace MuMech.AttitudeControllers
         private Vector3d vesselStarboard;
         private Vector3d targetForward;
         private Vector3d targetTop;
-        
+
         /* private Vector3d targetStarboard; */
 
         private void UpdateStateVectors() {
@@ -102,12 +102,12 @@ namespace MuMech.AttitudeControllers
 
             return Phi;
         }
-        
+
         private void UpdatePredictionPI() {
             phiTotal = PhiTotal();
 
             phiVector = PhiVector();
-            
+
             for(int i = 0; i < 3; i++) {
                 MaxOmega[i] = ControlTorque[i] * maxStoppingTime / ac.vesselState.MoI[i];
             }
@@ -135,7 +135,7 @@ namespace MuMech.AttitudeControllers
             yawRatePI.ResetI();
             rollRatePI.ResetI();
         }
-        
+
 
         private void UpdateControl() {
             /* TODO: static engine torque and/or differential throttle */

--- a/MechJeb2/AttitudeControllers/MJAttitudeController.cs
+++ b/MechJeb2/AttitudeControllers/MJAttitudeController.cs
@@ -190,7 +190,7 @@ namespace MuMech.AttitudeControllers
                 Math.Max(-Math.PI, Math.Min(Math.PI, err.z)));
 
             // ( MoI / available torque ) factor:
-            Vector3d NormFactor = Vector3d.Scale(ac.vesselState.MoI, ac.torque.InvertNoNaN());
+            Vector3d NormFactor = Vector3d.Scale(ac.vesselState.MoI, ac.torque.ToVector3d().InvertNoNaN());
 
             err.Scale(NormFactor);
 
@@ -202,7 +202,7 @@ namespace MuMech.AttitudeControllers
             omega.Scale(NormFactor);
 
             if (Tf_autoTune)
-                tuneTf(ac.torque);
+                tuneTf(ac.torque.ToVector3d());
             setPIDParameters();
 
             // angular velocity limit:

--- a/MechJeb2/MechJebModuleAttitudeAdjustment.cs
+++ b/MechJeb2/MechJebModuleAttitudeAdjustment.cs
@@ -60,7 +60,7 @@ namespace MuMech
 
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label2"), GUILayout.ExpandWidth(true));//Torque
-                GUILayout.Label("|" + core.attitude.torque.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(core.attitude.torque),
+                GUILayout.Label("|" + core.attitude.torque.ToVector3d().magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(core.attitude.torque),
                     GUILayout.ExpandWidth(false));
                 GUILayout.EndHorizontal();
 
@@ -71,7 +71,7 @@ namespace MuMech
                     GUILayout.ExpandWidth(false));
                 GUILayout.EndHorizontal();
 
-                Vector3d ratio = Vector3d.Scale(vesselState.MoI, core.attitude.torque.InvertNoNaN());
+                Vector3d ratio = Vector3d.Scale(vesselState.MoI, core.attitude.torque.ToVector3d().InvertNoNaN());
 
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label4"), GUILayout.ExpandWidth(true));//MOI / torque

--- a/MechJeb2/MechJebModuleAttitudeController.cs
+++ b/MechJeb2/MechJebModuleAttitudeController.cs
@@ -106,7 +106,7 @@ namespace MuMech
 
         public double attitudeError;
 
-        public Vector3d torque;
+        public Vector6 torque;
         public Vector3d inertia;
 
         public MechJebModuleAttitudeController(MechJebCore core)
@@ -322,14 +322,14 @@ namespace MuMech
             torque = vesselState.torqueAvailable;
             if (core.thrust.differentialThrottle &&
                 core.thrust.differentialThrottleSuccess == MechJebModuleThrustController.DifferentialThrottleStatus.Success)
-                torque += vesselState.torqueDiffThrottle * vessel.ctrlState.mainThrottle / 2.0;
+                torque.positive += vesselState.torqueDiffThrottle * vessel.ctrlState.mainThrottle / 2.0;
 
             // Inertia is a bad name. It's the "angular distance to stop"
             inertia = 0.5 * Vector3d.Scale(
                 vesselState.angularMomentum.Sign(),
                 Vector3d.Scale(
                     Vector3d.Scale(vesselState.angularMomentum, vesselState.angularMomentum),
-                    Vector3d.Scale(torque, vesselState.MoI).InvertNoNaN()
+                    Vector3d.Scale(torque.ToVector3d(), vesselState.MoI).InvertNoNaN()
                 )
             );
             Controller.OnFixedUpdate();

--- a/MechJeb2/MechJebModuleRoverController.cs
+++ b/MechJeb2/MechJebModuleRoverController.cs
@@ -326,7 +326,7 @@ namespace MuMech
 				Vector3.OrthoNormalize(ref norm, ref fwd);
 				Quaternion quat = Quaternion.LookRotation(fwd, norm);
 
-				if (vesselState.torqueAvailable.sqrMagnitude > 0)
+				if (vesselState.torqueAvailable.ToVector3d().sqrMagnitude > 0)
 					core.attitude.attitudeTo(quat, AttitudeReference.INERTIAL, this);
 			}
 

--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -392,11 +392,11 @@ namespace MuMech
                 }
                 else
                 {
-                    bool useGimbal = (vesselState.torqueGimbal.positive.x > vesselState.torqueAvailable.x * 10) ||
-                                     (vesselState.torqueGimbal.positive.z > vesselState.torqueAvailable.z * 10);
+                    bool useGimbal = (vesselState.torqueGimbal.positive.x > vesselState.torqueAvailable.positive.x * 10) ||
+                                     (vesselState.torqueGimbal.positive.z > vesselState.torqueAvailable.positive.z * 10);
 
-                    bool useDiffThrottle = (vesselState.torqueDiffThrottle.x > vesselState.torqueAvailable.x * 10) ||
-                                           (vesselState.torqueDiffThrottle.z > vesselState.torqueAvailable.z * 10);
+                    bool useDiffThrottle = (vesselState.torqueDiffThrottle.x > vesselState.torqueAvailable.positive.x * 10) ||
+                                           (vesselState.torqueDiffThrottle.z > vesselState.torqueAvailable.positive.z * 10);
 
                     if ((core.attitude.attitudeError >= 2) && (useGimbal || (useDiffThrottle && core.thrust.differentialThrottle)))
                     {

--- a/MechJeb2/MuUtils.cs
+++ b/MechJeb2/MuUtils.cs
@@ -65,6 +65,12 @@ namespace MuMech
             return "[" + PadPositive(vector.x, format) + ", " + PadPositive(vector.y, format) + ", " + PadPositive(vector.z, format) + " ]";
         }
 
+        public static string PrettyPrint(Vector6 vector, string format = "F3")
+        {
+            return "[" + PadPositive(vector.positive.x,format) + ", " + PadPositive(vector.positive.y,format) + ", " + PadPositive(vector.positive.z,format) +
+                   " ], [" + PadPositive(-vector.negative.x,format) + ", " + PadPositive(-vector.negative.y,format) + ", " + PadPositive(-vector.negative.z,format) + " ]";
+        }
+
         public static string PrettyPrint(Quaternion quaternion, string format = "F3")
         {
             return "[" + PadPositive(quaternion.x, format) + ", " + PadPositive(quaternion.y, format) + ", " + PadPositive(quaternion.z, format) + ", " + PadPositive(quaternion.w ,format) + "]";
@@ -171,7 +177,7 @@ namespace MuMech
         {
             return (TimeWarp.WarpMode == TimeWarp.Modes.LOW) || (TimeWarp.CurrentRateIndex == 0);
         }
-        
+
         public static string SystemClipboard
         {
             get => GUIUtility.systemCopyBuffer;

--- a/MechJeb2/Vector6.cs
+++ b/MechJeb2/Vector6.cs
@@ -2,9 +2,9 @@
 
 namespace MuMech
 {
-    public class Vector6 : IConfigNode
+    public struct Vector6 : IConfigNode
     {
-        public Vector3d positive = Vector3d.zero, negative = Vector3d.zero;
+        public Vector3d positive, negative;
 
         public enum Direction { FORWARD=0, BACK=1, UP=2, DOWN=3, RIGHT=4, LEFT=5 };
 
@@ -66,7 +66,6 @@ namespace MuMech
             }
         }
 
-        public Vector6() { }
         public Vector6(Vector3d positive, Vector3d negative)
         {
             this.positive = positive;
@@ -107,6 +106,21 @@ namespace MuMech
             return Math.Sqrt(sqrMagnitude);
         }
 
+        public Vector3d SelectAxis(Vector3d other)
+        {
+            return new Vector3d
+            {
+                x = other.x > 0 ? positive.x : negative.x,
+                y = other.y > 0 ? positive.y : negative.y,
+                z = other.z > 0 ? positive.z : negative.z,
+            };
+        }
+
+        public Vector3d ToVector3d()
+        {
+            return Vector3d.Max(positive,negative);
+        }
+
         public double MaxMagnitude()
         {
             return Math.Max(positive.MaxMagnitude(),negative.MaxMagnitude());
@@ -122,6 +136,17 @@ namespace MuMech
             {
                 negative = KSPUtil.ParseVector3d(node.GetValue("negative"));
             }
+        }
+
+        public static Vector6 operator +(Vector6 a,Vector6 b)
+        {
+            Vector6 sum = new Vector6
+            {
+                positive = a.positive + b.positive,
+                negative = a.negative + b.negative
+            };
+
+            return sum;
         }
 
         public void Save(ConfigNode node)

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using Smooth.Pools;
 using UnityEngine;
 using System.Reflection;
-using Expansions.Missions.Editor;
 using KSP.Localization;
 
 namespace MuMech

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Smooth.Pools;
 using UnityEngine;
 using System.Reflection;
+using Expansions.Missions.Editor;
 using KSP.Localization;
 
 namespace MuMech
@@ -272,7 +273,7 @@ namespace MuMech
 
 
         // Total torque
-        public Vector3d torqueAvailable;
+        public Vector6 torqueAvailable;
 
         public Vector3d torqueReactionSpeed;
 
@@ -922,7 +923,7 @@ namespace MuMech
         private const double _dVelocitySqrMinThreshold = 1;
         private const double _dAltitudeThreshold = 300;
         private const float _fAoAThreshold = 2;
-        private void CalculateVesselAeroForcesWithCache(Vessel v, out Vector3 farForce, out Vector3 farTorque, Vector3d surfaceVelocity, double altitudeASL) 
+        private void CalculateVesselAeroForcesWithCache(Vessel v, out Vector3 farForce, out Vector3 farTorque, Vector3d surfaceVelocity, double altitudeASL)
         {
             float AoA = Vector3.Angle(v.rootPart.transform.TransformDirection(Vector3.up), surfaceVelocity);
             if ((lastSurfaceVelocity - surfaceVelocity).sqrMagnitude > _dVelocitySqrThreshold
@@ -948,7 +949,7 @@ namespace MuMech
             parachutes.Clear();
             parachuteDeployed = false;
 
-            torqueAvailable = Vector3d.zero;
+            torqueAvailable = new Vector6();
 
             Vector6 torqueReactionSpeed6 = new Vector6();
 
@@ -1035,8 +1036,8 @@ namespace MuMech
                         rw.GetPotentialTorque(out pos, out neg);
 
                         // GetPotentialTorque reports the same value for pos & neg on ModuleReactionWheel
-                        torqueReactionWheel.Add(pos);
-                        torqueReactionWheel.Add(-neg);
+                        torqueReactionWheel.Add(pos.Abs());
+                        torqueReactionWheel.Add(-neg.Abs());
                     }
                     else if (pm is ModuleEngines)
                     {
@@ -1072,8 +1073,8 @@ namespace MuMech
 
                         cs.GetPotentialTorque(out ctrlTorquePos, out ctrlTorqueNeg);
 
-                        torqueControlSurface.Add(ctrlTorquePos);
-                        torqueControlSurface.Add(ctrlTorqueNeg);
+                        torqueControlSurface.Add(ctrlTorquePos.Abs());
+                        torqueControlSurface.Add(-ctrlTorqueNeg.Abs());
 
                         torqueReactionSpeed6.Add(Mathf.Abs(cs.ctrlSurfaceRange) / cs.actuatorSpeed * Vector3d.Max(ctrlTorquePos.Abs(), ctrlTorqueNeg.Abs()));
                     }
@@ -1099,8 +1100,8 @@ namespace MuMech
 
                         // GetPotentialTorque reports the same value for pos & neg on ModuleGimbal
 
-                        torqueGimbal.Add(pos);
-                        torqueGimbal.Add(-neg);
+                        torqueGimbal.Add(pos.Abs());
+                        torqueGimbal.Add(-neg.Abs());
 
                         if (g.useGimbalResponseSpeed)
                             torqueReactionSpeed6.Add((Mathf.Abs(g.gimbalRange) / g.gimbalResponseSpeed) * Vector3d.Max(pos.Abs(), neg.Abs()));
@@ -1117,8 +1118,8 @@ namespace MuMech
                         Vector3 neg;
                         tp.GetPotentialTorque(out pos, out neg);
 
-                        torqueOthers.Add(pos);
-                        torqueOthers.Add(neg);
+                        torqueOthers.Add(pos.Abs());
+                        torqueOthers.Add(-neg.Abs());
                     }
 
                     for (int index = 0; index < vesselStatePartModuleExtensions.Count; index++)
@@ -1154,25 +1155,25 @@ namespace MuMech
                 }
             }
 
-            torqueAvailable += Vector3d.Max(torqueReactionWheel.positive, torqueReactionWheel.negative);
+            torqueAvailable += torqueReactionWheel;
 
             //torqueAvailable += Vector3d.Max(torqueRcs.positive, torqueRcs.negative);
 
-            torqueAvailable += Vector3d.Max(rcsTorqueAvailable.positive, rcsTorqueAvailable.negative);
+            torqueAvailable += rcsTorqueAvailable;
 
-            torqueAvailable += Vector3d.Max(torqueControlSurface.positive, torqueControlSurface.negative);
+            torqueAvailable += torqueControlSurface;
 
-            torqueAvailable += Vector3d.Max(torqueGimbal.positive, torqueGimbal.negative);
+            torqueAvailable += torqueGimbal;
 
-            torqueAvailable += Vector3d.Max(torqueOthers.positive, torqueOthers.negative); // Mostly FAR
+            torqueAvailable += torqueOthers;
 
             torqueDiffThrottle = Vector3d.Max(einfo.torqueDiffThrottle.positive, einfo.torqueDiffThrottle.negative);
             torqueDiffThrottle.y = 0;
 
-            if (torqueAvailable.sqrMagnitude > 0)
+            if (torqueAvailable.ToVector3d().sqrMagnitude > 0)
             {
                 torqueReactionSpeed = Vector3d.Max(torqueReactionSpeed6.positive, torqueReactionSpeed6.negative);
-                torqueReactionSpeed.Scale(torqueAvailable.InvertNoNaN());
+                torqueReactionSpeed.Scale(torqueAvailable.ToVector3d().InvertNoNaN());
             }
             else
             {


### PR DESCRIPTION
- convert Vector6 to a struct
- convert availableTorque to a Vector6
- convert Vector6 ToVector3d in a few places to maintain backcompat
  (places that may continue to be buggy I suspect, but out of scope for now)
- in the BetterController select which torque 'sense' to use based on
  the sign of the component of the error vector (asymmetric torque
  handling)
- Abs() the values coming off of GetPotentialTorque() and fix the sense
  of the vector manually to work around KSP bugginess with pos/neg
  values being all over the place.