### PR TITLE
Some code cleanup in the PVG Ascent algorithm

### DIFF
--- a/MechJeb2/MechJebLib/PVG/OptimizerBuilder.cs
+++ b/MechJeb2/MechJebLib/PVG/OptimizerBuilder.cs
@@ -17,18 +17,20 @@ namespace MechJebLib.PVG
     {
         public class OptimizerBuilder : IDisposable
         {
-            private          IPVGTerminal? _terminal;
-            private readonly List<Phase>   _phases = new List<Phase>();
-            private          V3            _r0;
-            private          V3            _v0;
-            private          V3            _u0;
-            private          double        _t0;
-            private          double        _mu;
-            private          double        _rbody;
-            private          double        _hT;
-
-            public Optimizer Build()
+            private IPVGTerminal? _terminal;
+            private List<Phase>   _phases = null!;
+            private V3            _r0;
+            private V3            _v0;
+            private V3            _u0;
+            private double        _t0;
+            private double        _mu;
+            private double        _rbody;
+            private double        _hT;
+            
+            public Optimizer Build(List<Phase> phases)
             {
+                _phases = phases;
+                
                 double m0 = _phases[0].m0;
                 var problem = new Problem(_r0, _v0, _u0, m0, _t0, _mu, _rbody);
 
@@ -112,17 +114,6 @@ namespace MechJebLib.PVG
             public OptimizerBuilder TerminalConditions(double hT)
             {
                 _hT = hT;
-
-                return this;
-            }
-
-            public OptimizerBuilder Phases(IList<Phase> phases)
-            {
-                _phases.Clear();
-                for (int i = 0; i < phases.Count; i++)
-                {
-                    _phases.Add(phases[i]);
-                }
 
                 return this;
             }

--- a/MechJeb2/MechJebLib/PVG/Phase.cs
+++ b/MechJeb2/MechJebLib/PVG/Phase.cs
@@ -41,6 +41,13 @@ namespace MechJebLib.PVG
         public bool           Coast => thrust == 0;
         public V3             u0;
 
+        public Phase DeepCopy()
+        {
+            var newphase = (Phase) this.MemberwiseClone();
+
+            return newphase;
+        }
+        
         private Phase(double m0, double thrust, double isp, double mf, double bt, int kspStage)
         {
             this.KSPStage = kspStage;

--- a/MechJebLibTest/AssertionExtensions.cs
+++ b/MechJebLibTest/AssertionExtensions.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Globalization;
 using MechJebLib.Primitives;
+using MuMech;
 using Xunit.Sdk;
 using static MechJebLib.Utils.Statics;
 
@@ -78,6 +79,15 @@ namespace AssertExtensions
                     string.Format(CultureInfo.CurrentCulture, "{0:G17}", 0.0),
                     string.Format(CultureInfo.CurrentCulture, "{0:G17}", actual)
                 );
+        }
+
+        public static void ShouldBePositive(this double actual)
+        {
+            if (!actual.IsFinite())
+                throw new XunitException($"{actual} must be finite");
+
+            if (actual <= 0)
+                throw new XunitException($"{actual} must be positive");
         }
     }
 }

--- a/MechJebLibTest/PVG/AscentTests/TheStandardTests.cs
+++ b/MechJebLibTest/PVG/AscentTests/TheStandardTests.cs
@@ -40,6 +40,11 @@ namespace PVG
 
             using Solution solution = pvg.GetSolution();
             
+            solution.Tgo(solution.T0,0).ShouldBePositive();
+            solution.Tgo(solution.T0,1).ShouldBePositive();
+            solution.Tgo(solution.T0,2).ShouldBePositive();
+            solution.Tgo(solution.T0,3).ShouldBePositive();
+            
             pvg.Znorm.ShouldBeZero(1e-9);
 
             (V3 rf, V3 vf) = solution.TerminalStateVectors();
@@ -50,15 +55,15 @@ namespace PVG
             solution.R(t0).ShouldEqual(r0, EPS);
             solution.V(t0).ShouldEqual(v0, EPS);
             solution.M(t0).ShouldEqual(49119.7842689869, EPS);
-            solution.Vgo(t0).ShouldEqual(9442.4337137415314, 1e-7);
-            solution.Pv(t0).ShouldEqual(new V3(0.72074690601916824, -0.37044777147539532, 0.16448719154490499), 1e-7);
+            solution.Vgo(t0).ShouldEqual(9595.3503336684062, 1e-7);
+            solution.Pv(t0).ShouldEqual(new V3(0.4907116486773232, -0.35249571092720933, 0.16642316543642413), 1e-7);
 
             smaf.ShouldEqual(11463499.98898875, 1e-7);
             eccf.ShouldEqual(0.4280978753095433, 1e-7);
             incf.ShouldEqual(incT, 1e-7);
-            lanf.ShouldEqual(3.0481860980923936, 1e-7);
-            argpf.ShouldEqual(2.3459256350705218, 1e-7);
-            tanof.ShouldEqual(0.086322895047150183, 1e-7);
+            lanf.ShouldEqual(3.0481642123046941, 1e-7);
+            argpf.ShouldEqual(1.8684926416804641, 1e-7);
+            tanof.ShouldEqual(0.091089077094440363, 1e-7);
         }
     }
 }


### PR DESCRIPTION
breaks up the algorithm into fixed-vs-optimized rocket burntimes since those are getting difficult to handle, and also starts to treat the phase list a bit more immutably since that was getting crazy.