### PR TITLE
Some changes to PVG plane targetting

### DIFF
--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -457,7 +457,7 @@ namespace MuMech
                 {
                     launchingToMatchLAN = true;
                     autopilot.StartCountdown(vesselState.time +
-                            SpaceMath.MinimumTimeToPlane(
+                            SpaceMath.TimeToPlane(
                                 mainBody.rotationPeriod,
                                 vesselState.latitude,
                                 vesselState.celestialLongitude,
@@ -474,7 +474,7 @@ namespace MuMech
                     {
                         launchingToLAN = true;
                         autopilot.StartCountdown(vesselState.time +
-                                SpaceMath.MinimumTimeToPlane(
+                                SpaceMath.TimeToPlane(
                                     mainBody.rotationPeriod,
                                     vesselState.latitude,
                                     vesselState.celestialLongitude,

--- a/MechJeb2/MechJebModuleAscentPVG.cs
+++ b/MechJeb2/MechJebModuleAscentPVG.cs
@@ -144,7 +144,8 @@ namespace MuMech
 
             ConvertToSMAEcc(autopilot.desiredOrbitAltitude, DesiredApoapsis, out sma, out ecc);
             ConvertToVTRT(sma, ecc, AttachAltFlag ? attachAlt : autopilot.desiredOrbitAltitude, out gammaT, out rT, out vT);
-            double inclination = autopilot.desiredInclination;
+            // Negative inclination is used in the warp-to-launch code to select the window, but breaks targetting a fixed plane.
+            double inclination = Math.Abs(autopilot.desiredInclination);
 
             if (AscentGuidance.launchingToPlane && core.target.NormalTargetExists)
             {


### PR DESCRIPTION
- Fix the time-to-plane function to work for all combinations of inclinations and latitudes
- Fix a small bug in PVG's boundary conditions that caused it to launch into the wrong plane when a negative inclination is specified
- Use the sign of the inclination to select between the northern or southern launch window, instead of always going for the nearest of the two (only in PVG launch-to-LAN mode)

One more thing: when warping to a plane, it currently warps until the launch site is exactly on the target plane. However, since the launch vehicle already has some eastwards velocity due to the rotation of the Earth, the rocket is actually east of the plane during most of the launch - this causes PVG to perform a small dog-leg of a degree or so. As far as I know, the ideal time to launch would be approximately half the time-to-orbit _before_ the launch site is in the target plane.

Would it be useful to add an input field in the auto-warp menu, where the user can input an offset that is added/subtracted from the auto-warp time? A default value of 0 gives the behavior as it is now, but by tuning this value, a slightly more efficient ascent is possible.

Another side-effect would be that this makes PVG able to do an Apollo-style off-plane launch to rendez-vous after the moon landing: by varying the offset until the time-to-launch is barely positive (instead of almost a month away), PVG will perform the required dog-leg during ascent automatically (the offset would be approximately the time spent on the surface).