### PR TITLE
FFS fix for PVG

### DIFF
--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -50,7 +50,7 @@ namespace MuMech
             // Determine when each part will be decoupled
             _nodeLookup[negOnePart].AssignDecoupledInStage(negOnePart, null, _nodeLookup, -1);
 
-            _simStage = StageManager.LastStage;
+            _simStage = StageManager.CurrentStage;
 
             // Set up the fuel flow graph
             for (int i = 0; i < parts.Count; i++)
@@ -61,12 +61,6 @@ namespace MuMech
                 if (node.decoupledInStage >= _simStage) _simStage = node.decoupledInStage + 1;
             }
 
-            // Add a fake stage if we are beyond the first one
-            // Mostly useful for the Node Executor who use the last stage info
-            // and fail to get proper info when the ship was never staged and
-            // some engine were activated manually
-            if (StageManager.CurrentStage > StageManager.LastStage)
-                _simStage++;
             //print("Init End");
         }
 


### PR DESCRIPTION
For a couple of ticks post-staging the "LastStage" for some reason is still the old value.  This causes chaos with the FFS around staging and a few ticks of nonsense values.  It may be particularly bad with hotstaging in RO/RSS.  The CurrentStage seems to always have the right value.

What isn't clear is if this is an artifact of history or not and that LastStage was used in KSP prehistory incorrectly and the original author should have used CurrentStage (which of course may or may not have existed at the time), and then the second bit of code I've deleted here may have been working around that.

I don't really understand how manual activation would cause issues since the activated engine would be currently active and would then be considered to be in the currentstage and so would burn immediately in the simulation.  The need for a workaround isn't obvious.

At any rate, the behavior prior to this patch was definitively busted (and quite commonly, it was not an edge condition) with PVG's ability to track stages and have a consistent tick-to-tick view of the rocket staging analysis.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>