### PR TITLE
Rename the "Swapped" API

### DIFF
--- a/MechJeb2/GLUtils.cs
+++ b/MechJeb2/GLUtils.cs
@@ -228,7 +228,7 @@ namespace MuMech
                 //elliptical orbits:
                 for (int trueAnomaly = 0; trueAnomaly < 360; trueAnomaly += 1)
                 {
-                    _points.Add(o.SwappedAbsolutePositionAtUT(o.TimeOfTrueAnomaly(Deg2Rad(trueAnomaly), 0)));
+                    _points.Add(o.WorldPositionAtUT(o.TimeOfTrueAnomaly(Deg2Rad(trueAnomaly), 0)));
                 }
 
                 _points.Add(_points[0]); //close the loop
@@ -238,7 +238,7 @@ namespace MuMech
                 //hyperbolic orbits:
                 for (int meanAnomaly = -1000; meanAnomaly <= 1000; meanAnomaly += 5)
                 {
-                    _points.Add(o.SwappedAbsolutePositionAtUT(o.UTAtMeanAnomaly(meanAnomaly * UtilMath.Deg2Rad, 0)));
+                    _points.Add(o.WorldPositionAtUT(o.UTAtMeanAnomaly(meanAnomaly * UtilMath.Deg2Rad, 0)));
                 }
             }
 

--- a/MechJeb2/LandingAutopilot/CoastToDeceleration.cs
+++ b/MechJeb2/LandingAutopilot/CoastToDeceleration.cs
@@ -97,8 +97,8 @@ namespace MuMech
                     if (vesselState.drag < 0.01)
                     {
                         double decelerationStartTime = (core.landing.Prediction.trajectory.Any() ? core.landing.Prediction.trajectory.First().UT : vesselState.time);
-                        Vector3d decelerationStartAttitude = -orbit.SwappedOrbitalVelocityAtUT(decelerationStartTime);
-                        decelerationStartAttitude += mainBody.getRFrmVel(orbit.SwappedAbsolutePositionAtUT(decelerationStartTime));
+                        Vector3d decelerationStartAttitude = -orbit.WorldOrbitalVelocityAtUT(decelerationStartTime);
+                        decelerationStartAttitude += mainBody.getRFrmVel(orbit.WorldPositionAtUT(decelerationStartTime));
                         decelerationStartAttitude = decelerationStartAttitude.normalized;
                         core.attitude.attitudeTo(decelerationStartAttitude, AttitudeReference.INERTIAL, core.landing);
                     }

--- a/MechJeb2/LandingAutopilot/DecelerationBurn.cs
+++ b/MechJeb2/LandingAutopilot/DecelerationBurn.cs
@@ -34,8 +34,8 @@ namespace MuMech
                     status = Localizer.Format("#MechJeb_LandingGuidance_Status4");//"Warping to start of braking burn."
 
                     //warp to deceleration start
-                    Vector3d decelerationStartAttitude = -orbit.SwappedOrbitalVelocityAtUT(decelerationStartTime);
-                    decelerationStartAttitude += mainBody.getRFrmVel(orbit.SwappedAbsolutePositionAtUT(decelerationStartTime));
+                    Vector3d decelerationStartAttitude = -orbit.WorldOrbitalVelocityAtUT(decelerationStartTime);
+                    decelerationStartAttitude += mainBody.getRFrmVel(orbit.WorldPositionAtUT(decelerationStartTime));
                     decelerationStartAttitude = decelerationStartAttitude.normalized;
                     core.attitude.attitudeTo(decelerationStartAttitude, AttitudeReference.INERTIAL, core.landing);
                     bool warpReady = core.attitude.attitudeAngleFromTarget() < 5;

--- a/MechJeb2/LandingAutopilot/DeorbitBurn.cs
+++ b/MechJeb2/LandingAutopilot/DeorbitBurn.cs
@@ -55,7 +55,7 @@ namespace MuMech
 
                 //Compute the angle between the location of the target at the end of freefall and the normal to our orbit:
                 Vector3d currentRadialVector = vesselState.CoM - mainBody.position;
-                double targetAngleToOrbitNormal = Vector3d.Angle(orbit.SwappedOrbitNormal(), freefallEndTargetRadialVector);
+                double targetAngleToOrbitNormal = Vector3d.Angle(orbit.OrbitNormal(), freefallEndTargetRadialVector);
                 targetAngleToOrbitNormal = Math.Min(targetAngleToOrbitNormal, 180 - targetAngleToOrbitNormal);
 
                 double targetAheadAngle = Vector3d.Angle(currentRadialVector, freefallEndTargetRadialVector); //How far ahead the target is, in degrees

--- a/MechJeb2/Maneuver/OperationInterplanetaryTransfer.cs
+++ b/MechJeb2/Maneuver/OperationInterplanetaryTransfer.cs
@@ -59,7 +59,7 @@ namespace MuMech
             }
             else
             {
-                double relativeInclination = Vector3d.Angle(o.SwappedOrbitNormal(), o.referenceBody.orbit.SwappedOrbitNormal());
+                double relativeInclination = Vector3d.Angle(o.OrbitNormal(), o.referenceBody.orbit.OrbitNormal());
                 if (relativeInclination > 10)
                 {
                     ErrorMessage = Localizer.Format("#MechJeb_transfer_errormsg2", o.referenceBody.displayName.LocalizeRemoveGender(),

--- a/MechJeb2/MechJebModuleAscentMenu.cs
+++ b/MechJeb2/MechJebModuleAscentMenu.cs
@@ -467,7 +467,7 @@ namespace MuMech
                 targetAngularRate *= -1; //retrograde target
 
             Vector3d currentLaunchpadDirection = launchBody.GetSurfaceNVector(0, launchLongitude);
-            Vector3d currentTargetDirection = target.SwappedRelativePositionAtUT(Planetarium.GetUniversalTime());
+            Vector3d currentTargetDirection = target.WorldBCIPositionAtUT(Planetarium.GetUniversalTime());
             currentTargetDirection = Vector3d.Exclude(launchBody.angularVelocity, currentTargetDirection);
 
             double currentPhaseAngle = Math.Abs(Vector3d.Angle(currentLaunchpadDirection, currentTargetDirection));

--- a/MechJeb2/MechJebModuleInfoItems.cs
+++ b/MechJeb2/MechJebModuleInfoItems.cs
@@ -163,7 +163,7 @@ namespace MuMech
             {
                 for (int iter = 0; iter < 10; iter++)
                 {
-                    Vector3d impactPosition = orbit.SwappedAbsolutePositionAtUT(impactTime);
+                    Vector3d impactPosition = orbit.WorldPositionAtUT(impactTime);
                     double terrainRadius = mainBody.Radius + mainBody.TerrainAltitude(impactPosition);
                     impactTime = orbit.NextTimeOfRadius(vesselState.time, terrainRadius);
                 }
@@ -596,7 +596,7 @@ namespace MuMech
                 }
 
                 double relVel =
-                    (orbit.SwappedOrbitalVelocityAtUT(UT) - core.target.TargetOrbit.SwappedOrbitalVelocityAtUT(UT))
+                    (orbit.WorldOrbitalVelocityAtUT(UT) - core.target.TargetOrbit.WorldOrbitalVelocityAtUT(UT))
                         .magnitude;
                 return relVel.ToSI(-1) + "m/s";
             }

--- a/MechJeb2/MechJebModuleLandingAutopilot.cs
+++ b/MechJeb2/MechJebModuleLandingAutopilot.cs
@@ -239,9 +239,9 @@ namespace MuMech
 
             Vector3d orbitLandingPosition;
             if (orbit.PeR < endRadius)
-                orbitLandingPosition = orbit.SwappedRelativePositionAtUT(orbit.NextTimeOfRadius(vesselState.time, endRadius));
+                orbitLandingPosition = orbit.WorldBCIPositionAtUT(orbit.NextTimeOfRadius(vesselState.time, endRadius));
             else
-                orbitLandingPosition = orbit.SwappedRelativePositionAtUT(orbit.NextPeriapsisTime(vesselState.time));
+                orbitLandingPosition = orbit.WorldBCIPositionAtUT(orbit.NextPeriapsisTime(vesselState.time));
 
             // convertOrbitToActual is a rotation that rotates orbitLandingPosition on actualLandingPosition
             Quaternion convertOrbitToActual = Quaternion.FromToRotation(orbitLandingPosition, actualLandingPosition);
@@ -260,7 +260,7 @@ namespace MuMech
                 double perturbedLandingTime;
                 if (perturbedOrbit.PeR < endRadius) perturbedLandingTime = perturbedOrbit.NextTimeOfRadius(vesselState.time, endRadius);
                 else perturbedLandingTime = perturbedOrbit.NextPeriapsisTime(vesselState.time);
-                Vector3d perturbedLandingPosition = perturbedOrbit.SwappedRelativePositionAtUT(perturbedLandingTime); //find where it hits the planet
+                Vector3d perturbedLandingPosition = perturbedOrbit.WorldBCIPositionAtUT(perturbedLandingTime); //find where it hits the planet
                 Vector3d landingDelta = perturbedLandingPosition - orbitLandingPosition; //find the difference between that and the original orbit's intersection point
                 landingDelta = convertOrbitToActual * landingDelta; //rotate that difference vector so that we can now think of it as starting at the actual landing position
                 landingDelta = Vector3d.Exclude(actualLandingPosition, landingDelta); //project the difference vector onto the plane tangent to the actual landing position
@@ -534,7 +534,7 @@ namespace MuMech
         {
             if (mainBody.atmosphere) return false;
 
-            double periapsisSpeed = orbit.SwappedOrbitalVelocityAtUT(orbit.NextPeriapsisTime(vesselState.time)).magnitude;
+            double periapsisSpeed = orbit.WorldOrbitalVelocityAtUT(orbit.NextPeriapsisTime(vesselState.time)).magnitude;
             double stoppingDistance = Math.Pow(periapsisSpeed, 2) / (2 * vesselState.limitedMaxThrustAccel);
 
             return orbit.PeA < 2 * stoppingDistance + mainBody.Radius / 4;

--- a/MechJeb2/MechJebModuleRendezvousAutopilot.cs
+++ b/MechJeb2/MechJebModuleRendezvousAutopilot.cs
@@ -84,7 +84,7 @@ namespace MuMech
 
                     //adjust burn time so as to come to rest at the desired distance from the target:
                     double approachDistance = orbit.Separation(core.target.TargetOrbit, UT);
-                    double approachSpeed = (orbit.SwappedOrbitalVelocityAtUT(UT) - core.target.TargetOrbit.SwappedOrbitalVelocityAtUT(UT)).magnitude;
+                    double approachSpeed = (orbit.WorldOrbitalVelocityAtUT(UT) - core.target.TargetOrbit.WorldOrbitalVelocityAtUT(UT)).magnitude;
                     if (approachDistance < desiredDistance)
                     {
                         UT -= Math.Sqrt(Math.Abs(desiredDistance * desiredDistance - approachDistance * approachDistance)) / approachSpeed;
@@ -120,8 +120,8 @@ namespace MuMech
                 Vector3d dV = OrbitalManeuverCalculator.DeltaVToMatchVelocities(orbit, UT, core.target.TargetOrbit);
 
                 //adjust burn time so as to come to rest at the desired distance from the target:
-                double approachDistance = (orbit.SwappedAbsolutePositionAtUT(UT) - core.target.TargetOrbit.SwappedAbsolutePositionAtUT(UT)).magnitude;
-                double approachSpeed = (orbit.SwappedOrbitalVelocityAtUT(UT) - core.target.TargetOrbit.SwappedOrbitalVelocityAtUT(UT)).magnitude;
+                double approachDistance = (orbit.WorldPositionAtUT(UT) - core.target.TargetOrbit.WorldPositionAtUT(UT)).magnitude;
+                double approachSpeed = (orbit.WorldOrbitalVelocityAtUT(UT) - core.target.TargetOrbit.WorldOrbitalVelocityAtUT(UT)).magnitude;
                 if (approachDistance < desiredDistance)
                 {
                     UT -= Math.Sqrt(Math.Abs(desiredDistance * desiredDistance - approachDistance * approachDistance)) / approachSpeed;

--- a/MechJeb2/ReentrySimulation.cs
+++ b/MechJeb2/ReentrySimulation.cs
@@ -176,7 +176,7 @@ namespace MuMech
             referenceFrame.UpdateAtCurrentTime(_initialOrbit.referenceBody);
             orbitReenters = OrbitReenters(_initialOrbit);
 
-            startX = initialOrbit.SwappedRelativePositionAtUT(startUT);
+            startX = initialOrbit.WorldBCIPositionAtUT(startUT);
             // This calls some Unity function so it should be done outside the thread
             if (orbitReenters)
             {
@@ -316,8 +316,8 @@ namespace MuMech
         {
             t = FindFreefallEndTime(initialOrbit);
 
-            x = initialOrbit.SwappedRelativePositionAtUT(t);
-            v = initialOrbit.SwappedOrbitalVelocityAtUT(t);
+            x = initialOrbit.WorldBCIPositionAtUT(t);
+            v = initialOrbit.WorldOrbitalVelocityAtUT(t);
 
             if (double.IsNaN(v.magnitude))
             {
@@ -363,8 +363,8 @@ namespace MuMech
         //    - the descent speed policy says to start braking
         private bool FreefallEnded(Orbit initialOrbit, double UT)
         {
-            Vector3d pos = initialOrbit.SwappedRelativePositionAtUT(UT);
-            Vector3d surfaceVelocity = SurfaceVelocity(pos, initialOrbit.SwappedOrbitalVelocityAtUT(UT));
+            Vector3d pos = initialOrbit.WorldBCIPositionAtUT(UT);
+            Vector3d surfaceVelocity = SurfaceVelocity(pos, initialOrbit.WorldOrbitalVelocityAtUT(UT));
 
             if (pos.magnitude < aerobrakedRadius) return true;
             if (Vector3d.Dot(surfaceVelocity, initialOrbit.Up(UT)) > 0) return false;


### PR DESCRIPTION
I never remember if "Swapped" in the API refers to world
space being "Swapped" or right-handed space being "Swapped".

Removes Prograde() and Up() since those are now actual KSP
APIs and those extension methods are confusingly overwriting
what KSP does (although both are world coordinates and
backwards compatible -- I hope).

Also "Relative" is now "BCI" which means "Body Centered Inertial"
which is what it is (although it is still crazy rotating space).

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>