### PR TITLE
Fix PVG launch into plane of target

### DIFF
--- a/MechJeb2/MechJebLib/Maths/Functions.cs
+++ b/MechJeb2/MechJebLib/Maths/Functions.cs
@@ -23,11 +23,13 @@ namespace MechJebLib.Maths
         /// <param name="celestialLongitude">Celestial longitude of the current position of the launch site.</param>
         /// <param name="LAN">Longitude of the Ascending Node of the target plane (degrees).</param>
         /// <param name="inc">Inclination of the target plane (degrees).</param>
-        public static double MinimumTimeToPlane(double rotationPeriod,double latitude,double celestialLongitude,double LAN,double inc)
+        /// <param name="launchNorth">True when the returned time is until the northern launch window, false for the southern window.</param>
+        public static double MinimumTimeToPlane(double rotationPeriod,double latitude,double celestialLongitude,double LAN,double inc, out bool launchNorth)
         {
-            double one = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,inc);
-            double two = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,-inc);
-            return Math.Min(one,two);
+            double north = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,Math.Abs(inc));
+            double south = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,-Math.Abs(inc));
+            launchNorth = (north < south);
+            return Math.Min(north, south);
         }
 
 

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -427,6 +427,7 @@ namespace MuMech
 
             if (!Launching)
             {
+                bool launchingNorth = desiredInclination > 0;
                 // Launch to Rendezvous
                 if (targetExists && ascentPathIdx != ascentType.PVG
                     && GuiUtils.ButtonTextBox(CachedLocalizer.Instance.MechJeb_Ascent_button14,autopilot.launchPhaseAngle,"º",width: 40)) //Launch to rendezvous:
@@ -447,7 +448,8 @@ namespace MuMech
                                 vesselState.latitude,
                                 vesselState.celestialLongitude,
                                 core.target.TargetOrbit.LAN - autopilot.launchLANDifference,
-                                core.target.TargetOrbit.inclination
+                                core.target.TargetOrbit.inclination,
+                                out launchingNorth
                                 )
                             );
                 }
@@ -463,7 +465,8 @@ namespace MuMech
                                 vesselState.latitude,
                                 vesselState.celestialLongitude,
                                 core.target.TargetOrbit.LAN - autopilot.launchLANDifference,
-                                desiredInclination
+                                desiredInclination,
+                                out launchingNorth
                                 )
                             );
                 }
@@ -480,13 +483,17 @@ namespace MuMech
                                     vesselState.latitude,
                                     vesselState.celestialLongitude,
                                     desiredLAN,
-                                    desiredInclination
+                                    desiredInclination,
+                                    out launchingNorth
                                     )
                                 );
                     }
 
                     autopilot.desiredLAN = desiredLAN;
                 }
+
+                // Fix up the sign of the inclination to match the window MinimumTimeToPlane selected
+                desiredInclination = launchingNorth ? Math.Abs(desiredInclination) : -Math.Abs(desiredInclination);
             }
 
             if (Launching)

--- a/MechJeb2/MechJebModuleAscentPVG.cs
+++ b/MechJeb2/MechJebModuleAscentPVG.cs
@@ -149,7 +149,7 @@ namespace MuMech
             if (AscentGuidance.launchingToPlane && core.target.NormalTargetExists)
             {
                 LAN         = core.target.TargetOrbit.LAN;
-                inclination = core.target.TargetOrbit.inclination;
+                inclination = Math.Sign(inclination) * core.target.TargetOrbit.inclination;
                 lanflag     = true;
             }
             else if (AscentGuidance.launchingToMatchLAN && core.target.NormalTargetExists)

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -242,7 +242,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle4constraint, rT: " + rT + " vT:" + vT + " inc:" + inc + " gamma:" + gamma);
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle4constraint(rT, vT, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad);
+                solver.flightangle4constraint(rT, vT, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad));
                 p = solver;
             }
 
@@ -272,7 +272,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle5constraint, rT: " + rT + " vT:" + vT + " inc:" + inc + " gamma:" + gamma + " LAN:" + LAN + " sma: " + sma);
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle5constraint(rT, vT, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad);
+                solver.flightangle5constraint(rT, vT, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -330,7 +330,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up keplerian3constraint");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.keplerian3constraint(sma, ecc, inc * UtilMath.Deg2Rad);
+                solver.keplerian3constraint(sma, ecc, Math.Abs(inc * UtilMath.Deg2Rad));
                 p = solver;
             }
 
@@ -368,7 +368,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up keplerian4constraintArgPfree");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.keplerian4constraintArgPfree(sma, ecc, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad);
+                solver.keplerian4constraintArgPfree(sma, ecc, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -403,7 +403,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up keplerian5constraint");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.keplerian5constraint(sma, ecc, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad, ArgP * UtilMath.Deg2Rad);
+                solver.keplerian5constraint(sma, ecc, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad, ArgP * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -437,7 +437,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle3constraintMAXE");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle3constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad, numStages);
+                solver.flightangle3constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad), numStages);
                 p = solver;
             }
 
@@ -470,7 +470,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle3constraintMAXE");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle4constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad, numStages);
+                solver.flightangle4constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad, numStages);
                 p = solver;
             }
 


### PR DESCRIPTION
There were actually two related issues:

1. MJ uses a negative inclination sign as a flag that the southern
   launch window should be chosen; however, this flag is not set by the
   `MinimumTimeToPlane` function, thereby making the heading used for
   the initial guess fed into the optimizer wrong.

2. The boundary conditions in PVG assume that the inclination is always
   positive, which caused PVG to try and launch into the wrong plane
   (LAN offset by 180°, or AN and DN swapped).

The fix is to change the `MinimumTimeToPlane` function to feed-back
whether the chosen launch window is the north or south one, and to
update the sign of the inclination accordingly. This is then fed into
the `HeadingForInclination` function to determine the heading for the
initial guess. After this, the inclination is stripped of its sign flag
such that PVG's boundary conditions are correct.

The reason that it worked previously most of the time, is that for lower
inclinations, the heading error between north and south is small enough
that the optimizer can correct it. For near-polar inclinations, the
error grows to 180° and the optimizer failed to find a solution.

With these fixes, "Launch into plane of target", "Launch into target
LAN" and "Launch to manual LAN" should all work correctly for all
combinations of inclination and LAN.

Supersedes #1551.

---
@lamont-granquist 
> My suspicion is that the initial guess of the heading angle that PVG uses to bootstrap the optimizer is getting northgoing and southgoing confused.

This was indeed the cause for most of the issues with Launch-to-plane - the heading was wrong when launching south with a positive inclination, or north with a negative inclination specified. This causes the initial guess to be wrong, which the optimizer was able to correct for small inclinations (where the north and south headings are close together), but not for larger inclinations. The fix I implemented is to always set the inclination positive if `MinimumTimeToPlane` launching north, and negative if launching south.

The code at https://github.com/MuMech/MechJeb2/blob/7f052947639b458fdbef0053af7e68346eaa50f4/MechJeb2/MechJebModuleAscentGuidance.cs#L494-L500
fixes the same bug for "Launch into plane of target", which is the only option for "classic" ascent guidance.

> So if you want to update the PR to just have the fix to remove MinimumTimeToPlane from PVG and to implement the launch-now or launch-after-fixed-time that'd probably be fine. That feels like the correct direction to me.

This PR fixes the bug while keeping the current behavior (launching at the nearest window). I'll make another PR that makes the change to "launch north if user specified positive inclination, south if negative". If you choose to go that direction, the change to `MinimumTimeToPlane` is not quite as necessary, since the function is not used anymore in the cases where the error occured. 