### PR TITLE
Clean up TimeToPlane (fix reverse planetary rotations and poles)

### DIFF
--- a/MechJeb2.sln.DotSettings
+++ b/MechJeb2.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=KSC/@EntryIndexedValue">KSC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SOI/@EntryIndexedValue">SOI</s:String></wpf:ResourceDictionary>

--- a/MechJeb2/MechJeb2.csproj
+++ b/MechJeb2/MechJeb2.csproj
@@ -111,6 +111,7 @@
     <Compile Include="MechJebCore.cs" />
     <Compile Include="MechJebLib\Maths\BrentMin.cs" />
     <Compile Include="MechJebLib\Maths\BrentRoot.cs" />
+    <Compile Include="MechJebLib\Maths\Functions.cs" />
     <Compile Include="MechJebLib\Maths\Gooding.cs" />
     <Compile Include="MechJebLib\Maths\Shepperd.cs" />
     <Compile Include="MechJebLib\Utils\Check.cs" />

--- a/MechJeb2/MechJebLib/Maths/Functions.cs
+++ b/MechJeb2/MechJebLib/Maths/Functions.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * Copyright Lamont Granquist (lamont@scriptkiddie.org)
+ * Dual licensed under the MIT (MIT-LICENSE) license
+ * and GPLv2 (GPLv2-LICENSE) license or any later version.
+ */
+
+using System;
+using static MechJebLib.Utils.Statics;
+
+#nullable enable
+
+namespace MechJebLib.Maths
+{
+    public static class Functions
+    {
+        /// <summary>
+        ///     Find the time to a target plane defined by the LAN and inc for a rocket on the ground.  Wrapper which handles
+        ///     picking
+        ///     the soonest of the northgoing and southgoing ground tracks.
+        /// </summary>
+        /// <param name="rotationPeriod">Rotation period of the central body (seconds).</param>
+        /// <param name="latitude">Latitude of the launch site (degrees).</param>
+        /// <param name="celestialLongitude">Celestial longitude of the current position of the launch site.</param>
+        /// <param name="LAN">Longitude of the Ascending Node of the target plane (degrees).</param>
+        /// <param name="inc">Inclination of the target plane (degrees).</param>
+        public static double MinimumTimeToPlane(double rotationPeriod,double latitude,double celestialLongitude,double LAN,double inc)
+        {
+            double one = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,inc);
+            double two = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,-inc);
+            return Math.Min(one,two);
+        }
+
+
+        /// <summary>
+        ///     Find the time to a target plane defined by the LAN and inc for a rocket on the ground.
+        /// </summary>
+        /// <param name="rotationPeriod">Rotation period of the central body (seconds).</param>
+        /// <param name="latitude">Latitude of the launch site (degrees).</param>
+        /// <param name="celestialLongitude">Celestial longitude of the current position of the launch site (degrees).</param>
+        /// <param name="LAN">Longitude of the Ascending Node of the target plane (degrees).</param>
+        /// <param name="inc">Inclination of the target plane (degrees).</param>
+        public static double TimeToPlane(double rotationPeriod,double latitude,double celestialLongitude,double LAN,double inc)
+        {
+            latitude           = Deg2Rad(latitude);
+            celestialLongitude = Deg2Rad(celestialLongitude);
+            LAN                = Deg2Rad(LAN);
+            inc                = Deg2Rad(inc);
+
+            // handle singularities at the poles where tan(lat) is infinite
+            if (Math.Abs(Math.Abs(latitude) - PI / 2) < EPS)
+                return 0;
+
+            // Napier's rules for spherical trig
+            // the clamped Asin produces correct results for abs(inc) < abs(lat)
+            double angleEastOfAN = SafeAsin(Math.Tan(latitude) / Math.Tan(Math.Abs(inc)));
+
+            // handle south going trajectories (and the other two quadrants that Asin doesn't cover).
+            // if you are launching to the north your AN is always going to be [-90,90] relative to
+            // the zero of the launch site.  or facing the launch site your AN is always going to be
+            // in "front" of the planet.  but launching south the AN is [90,270] and the AN is always
+            // "behind" the planet.
+            if (inc < 0)
+                angleEastOfAN = PI - angleEastOfAN;
+
+            double LANNow = celestialLongitude - angleEastOfAN;
+
+            double LANDiff = LAN - LANNow;
+
+            // handle planets that rotate backwards
+            if (rotationPeriod < 0)
+                LANDiff = -LANDiff;
+
+            return Clamp2Pi(LANDiff) / TAU * Math.Abs(rotationPeriod);
+        }
+    }
+}

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using KSP.UI.Screens;
 using KSP.Localization;
+using MechJebLib.Maths;
 using UnityEngine.Profiling;
 
 namespace MuMech
@@ -21,7 +22,7 @@ namespace MuMech
         public bool launchingToMatchLAN = false;
         public bool launchingToLAN = false;
         public bool Launching => launchingToPlane || launchingToRendezvous || launchingToMatchLAN || launchingToLAN;
-                
+
         public MechJebModuleAscentAutopilot autopilot { get { return core.GetComputerModule<MechJebModuleAscentAutopilot>(); } }
         public MechJebModuleAscentPVG pvgascent { get { return core.GetComputerModule<MechJebModuleAscentPVG>(); } }
         public MechJebModuleAscentGT gtascent { get { return core.GetComputerModule<MechJebModuleAscentGT>(); } }
@@ -441,7 +442,7 @@ namespace MuMech
                 {
                     launchingToPlane = true;
                     autopilot.StartCountdown(vesselState.time +
-                            SpaceMath.MinimumTimeToPlane(
+                            Functions.MinimumTimeToPlane(
                                 mainBody.rotationPeriod,
                                 vesselState.latitude,
                                 vesselState.celestialLongitude,
@@ -457,7 +458,7 @@ namespace MuMech
                 {
                     launchingToMatchLAN = true;
                     autopilot.StartCountdown(vesselState.time +
-                            SpaceMath.MinimumTimeToPlane(
+                            Functions.MinimumTimeToPlane(
                                 mainBody.rotationPeriod,
                                 vesselState.latitude,
                                 vesselState.celestialLongitude,
@@ -474,7 +475,7 @@ namespace MuMech
                     {
                         launchingToLAN = true;
                         autopilot.StartCountdown(vesselState.time +
-                                SpaceMath.MinimumTimeToPlane(
+                                Functions.MinimumTimeToPlane(
                                     mainBody.rotationPeriod,
                                     vesselState.latitude,
                                     vesselState.celestialLongitude,

--- a/MechJeb2/SpaceMath.cs
+++ b/MechJeb2/SpaceMath.cs
@@ -10,48 +10,6 @@ namespace MuMech
     public static class SpaceMath
     {
         /// <summary>
-        /// Find the time to a target plane defined by the LAN and inc for a rocket on the ground.  Wrapper which handles picking
-        /// the soonest of the northgoing and southgoing ground tracks.
-        /// </summary>
-        ///
-        /// <param name="rotationPeriod">Rotation period of the central body (seconds).</param>
-        /// <param name="latitude">Latitude of the launchite (degrees).</param>
-        /// <param name="celestialLongitude">Celestial longitude of the current position of the launchsite.</param>
-        /// <param name="LAN">Longitude of the Ascending Node of the target plane (degrees).</param>
-        /// <param name="inc">Inclination of the target plane (degrees).</param>
-        ///
-        public static double MinimumTimeToPlane(double rotationPeriod, double latitude, double celestialLongitude, double LAN, double inc)
-        {
-            double one = TimeToPlane(rotationPeriod, latitude, celestialLongitude, LAN, inc);
-            double two = TimeToPlane(rotationPeriod, latitude, celestialLongitude, LAN, -inc);
-            return Math.Min(one, two);
-        }
-
-        /// <summary>
-        /// Find the time to a target plane defined by the LAN and inc for a rocket on the ground.
-        /// </summary>
-        ///
-        /// <param name="rotationPeriod">Rotation period of the central body (seconds).</param>
-        /// <param name="latitude">Latitude of the launchite (degrees).</param>
-        /// <param name="celestialLongitude">Celestial longitude of the current position of the launchsite.</param>
-        /// <param name="LAN">Longitude of the Ascending Node of the target plane (degrees).</param>
-        /// <param name="inc">Inclination of the target plane (degrees).</param>
-        ///
-        public static double TimeToPlane(double rotationPeriod, double latitude, double celestialLongitude, double LAN, double inc)
-        {
-            // alpha is the 90 degree angle between the line of longitude and the equator and omitted
-            double beta = OrbitalManeuverCalculator.HeadingForInclination(inc, latitude) * UtilMath.Deg2Rad;
-            double c = Math.Abs(latitude) * UtilMath.Deg2Rad; // Abs for south hemisphere launch sites
-            // b is how many radians to the west of the launch site that the LAN is (east in south hemisphere)
-            double b = Math.Atan2( 2 * Math.Sin(beta), Math.Cos(beta) / Math.Tan(c/2) + Math.Tan(c/2) * Math.Cos(beta) ); // napier's analogies
-            // LAN if we launched now
-            double LANnow = celestialLongitude - Math.Sign(latitude) * b * UtilMath.Rad2Deg;
-
-
-            return MuUtils.ClampDegrees360( LAN - LANnow ) / 360 * rotationPeriod;
-        }
-
-        /// <summary>
         /// Single impulse transfer from an ellipitical, non-coplanar parking orbit to an arbitrary hyperbolic v-infinity target.
         ///
         /// Ocampo, C., & Saudemont, R. R. (2010). Initial Trajectory Model for a Multi-Maneuver Moon-to-Earth Abort Sequence.

--- a/MechJebLibTest/Maths/FunctionsTests.cs
+++ b/MechJebLibTest/Maths/FunctionsTests.cs
@@ -1,0 +1,341 @@
+﻿using AssertExtensions;
+using Xunit;
+using MechJebLib.Maths;
+using static MechJebLib.Utils.Statics;
+
+namespace MechJebLibTest.Maths
+{
+    public class FunctionsTests
+    {
+        private const double PERIOD = 86164.0905;
+
+        private const double ACC  = EPS * 8;
+        private const double ACC2 = 1e-7; // due west launches have some mathematical irregularities
+
+        [Fact]
+        void Test90()
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    double lng = i * 45;
+                    double lan = j * 45;
+
+                    // zero degree advance
+                    double delay = PERIOD / 8 * ((j - i + 8) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,28.608,lng,lan,90).ShouldEqual(delay,ACC);
+                        Functions.TimeToPlane(PERIOD,-28.608,lng,lan,90).ShouldEqual(delay,ACC);
+                    }
+
+                    // reverse
+                    delay = PERIOD / 8 * ((i - j + 8) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,28.608,lng,lan,90).ShouldEqual(delay,ACC);
+                        Functions.TimeToPlane(-PERIOD,-28.608,lng,lan,90).ShouldEqual(delay,ACC);
+                    }
+
+                    // advance by 180 degrees
+                    delay = PERIOD / 8 * ((j - i + 8 + 4) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,28.608,lng,lan,-90).ShouldEqual(delay,ACC);
+                        Functions.TimeToPlane(PERIOD,-28.608,lng,lan,-90).ShouldEqual(delay,ACC);
+                    }
+
+                    // reverse and advance by 180 degrees
+                    delay = PERIOD / 8 * ((i - j + 8 + 4) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,28.608,lng,lan,-90).ShouldEqual(delay,ACC);
+                        Functions.TimeToPlane(-PERIOD,-28.608,lng,lan,-90).ShouldEqual(delay,ACC);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        private void Test45At45()
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    double lng = i * 45;
+                    double lan = j * 45;
+
+                    // advance by 90 degrees
+                    double delay = PERIOD / 8 * ((j - i + 8 + 2) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,45,lng,lan,45).ShouldEqual(delay,ACC);
+                        Functions.TimeToPlane(PERIOD,45,lng,lan,-45).ShouldEqual(delay,ACC);
+                    }
+
+                    // advance by 270 degrees
+                    delay = PERIOD / 8 * ((j - i + 8 + 6) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,-45,lng,lan,45).ShouldEqual(delay,ACC);
+                        Functions.TimeToPlane(PERIOD,-45,lng,lan,-45).ShouldEqual(delay,ACC);
+                    }
+
+                    // reverse and advance by 270 degrees
+                    delay = PERIOD / 8 * ((i - j + 8 + 6) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,45,lng,lan,45).ShouldEqual(delay,ACC);
+                        Functions.TimeToPlane(-PERIOD,45,lng,lan,-45).ShouldEqual(delay,ACC);
+                    }
+
+                    // reverse and advance by 90 degrees
+                    delay = PERIOD / 8 * ((i - j + 8 + 2) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,-45,lng,lan,45).ShouldEqual(delay,ACC);
+                        Functions.TimeToPlane(-PERIOD,-45,lng,lan,-45).ShouldEqual(delay,ACC);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        private void Test135At45()
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    double lng = i * 45;
+                    double lan = j * 45;
+
+                    // advance by 270 degrees
+                    double delay = PERIOD / 8 * ((j - i + 8 + 6) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,45,lng,lan,135).ShouldEqual(delay,ACC2);
+                        Functions.TimeToPlane(PERIOD,45,lng,lan,-135).ShouldEqual(delay,ACC2);
+                    }
+
+                    // advance by 90 degrees
+                    delay = PERIOD / 8 * ((j - i + 8 + 2) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,-45,lng,lan,135).ShouldEqual(delay,ACC2);
+                        Functions.TimeToPlane(PERIOD,-45,lng,lan,-135).ShouldEqual(delay,ACC2);
+                    }
+
+                    // reverse and advance by 90 degrees
+                    delay = PERIOD / 8 * ((i - j + 8 + 2) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,45,lng,lan,135).ShouldEqual(delay,ACC2);
+                        Functions.TimeToPlane(-PERIOD,45,lng,lan,-135).ShouldEqual(delay,ACC2);
+                    }
+
+                    // reverse and advance by 270 degrees
+                    delay = PERIOD / 8 * ((i - j + 8 + 6) % 8);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,-45,lng,lan,135).ShouldEqual(delay,ACC2);
+                        Functions.TimeToPlane(-PERIOD,-45,lng,lan,-135).ShouldEqual(delay,ACC2);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        private void Test47AtKSCLat()
+        {
+            // this produces a 330 degree LAN from 28.608 so everything is 30 degrees offset
+            const double inc = 47.486638356389;
+
+            for (int i = 0; i < 12; i++)
+            {
+                for (int j = 0; j < 12; j++)
+                {
+                    double lng = i * 30;
+                    double lan = j * 30;
+
+                    // advance by 30 degrees
+                    double delay = PERIOD / 12 * ((j - i + 12 + 1) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,28.608,lng,lan,inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // advance by 150 degrees
+                    delay = PERIOD / 12 * ((j - i + 12 + 5) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,28.608,lng,lan,-inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // advance by 330 degrees
+                    delay = PERIOD / 12 * ((j - i + 12 + 11) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,-28.608,lng,lan,inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // advance by 210 degrees
+                    delay = PERIOD / 12 * ((j - i + 12 + 7) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,-28.608,lng,lan,-inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // reverse and advance by 330 degrees
+                    delay = PERIOD / 12 * ((i - j + 12 + 11) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,28.608,lng,lan,inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // reverse and advance by 210 degrees
+                    delay = PERIOD / 12 * ((i - j + 12 + 7) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,28.608,lng,lan,-inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // advance by 30 degrees
+                    delay = PERIOD / 12 * ((i - j + 12 + 1) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,-28.608,lng,lan,inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // advance by 150 degrees
+                    delay = PERIOD / 12 * ((i - j + 12 + 5) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,-28.608,lng,lan,-inc).ShouldEqual(delay,ACC);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        private void Test132AtKSCLat()
+        {
+            // similar to the 47 degree tests only retrograde
+            const double inc = 180 - 47.486638356389;
+
+            for (int i = 0; i < 12; i++)
+            {
+                for (int j = 0; j < 12; j++)
+                {
+                    double lng = i * 30;
+                    double lan = j * 30;
+
+                    // advance by 330 degrees
+                    double delay = PERIOD / 12 * ((j - i + 12 + 11) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,28.608,lng,lan,inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // advance by 210 degrees
+                    delay = PERIOD / 12 * ((j - i + 12 + 7) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,28.608,lng,lan,-inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // advance by 30 degrees
+                    delay = PERIOD / 12 * ((j - i + 12 + 1) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,-28.608,lng,lan,inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // advance by 150 degrees
+                    delay = PERIOD / 12 * ((j - i + 12 + 5) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(PERIOD,-28.608,lng,lan,-inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // reverse and advance by 30 degrees
+                    delay = PERIOD / 12 * ((i-j + 12 + 1) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,28.608,lng,lan,inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // reverse and advance by 150 degrees
+                    delay = PERIOD / 12 * ((i-j + 12 + 5) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,28.608,lng,lan,-inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // reverse and advance by 330 degrees
+                    delay = PERIOD / 12 * ((i -j + 12 + 11) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,-28.608,lng,lan,inc).ShouldEqual(delay,ACC);
+                    }
+
+                    // reverse and advance by 210 degrees
+                    delay = PERIOD / 12 * ((i-j + 12 + 7) % 12);
+
+                    if (delay != 0)
+                    {
+                        Functions.TimeToPlane(-PERIOD,-28.608,lng,lan,-inc).ShouldEqual(delay,ACC);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        private void Poles()
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    for (int k = 0; k <= 8; k++)
+                    {
+                        double lng = i * 45;
+                        double lan = j * 45;
+                        double inc = k * 45 - 180;
+                        Functions.TimeToPlane(PERIOD,90,lng,lan,inc).ShouldBeZero(ACC);
+                        Functions.TimeToPlane(PERIOD,-90,lng,lan,inc).ShouldBeZero(ACC);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MechJebLibTest/MechJebLibTest.csproj
+++ b/MechJebLibTest/MechJebLibTest.csproj
@@ -55,6 +55,7 @@
     <ItemGroup>
         <Compile Include="AssertionExtensions.cs" />
         <Compile Include="BrentRootTests.cs" />
+        <Compile Include="Maths\FunctionsTests.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
- Cleans up TimeToPlane based on #1551.
- Adds reasonably thorough tests around all the different edge conditions.
- Fixes behavior for planets rotating backwards.
- Fixes behavior at the exact poles just 'cuz it was there to be fixed.
- The use of SafeAcos eliminated a lot of the special handling of lat<inc.
- I changed the handling of reverse planetary rotations to keep the values positive,
  which just makes it more readable for my own brain... might just be me.

This change should not fix any in-game breakage on planets that
RSS/RO/PVG users have reported.  It just lays a bit more solid and
readable foundations for the underlying math.