### PR TITLE
Fix Launch-into-plane-of-target with Principia

### DIFF
--- a/MechJeb2/MechJebModuleAscentPVG.cs
+++ b/MechJeb2/MechJebModuleAscentPVG.cs
@@ -128,6 +128,7 @@ namespace MuMech
         private void SetTarget()
         {
             bool lanflag = false;
+            bool targetInc = false;
 
             double sma = 0;
             double ecc = 0;
@@ -150,6 +151,7 @@ namespace MuMech
             {
                 LAN         = core.target.TargetOrbit.LAN;
                 inclination = Math.Sign(inclination) * core.target.TargetOrbit.inclination;
+                targetInc   = true;
                 lanflag     = true;
             }
             else if (AscentGuidance.launchingToMatchLAN && core.target.NormalTargetExists)
@@ -170,9 +172,9 @@ namespace MuMech
             if (lanflag)
             {
                 if (ecc < 1e-4 || AttachAltFlag)
-                    core.guidance.flightangle5constraint(rT, vT, inclination, gammaT, LAN, sma, coastLen, false, true);
+                    core.guidance.flightangle5constraint(rT, vT, inclination, gammaT, LAN, sma, coastLen, targetInc, true);
                 else
-                    core.guidance.keplerian4constraintArgPfree(sma, ecc, inclination, LAN, coastLen, false, true);
+                    core.guidance.keplerian4constraintArgPfree(sma, ecc, inclination, LAN, coastLen, targetInc, true);
             }
             else
             {


### PR DESCRIPTION
When launching into the plane of a target with Principia installed, PVG gets stuck on 'INITIALIZING' and never actually launches.

This was previously fixed in cd3d194760f7875658e7e04690e37113d2ca1cd6 by adding the `targetInc` parameter to the PVG constraint setup functions, but the refactor in 136964af2380013e860a04e0433fe6a607874847 broke the fix.