### PR TITLE
Fix FuelFlowSim for NO_FLOW resources in Engines

### DIFF
--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -263,15 +263,22 @@ namespace MuMech
                             return false;
                         }
 
-                        if (n.ContainsResources(burnedResources.value))
+                        foreach (int id in burnedResources.value)
                         {
-                            for (int j = 0; j < activeEnginesCount.value.Count; j++)
+                            if (!n.ContainsResource(id))
+                                continue;
+
+                            for (int j = 0; j < activeEngines.value.Count; j++)
                             {
                                 FuelNode engine = activeEngines.value[j];
-                                if (engine.CanDrawFrom(n))
-                                    //print("Not allowed to stage because " + n.partName + " contains resources (" + n.ContainsResources(burnedResources.value) + ") reachable by an active engine");
+
+                                if (engine.CanDrawResourceFrom(id, n))
+                                {
+                                    //print("Not allowed to stage because " + n.partName + " contains resources (" +
+                                    //      n.ContainsResources(burnedResources.value) + ") reachable by an active engine");
                                     //n.DebugResources();
                                     return false;
+                                }
                             }
                         }
                     }

--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -168,8 +168,10 @@ namespace MuMech
             {
                 if (engines.value.Count > 0)
                 {
-                    for (int i = 0; i < engines.value.Count; i++) engines.value[i].AssignResourceDrainRates(_nodes);
-                    //foreach (FuelNode n in nodes) n.DebugDrainRates();
+                    for (int i = 0; i < engines.value.Count; i++)
+                        engines.value[i].AssignResourceDrainRates(_nodes);
+
+                    //foreach (FuelNode n in _nodes) n.DebugDrainRates();
 
                     double maxDt = _nodes.Slinq().Select(n => n.MaxTimeStep()).Min();
                     dt = Math.Min(desiredDt, maxDt);
@@ -177,8 +179,10 @@ namespace MuMech
                     //print("Simulating time step of " + dt);
 
                     for (int i = 0; i < _nodes.Count; i++)
+                    {
                         _nodes[i].DrainResources(dt);
-                    //nodes[i].DebugResources();
+                        //_nodes[i].DebugResources();
+                    }
                 }
                 else
                 {
@@ -226,7 +230,6 @@ namespace MuMech
         //Whether we've used up the current stage
         private bool AllowedToStage()
         {
-            //print("Checking whether allowed to stage at t = " + t);
             //print("Checking whether allowed to stage");
 
             using (Disposable<List<FuelNode>> activeEngines = FindActiveEngines())
@@ -235,8 +238,10 @@ namespace MuMech
 
                 //if no engines are active, we can always stage
                 if (activeEngines.value.Count == 0)
+                {
                     //print("Allowed to stage because no active engines");
                     return true;
+                }
 
                 using (Disposable<List<int>> burnedResources = ListPool<int>.Instance.BorrowDisposable())
                 {
@@ -247,24 +252,26 @@ namespace MuMech
                     {
                         FuelNode n = _nodes[i];
                         //print(n.partName + " is sepratron? " + n.isSepratron);
-                        if (n.decoupledInStage == _simStage - 1 && !n.isSepratron)
-                        {
-                            if (activeEngines.value.Contains(n))
-                                //print("Not allowed to stage because " + n.partName + " is an active engine (" + activeEngines.value.Contains(n) +")");
-                                //n.DebugResources();
-                                return false;
 
-                            if (n.ContainsResources(burnedResources.value))
+                        // filter only the parts that are going to get dropped
+                        if (n.decoupledInStage != _simStage - 1 || n.isSepratron) continue;
+
+                        if (activeEngines.value.Contains(n))
+                        {
+                            //print("Not allowed to stage because " + n.partName + " is an active engine (" + activeEngines.value.Contains(n) +")");
+                            //n.DebugResources();
+                            return false;
+                        }
+
+                        if (n.ContainsResources(burnedResources.value))
+                        {
+                            for (int j = 0; j < activeEnginesCount.value.Count; j++)
                             {
-                                int activeEnginesCount = activeEngines.value.Count;
-                                for (int j = 0; j < activeEnginesCount; j++)
-                                {
-                                    FuelNode engine = activeEngines.value[j];
-                                    if (engine.CanDrawFrom(n))
-                                        //print("Not allowed to stage because " + n.partName + " contains resources (" + n.ContainsResources(burnedResources.value) + ") reachable by an active engine");
-                                        //n.DebugResources();
-                                        return false;
-                                }
+                                FuelNode engine = activeEngines.value[j];
+                                if (engine.CanDrawFrom(n))
+                                    //print("Not allowed to stage because " + n.partName + " contains resources (" + n.ContainsResources(burnedResources.value) + ") reachable by an active engine");
+                                    //n.DebugResources();
+                                    return false;
                             }
                         }
                     }
@@ -280,24 +287,32 @@ namespace MuMech
                         FuelNode n = _nodes[i];
                         if (activeEngines.value.Contains(n))
                             if (n.CanDrawNeededResources(_nodes))
+                            {
                                 //print("Part " + n.partName + " is an active engine that still has resources to draw on.");
                                 activeEnginesWorking = true;
+                            }
 
                         if (n.decoupledInStage == _simStage - 1)
+                        {
                             //print("Part " + n.partName + " is decoupled in the next stage.");
                             partDecoupledInNextStage = true;
+                        }
                     }
 
                     if (!partDecoupledInNextStage && activeEnginesWorking)
+                    {
                         //print("Not allowed to stage because nothing is decoupled in the next stage, and there are already other engines active.");
                         return false;
+                    }
                 }
             }
 
             //if this isn't the last stage, we're allowed to stage because doing so wouldn't drop anything important
             if (_simStage > 0)
+            {
                 //print("Allowed to stage because this isn't the last stage");
                 return true;
+            }
 
             //print("Not allowed to stage because there are active engines and this is the last stage");
 

--- a/MechJeb2/FuelNode.cs
+++ b/MechJeb2/FuelNode.cs
@@ -345,8 +345,7 @@ namespace MuMech
                 {
                     PartModule m = p.Modules[i];
 
-                    var mDecouple = m as ModuleDecouple;
-                    if (mDecouple != null)
+                    if (m is ModuleDecouple mDecouple)
                         if (!mDecouple.isDecoupled && mDecouple.stagingEnabled && p.stagingOn)
                         {
                             if (mDecouple.isOmniDecoupler)
@@ -361,17 +360,14 @@ namespace MuMech
                                 AttachNode attach;
                                 if (HighLogic.LoadedSceneIsEditor)
                                 {
-                                    if (mDecouple.explosiveNodeID != "srf")
-                                        attach = p.FindAttachNode(mDecouple.explosiveNodeID);
-                                    else
-                                        attach = p.srfAttachNode;
+                                    attach = mDecouple.explosiveNodeID != "srf" ? p.FindAttachNode(mDecouple.explosiveNodeID) : p.srfAttachNode;
                                 }
                                 else
                                 {
                                     attach = mDecouple.ExplosiveNode;
                                 }
 
-                                if (attach != null && attach.attachedPart != null)
+                                if (attach is { attachedPart: { } })
                                 {
                                     if (attach.attachedPart == traversalParent && mDecouple.staged)
                                     {
@@ -394,17 +390,14 @@ namespace MuMech
                             break; // Hopefully no one made part with multiple decoupler modules ?
                         }
 
-                    var mAnchoredDecoupler = m as ModuleAnchoredDecoupler;
-                    if (mAnchoredDecoupler != null)
+                    if (m is ModuleAnchoredDecoupler mAnchoredDecoupler)
+                    {
                         if (!mAnchoredDecoupler.isDecoupled && mAnchoredDecoupler.stagingEnabled && p.stagingOn)
                         {
                             AttachNode attach;
                             if (HighLogic.LoadedSceneIsEditor)
                             {
-                                if (mAnchoredDecoupler.explosiveNodeID != "srf")
-                                    attach = p.FindAttachNode(mAnchoredDecoupler.explosiveNodeID);
-                                else
-                                    attach = p.srfAttachNode;
+                                attach = mAnchoredDecoupler.explosiveNodeID != "srf" ? p.FindAttachNode(mAnchoredDecoupler.explosiveNodeID) : p.srfAttachNode;
                             }
                             else
                             {
@@ -432,14 +425,14 @@ namespace MuMech
 
                             break;
                         }
+                    }
 
-                    var mDockingNode = m as ModuleDockingNode;
-                    if (mDockingNode != null)
+                    if (m is ModuleDockingNode mDockingNode)
                     {
                         if (mDockingNode.staged && mDockingNode.stagingEnabled && p.stagingOn)
                         {
                             Part attachedPart = mDockingNode.referenceNode.attachedPart;
-                            if (attachedPart != null)
+                            if (!(attachedPart is null))
                             {
                                 if (attachedPart == traversalParent)
                                 {
@@ -447,7 +440,6 @@ namespace MuMech
                                     isDecoupler      = true;
                                     decoupledInStage = p.inverseStage;
                                     AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-                                    isDecoupler = true;
                                 }
                                 else
                                 {
@@ -470,7 +462,6 @@ namespace MuMech
                             isDecoupler      = true;
                             decoupledInStage = p.inverseStage;
                             AssignChildrenDecoupledInStage(p, traversalParent, nodeLookup, decoupledInStage);
-                            isDecoupler = true;
                             break;
                         }
                 }
@@ -670,6 +661,11 @@ namespace MuMech
                 return false;
             }
 
+            public bool ContainsResource(int id)
+            {
+                return resources[id] > ResidualThreshold(id);
+            }
+
             public bool CanDrawNeededResources(List<FuelNode> vessel)
             {
                 // XXX: this fix is intended to fix SRBs which have burned out but which
@@ -733,6 +729,7 @@ namespace MuMech
                     switch (resourceFlowMode)
                     {
                         case ResourceFlowMode.NO_FLOW:
+                            //print("NO_FLOW for " + partName + " searching for " + amount + " of " + PartResourceLibrary.Instance.GetDefinition(type).name);
                             resourceResidual[type] =  maxEngineResiduals;
                             resourceDrains[type]   += amount;
                             break;

--- a/MechJeb2/FuelNode.cs
+++ b/MechJeb2/FuelNode.cs
@@ -711,9 +711,30 @@ namespace MuMech
                 return true; //we didn't find ourselves lacking for any resource
             }
 
-            public bool CanDrawFrom(FuelNode node)
+            public bool CanDrawResourceFrom(int type, FuelNode node)
             {
-                return crossfeedSources.Contains(node);
+                ResourceFlowMode resourceFlowMode = propellantFlows[type];
+
+                switch (resourceFlowMode)
+                {
+                    case ResourceFlowMode.NO_FLOW:
+                            return node == this;
+
+                    case ResourceFlowMode.ALL_VESSEL:
+                    case ResourceFlowMode.ALL_VESSEL_BALANCE:
+                    case ResourceFlowMode.STAGE_PRIORITY_FLOW:
+                    case ResourceFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
+                            return true;
+
+                    case ResourceFlowMode.STAGE_STACK_FLOW:
+                    case ResourceFlowMode.STAGE_STACK_FLOW_BALANCE:
+                    case ResourceFlowMode.STACK_PRIORITY_SEARCH:
+                            return crossfeedSources.Contains(node);
+
+                    case ResourceFlowMode.NULL:
+                    default:
+                        return false;
+                }
             }
 
             public void AssignResourceDrainRates(List<FuelNode> vessel)


### PR DESCRIPTION
This fixes a bug affecting Delta IV Heavy setup with asparagus staging.  The RS68 engines have had Ablator added to them as an additional "fuel" which is NO_FLOW.

The old check CanDrawResource() which was used to determine if staging was allowed was not aware of fuel modes and that caused it to check if any part in the crossfeedset had the fuel even for NO_FLOW fuels.  This meant that after the side boosters flamed out that the center core would still be burning Ablator and it would find that Ablator "accessible" in its crossfeed set coming from the side engines (because of asparagus).

This may also affect SRBs since those fuels are NO_FLOW as well?

However, I think it requires something like Asparagus staging And given that RO doesn't allow crossfeed through decouplers or fuel pipes it may be a pretty narrow bugfix.