### PR TITLE
Fix automatically setting config to new skin on load

### DIFF
--- a/MechJeb2/MechJebModuleSettings.cs
+++ b/MechJeb2/MechJebModuleSettings.cs
@@ -46,7 +46,6 @@ namespace MuMech
             if (useOldSkin)
             {
                 skinId = 1;
-                useOldSkin = false;
             }
         }
 


### PR DESCRIPTION
Remove line resetting old skin flag on config load.

Was trying to set the old skin but it would keep resetting it in the config file. I found this line, and it seems like it might be the culprit. Not sure if this was put here intentionally or perhaps I have no idea what I'm talking about.