### PR TITLE
fix probable transfer calculator bug

### DIFF
--- a/MechJeb2/Maneuver/TransferCalculator.cs
+++ b/MechJeb2/Maneuver/TransferCalculator.cs
@@ -237,7 +237,7 @@ namespace MuMech
                 Debug.Log("[MechJeb TransferCalculator] BUG mu = " + initialOrbit.referenceBody.gravParameter + " r0 = " + r0 + " v0 = " + v0 +
                           " vinf = " + exitVelocity);
 
-            return new ManeuverParameters((vpos - vneg).V3ToWorldRotated(), ut0 + dt);
+            return new ManeuverParameters((vpos - vneg).V3ToWorld(), ut0 + dt);
         }
 
         private double        _impulseScale;


### PR DESCRIPTION
This has to be buggy, and its easier to see now that I renamed the APIs to included "Rotated" in them.  We don't rotate to start so we shouldn't be rotating to end.