### PR TITLE
Don't release clamps if an engine failed to ignite

### DIFF
--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -124,33 +124,21 @@ namespace MuMech
             {
                 if (anyNodeExists && !core.node.enabled)
                 {
-                    if (VesselState.isLoadedPrincipia)
+                    if (GUILayout.Button(Localizer.Format("#MechJeb_Maneu_button4")))//Execute next node
                     {
-                        if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
-                        {
-                            core.node.ExecuteOnePNode(this);
-                        }
-                        else if (core.node.enabled)
-                        {
-                            if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button6")))//"Abort node execution"
-                            {
-                                core.node.Abort();
-                            }
-                        }
+                        core.node.ExecuteOneNode(this);
                     }
-                    else
-                    {
-                        if (GUILayout.Button(Localizer.Format("#MechJeb_Maneu_button4")))//Execute next node
-                        {
-                            core.node.ExecuteOneNode(this);
-                        }
 
-                        if (vessel.patchedConicSolver.maneuverNodes.Count > 1)
+                    if (VesselState.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
+                    {
+                        core.node.ExecuteOnePNode(this);
+                    }
+
+                    if (vessel.patchedConicSolver.maneuverNodes.Count > 1)
+                    {
+                        if (GUILayout.Button(Localizer.Format("#MechJeb_Maneu_button5")))//Execute all nodes
                         {
-                            if (GUILayout.Button(Localizer.Format("#MechJeb_Maneu_button5")))//Execute all nodes
-                            {
-                                core.node.ExecuteAllNodes(this);
-                            }
+                            core.node.ExecuteAllNodes(this);
                         }
                     }
                 }

--- a/MechJeb2/MechJebModuleNodeEditor.cs
+++ b/MechJeb2/MechJebModuleNodeEditor.cs
@@ -225,26 +225,21 @@ namespace MuMech
             {
                 if (vessel.patchedConicSolver.maneuverNodes.Count > 0 && !core.node.enabled)
                 {
-                    if (VesselState.isLoadedPrincipia)
+                    if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button4")))//"Execute next node"
                     {
-                        if (VesselState.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
-                        {
-                            core.node.ExecuteOnePNode(this);
-                        }
+                        core.node.ExecuteOneNode(this);
                     }
-                    else
-                    {
-                        if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button4")))//"Execute next node"
-                        {
-                            core.node.ExecuteOneNode(this);
-                        }
 
-                        if (vessel.patchedConicSolver.maneuverNodes.Count > 1)
+                    if (VesselState.isLoadedPrincipia && GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button7")))//Execute next Principia node
+                    {
+                        core.node.ExecuteOnePNode(this);
+                    }
+
+                    if (vessel.patchedConicSolver.maneuverNodes.Count > 1)
+                    {
+                        if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button5")))//"Execute all nodes"
                         {
-                            if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button5")))//"Execute all nodes"
-                            {
-                                core.node.ExecuteAllNodes(this);
-                            }
+                            core.node.ExecuteAllNodes(this);
                         }
                     }
                 }

--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -268,8 +268,8 @@ namespace MuMech
                     HasFairing(vessel.currentStage - 1))
                     return;
 
-                //only release launch clamps if we're at nearly full thrust
-                if (vesselState.thrustCurrent / vesselState.thrustAvailable < clampAutoStageThrustPct &&
+                //only release launch clamps if we're at nearly full thrust and no failed engines
+                if ((vesselState.thrustCurrent / vesselState.thrustAvailable < clampAutoStageThrustPct || AnyFailedEngines(allModuleEngines)) &&
                     InverseStageReleasesClamps(vessel.currentStage - 1))
                     return;
             }
@@ -356,6 +356,18 @@ namespace MuMech
             result = allModuleEngines.FirstOrDefault(me => me.part.inverseStage == inverseStage) != null;
             inverseStageHasEngines.Add(inverseStage, result);
             return result;
+        }
+
+        public bool AnyFailedEngines(List<ModuleEngines> allEngines)
+        {
+            foreach (ModuleEngines engine in allEngines)
+            {
+                Part p = engine.part;
+                if (p.inverseStage >= vessel.currentStage && !p.IsDecoupledInStage(vessel.currentStage - 1) && engine.isEnabled && !engine.EngineIgnited && engine.allowShutdown)
+                    return true;
+            }
+
+            return false;
         }
 
         public void UpdateActiveModuleEngines(List<ModuleEngines> allEngines)

--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -379,7 +379,7 @@ namespace MuMech
         // detect if this part is an SRB, will be dropped in the next stage, and we are below the enabled dropSolidsLeadTime
         public bool isBurnedOutSRBDecoupledInNextStage(Part p)
         {
-            return dropSolids && p.IsEngine() && p.IsThrottleLockedEngine() && LastNonZeroDVStageBurnTime() < dropSolidsLeadTime && p.IsDecoupledInStage(vessel.currentStage - 1);
+            return dropSolids && p.IsThrottleLockedEngine() && LastNonZeroDVStageBurnTime() < dropSolidsLeadTime && p.IsDecoupledInStage(vessel.currentStage - 1);
         }
 
         //detect if a part is above an active or idle engine in the part tree
@@ -392,7 +392,7 @@ namespace MuMech
 
             if (!p.IsSepratron() && !isBurnedOutSRBDecoupledInNextStage(p))
             {
-                if ((p.State == PartStates.ACTIVE || p.State == PartStates.IDLE) && p.IsEngine() && p.EngineHasFuel())
+                if ((p.State == PartStates.ACTIVE || p.State == PartStates.IDLE) && p.EngineHasFuel())
                 {
                     return true; // TODO: properly check if ModuleEngines is active
                 }
@@ -455,7 +455,7 @@ namespace MuMech
             if (p is null)
                 return false;
 
-            if ((p.State == PartStates.DEACTIVATED) && (p.IsEngine()) && !p.IsSepratron())
+            if ((p.State == PartStates.DEACTIVATED) && p.IsEngine() && !p.IsSepratron())
             {
                 return true; // TODO: yet more ModuleEngine lazy checks
             }


### PR DESCRIPTION
(And add back the regular execute node buttons when Principia is installed because @lpgagnon misses them.)

Rather than reflecting into TF/TL/whatever, we just simply detect if an engine's stage is >= the current active stage, and if it is not ignited we do not release the next (clamp) stage. This does not interfere with normal clamp decoupling but does prevent decoupling when one or more engines fail to light (due to TF ignition failures or whatever).

This prevents the rocket from falling down and exploding real good, which seems useful.