### PR TITLE
Respect the user-provided inclination sign in PVG launch-to-LAN

### DIFF
--- a/MechJeb2/MechJebLib/Maths/Functions.cs
+++ b/MechJeb2/MechJebLib/Maths/Functions.cs
@@ -23,11 +23,13 @@ namespace MechJebLib.Maths
         /// <param name="celestialLongitude">Celestial longitude of the current position of the launch site.</param>
         /// <param name="LAN">Longitude of the Ascending Node of the target plane (degrees).</param>
         /// <param name="inc">Inclination of the target plane (degrees).</param>
-        public static double MinimumTimeToPlane(double rotationPeriod,double latitude,double celestialLongitude,double LAN,double inc)
+        /// <param name="launchNorth">True when the returned time is until the northern launch window, false for the southern window.</param>
+        public static double MinimumTimeToPlane(double rotationPeriod,double latitude,double celestialLongitude,double LAN,double inc, out bool launchNorth)
         {
-            double one = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,inc);
-            double two = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,-inc);
-            return Math.Min(one,two);
+            double north = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,Math.Abs(inc));
+            double south = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,-Math.Abs(inc));
+            launchNorth = (north < south);
+            return Math.Min(north, south);
         }
 
 

--- a/MechJeb2/MechJebLib/Maths/Functions.cs
+++ b/MechJeb2/MechJebLib/Maths/Functions.cs
@@ -23,13 +23,11 @@ namespace MechJebLib.Maths
         /// <param name="celestialLongitude">Celestial longitude of the current position of the launch site.</param>
         /// <param name="LAN">Longitude of the Ascending Node of the target plane (degrees).</param>
         /// <param name="inc">Inclination of the target plane (degrees).</param>
-        /// <param name="launchNorth">True when the returned time is until the northern launch window, false for the southern window.</param>
-        public static double MinimumTimeToPlane(double rotationPeriod,double latitude,double celestialLongitude,double LAN,double inc, out bool launchNorth)
+        public static (double time, double inclination) MinimumTimeToPlane(double rotationPeriod,double latitude,double celestialLongitude,double LAN,double inc)
         {
             double north = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,Math.Abs(inc));
             double south = TimeToPlane(rotationPeriod,latitude,celestialLongitude,LAN,-Math.Abs(inc));
-            launchNorth = (north < south);
-            return Math.Min(north, south);
+            return north < south ? (north,Math.Abs(inc)) : (south,-Math.Abs(inc));
         }
 
 

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -427,6 +427,7 @@ namespace MuMech
 
             if (!Launching)
             {
+                bool launchingNorth = desiredInclination > 0;
                 // Launch to Rendezvous
                 if (targetExists && ascentPathIdx != ascentType.PVG
                     && GuiUtils.ButtonTextBox(CachedLocalizer.Instance.MechJeb_Ascent_button14,autopilot.launchPhaseAngle,"º",width: 40)) //Launch to rendezvous:
@@ -447,7 +448,8 @@ namespace MuMech
                                 vesselState.latitude,
                                 vesselState.celestialLongitude,
                                 core.target.TargetOrbit.LAN - autopilot.launchLANDifference,
-                                core.target.TargetOrbit.inclination
+                                core.target.TargetOrbit.inclination,
+                                out launchingNorth
                                 )
                             );
                 }
@@ -463,7 +465,8 @@ namespace MuMech
                                 vesselState.latitude,
                                 vesselState.celestialLongitude,
                                 core.target.TargetOrbit.LAN - autopilot.launchLANDifference,
-                                desiredInclination
+                                desiredInclination,
+                                out launchingNorth
                                 )
                             );
                 }
@@ -480,13 +483,17 @@ namespace MuMech
                                     vesselState.latitude,
                                     vesselState.celestialLongitude,
                                     desiredLAN,
-                                    desiredInclination
+                                    desiredInclination,
+                                    out launchingNorth
                                     )
                                 );
                     }
 
                     autopilot.desiredLAN = desiredLAN;
                 }
+
+                // Fix up the sign of the inclination to match the window MinimumTimeToPlane selected
+                desiredInclination = launchingNorth ? Math.Abs(desiredInclination) : -Math.Abs(desiredInclination);
             }
 
             if (Launching)

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -427,7 +427,6 @@ namespace MuMech
 
             if (!Launching)
             {
-                bool launchingNorth = desiredInclination > 0;
                 // Launch to Rendezvous
                 if (targetExists && ascentPathIdx != ascentType.PVG
                     && GuiUtils.ButtonTextBox(CachedLocalizer.Instance.MechJeb_Ascent_button14,autopilot.launchPhaseAngle,"º",width: 40)) //Launch to rendezvous:
@@ -449,9 +448,11 @@ namespace MuMech
                                 vesselState.celestialLongitude,
                                 core.target.TargetOrbit.LAN - autopilot.launchLANDifference,
                                 core.target.TargetOrbit.inclination,
-                                out launchingNorth
+                                out bool launchingNorth
                                 )
                             );
+                    // Fix up the sign of the inclination to match the window MinimumTimeToPlane selected
+                    desiredInclination = launchingNorth ? Math.Abs(desiredInclination) : -Math.Abs(desiredInclination);
                 }
 
                 //Launch to target LAN
@@ -460,13 +461,12 @@ namespace MuMech
                 {
                     launchingToMatchLAN = true;
                     autopilot.StartCountdown(vesselState.time +
-                            Functions.MinimumTimeToPlane(
+                            Functions.TimeToPlane(
                                 mainBody.rotationPeriod,
                                 vesselState.latitude,
                                 vesselState.celestialLongitude,
                                 core.target.TargetOrbit.LAN - autopilot.launchLANDifference,
-                                desiredInclination,
-                                out launchingNorth
+                                desiredInclination
                                 )
                             );
                 }
@@ -478,22 +478,18 @@ namespace MuMech
                     {
                         launchingToLAN = true;
                         autopilot.StartCountdown(vesselState.time +
-                                Functions.MinimumTimeToPlane(
+                                Functions.TimeToPlane(
                                     mainBody.rotationPeriod,
                                     vesselState.latitude,
                                     vesselState.celestialLongitude,
                                     desiredLAN,
-                                    desiredInclination,
-                                    out launchingNorth
+                                    desiredInclination
                                     )
                                 );
                     }
 
                     autopilot.desiredLAN = desiredLAN;
                 }
-
-                // Fix up the sign of the inclination to match the window MinimumTimeToPlane selected
-                desiredInclination = launchingNorth ? Math.Abs(desiredInclination) : -Math.Abs(desiredInclination);
             }
 
             if (Launching)

--- a/MechJeb2/MechJebModuleAscentGuidance.cs
+++ b/MechJeb2/MechJebModuleAscentGuidance.cs
@@ -441,18 +441,15 @@ namespace MuMech
                 if (targetExists && GuiUtils.ButtonTextBox(CachedLocalizer.Instance.MechJeb_Ascent_button15,autopilot.launchLANDifference,"º",width: LAN_width)) //Launch into plane of target
                 {
                     launchingToPlane = true;
-                    autopilot.StartCountdown(vesselState.time +
-                            Functions.MinimumTimeToPlane(
-                                mainBody.rotationPeriod,
-                                vesselState.latitude,
-                                vesselState.celestialLongitude,
-                                core.target.TargetOrbit.LAN - autopilot.launchLANDifference,
-                                core.target.TargetOrbit.inclination,
-                                out bool launchingNorth
-                                )
-                            );
-                    // Fix up the sign of the inclination to match the window MinimumTimeToPlane selected
-                    desiredInclination = launchingNorth ? Math.Abs(desiredInclination) : -Math.Abs(desiredInclination);
+                    (double timeToPlane, double inclination) = Functions.MinimumTimeToPlane(
+                            mainBody.rotationPeriod,
+                            vesselState.latitude,
+                            vesselState.celestialLongitude,
+                            core.target.TargetOrbit.LAN - autopilot.launchLANDifference,
+                            core.target.TargetOrbit.inclination
+                        );
+                    autopilot.StartCountdown(vesselState.time + timeToPlane);
+                    desiredInclination = inclination;
                 }
 
                 //Launch to target LAN
@@ -494,13 +491,6 @@ namespace MuMech
 
             if (Launching)
             {
-                if (launchingToPlane)
-                {
-                    desiredInclination = MuUtils.Clamp(core.target.TargetOrbit.inclination,Math.Abs(vesselState.latitude),180 - Math.Abs(vesselState.latitude));
-                    desiredInclination *=
-                        Math.Sign(Vector3d.Dot(core.target.TargetOrbit.SwappedOrbitNormal(),
-                                    Vector3d.Cross(vesselState.CoM - mainBody.position,mainBody.transform.up)));
-                }
                 GUILayout.Label(launchTimer);
                 if (GUILayout.Button(CachedLocalizer.Instance.MechJeb_Ascent_button17))//Abort
                     launchingToPlane = launchingToRendezvous = launchingToMatchLAN = launchingToLAN = autopilot.timedLaunch = false;

--- a/MechJeb2/MechJebModuleAscentPVG.cs
+++ b/MechJeb2/MechJebModuleAscentPVG.cs
@@ -149,7 +149,7 @@ namespace MuMech
             if (AscentGuidance.launchingToPlane && core.target.NormalTargetExists)
             {
                 LAN         = core.target.TargetOrbit.LAN;
-                inclination = core.target.TargetOrbit.inclination;
+                inclination = Math.Sign(inclination) * core.target.TargetOrbit.inclination;
                 lanflag     = true;
             }
             else if (AscentGuidance.launchingToMatchLAN && core.target.NormalTargetExists)

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -242,7 +242,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle4constraint, rT: " + rT + " vT:" + vT + " inc:" + inc + " gamma:" + gamma);
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle4constraint(rT, vT, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad);
+                solver.flightangle4constraint(rT, vT, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad));
                 p = solver;
             }
 
@@ -272,7 +272,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle5constraint, rT: " + rT + " vT:" + vT + " inc:" + inc + " gamma:" + gamma + " LAN:" + LAN + " sma: " + sma);
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle5constraint(rT, vT, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad);
+                solver.flightangle5constraint(rT, vT, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -330,7 +330,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up keplerian3constraint");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.keplerian3constraint(sma, ecc, inc * UtilMath.Deg2Rad);
+                solver.keplerian3constraint(sma, ecc, Math.Abs(inc * UtilMath.Deg2Rad));
                 p = solver;
             }
 
@@ -368,7 +368,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up keplerian4constraintArgPfree");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.keplerian4constraintArgPfree(sma, ecc, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad);
+                solver.keplerian4constraintArgPfree(sma, ecc, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -403,7 +403,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up keplerian5constraint");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.keplerian5constraint(sma, ecc, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad, ArgP * UtilMath.Deg2Rad);
+                solver.keplerian5constraint(sma, ecc, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad, ArgP * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -437,7 +437,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle3constraintMAXE");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle3constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad, numStages);
+                solver.flightangle3constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad), numStages);
                 p = solver;
             }
 
@@ -470,7 +470,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle3constraintMAXE");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle4constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad, numStages);
+                solver.flightangle4constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad, numStages);
                 p = solver;
             }
 

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -242,7 +242,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle4constraint, rT: " + rT + " vT:" + vT + " inc:" + inc + " gamma:" + gamma);
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle4constraint(rT, vT, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad));
+                solver.flightangle4constraint(rT, vT, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -272,7 +272,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle5constraint, rT: " + rT + " vT:" + vT + " inc:" + inc + " gamma:" + gamma + " LAN:" + LAN + " sma: " + sma);
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle5constraint(rT, vT, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad);
+                solver.flightangle5constraint(rT, vT, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -330,7 +330,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up keplerian3constraint");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.keplerian3constraint(sma, ecc, Math.Abs(inc * UtilMath.Deg2Rad));
+                solver.keplerian3constraint(sma, ecc, inc * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -368,7 +368,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up keplerian4constraintArgPfree");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.keplerian4constraintArgPfree(sma, ecc, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad);
+                solver.keplerian4constraintArgPfree(sma, ecc, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -403,7 +403,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up keplerian5constraint");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.keplerian5constraint(sma, ecc, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad, ArgP * UtilMath.Deg2Rad);
+                solver.keplerian5constraint(sma, ecc, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad, ArgP * UtilMath.Deg2Rad);
                 p = solver;
             }
 
@@ -437,7 +437,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle3constraintMAXE");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle3constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad), numStages);
+                solver.flightangle3constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad, numStages);
                 p = solver;
             }
 
@@ -470,7 +470,7 @@ namespace MuMech
                 Debug.Log("[MechJeb] MechJebModuleGuidanceController: setting up flightangle3constraintMAXE");
                 PontryaginLaunch solver = NewPontryaginForLaunch(inc, sma);
                 solver.fixedCoast = fixedCoast;
-                solver.flightangle4constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, Math.Abs(inc * UtilMath.Deg2Rad), LAN * UtilMath.Deg2Rad, numStages);
+                solver.flightangle4constraintMAXE(rTm, gamma * UtilMath.Deg2Rad, inc * UtilMath.Deg2Rad, LAN * UtilMath.Deg2Rad, numStages);
                 p = solver;
             }
 

--- a/MechJeb2/Pontryagin/PontryaginLaunch.cs
+++ b/MechJeb2/Pontryagin/PontryaginLaunch.cs
@@ -28,7 +28,7 @@ namespace MuMech {
             this.rTm = rTm / r_scale;
             this.vTm = vTm / v_scale;
             this.gammaT = gammaT;
-            this.incT = incT;
+            this.incT = Math.Abs(incT);
             this.LANT = LANT;
             bcfun = flightangle5constraint;
             bctype = BCType.FLIGHTANGLE5;
@@ -72,7 +72,7 @@ namespace MuMech {
             this.rTm = rTm / r_scale;
             this.vTm = vTm / v_scale;
             this.gammaT = gammaT;
-            this.incT = incT;
+            this.incT = Math.Abs(incT);
             bcfun = flightangle4constraint;
             bctype = BCType.FLIGHTANGLE4;
         }
@@ -112,7 +112,7 @@ namespace MuMech {
         {
             this.smaT = sma / r_scale;
             this.eccT = ecc;
-            this.incT = inc;
+            this.incT = Math.Abs(inc);
             bcfun = keplerian3constraint;
             bctype = BCType.KEPLER3;
         }
@@ -234,7 +234,7 @@ namespace MuMech {
         {
             this.smaT = sma / r_scale;
             this.eccT = ecc;
-            this.incT = inc;
+            this.incT = Math.Abs(inc);
             this.LANT = LAN;
             bcfun = keplerian4constraintArgPfree;
             bctype = BCType.KEPLER4;
@@ -277,7 +277,7 @@ namespace MuMech {
         {
             this.smaT = sma / r_scale;
             this.eccT = ecc;
-            this.incT = inc;
+            this.incT = Math.Abs(inc);
             this.LANT = LAN;
             this.ArgPT = ArgP;
             bcfun = keplerian5constraint;
@@ -340,7 +340,7 @@ namespace MuMech {
             this.rTm = rTm / r_scale;
             this.gammaT = gammaT;
             this.numStages = numStages;
-            this.incT = incT;
+            this.incT = Math.Abs(incT);
             bcfun = flightangle3constraintMAXE;
         }
 
@@ -375,7 +375,7 @@ namespace MuMech {
         {
             this.rTm = rTm / r_scale;
             this.gammaT = gammaT;
-            this.incT = incT;
+            this.incT = Math.Abs(incT);
             this.LANT = LANT;
             this.numStages = numStages;
             bcfun = flightangle4constraintMAXE;


### PR DESCRIPTION
Instead of warping to the nearest of the northern or southern windows, warp to the northern window if inclination is positive and southern if inclination is negative.

Only in the case of "Launch into LAN of target" and "Launch into manual LAN"; the case "Launch into plane of target" keeps the previous behavior: for this case, the inclination input by the user was already ignored in favor of the inclination of the target (which is always positive), so it seems weird to ignore the user input _except_ for the sign of the value.

Includes #1554.
Supersedes part of #1551.