### PR TITLE
Cleanup of Angle APIs

### DIFF
--- a/MechJeb2/MechJebLib/Core/Functions/Angles.cs
+++ b/MechJeb2/MechJebLib/Core/Functions/Angles.cs
@@ -1,27 +1,50 @@
-﻿using System;
+﻿/*
+ * Copyright Lamont Granquist (lamont@scriptkiddie.org)
+ * Dual licensed under the MIT (MIT-LICENSE) license
+ * and GPLv2 (GPLv2-LICENSE) license or any later version.
+ */
+
+using System;
 using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
 using MechJebLib.Utils;
 using Steamworks;
 using static MechJebLib.Utils.Statics;
 
+// ReSharper disable InconsistentNaming
 namespace MechJebLib.Core.Functions
 {
-    public class Angles
+    public static class Angles
     {
+        [UsedImplicitly]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double KeplerEquation(double E, double M, double ecc)
         {
-            return EToM(E, ecc) - M;
+            Check.Finite(E);
+            Check.Finite(M);
+            Check.NonNegativeFinite(ecc);
+
+            return MFromE(E, ecc) - M;
         }
 
+        [UsedImplicitly]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double KeplerEquationPrime(double E, double M, double ecc)
         {
+            Check.Finite(E);
+            Check.Finite(M);
+            Check.NonNegativeFinite(ecc);
+
             return 1 - ecc * Math.Cos(E);
         }
 
+        [UsedImplicitly]
         public static double NewtonElliptic(double E0, double M, double ecc)
         {
+            Check.Finite(E0);
+            Check.Finite(M);
+            Check.NonNegativeFinite(ecc);
+
             double tol = 1.48e-08;
             double E = E0;
 
@@ -38,23 +61,34 @@ namespace MechJebLib.Core.Functions
             throw new Exception($"NewtonElliptic({E0}, {M}, {ecc}): Maximum iterations exceeded");
         }
 
+        [UsedImplicitly]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double KeplerEquationHyper(double F, double M, double ecc)
         {
-            return FToM(F, ecc) - M;
+            Check.Finite(F);
+            Check.Finite(M);
+            Check.NonNegativeFinite(ecc);
+
+            return MFromF(F, ecc) - M;
         }
 
+        [UsedImplicitly]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double KeplerEquationPrimeHyper(double F, double M, double ecc)
         {
+            Check.Finite(F);
+            Check.Finite(M);
+            Check.NonNegativeFinite(ecc);
+
             return ecc * Math.Cosh(F) - 1;
         }
 
+        [UsedImplicitly]
         public static double NewtonHyperbolic(double F0, double M, double ecc)
         {
             Check.Finite(F0);
             Check.Finite(M);
-            Check.Finite(ecc);
+            Check.NonNegativeFinite(ecc);
 
             double tol = 1.48e-08;
             double F = F0;
@@ -73,43 +107,62 @@ namespace MechJebLib.Core.Functions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double DToNu(double D)
+        public static double NuFromD(double D)
         {
+            Check.Finite(D);
+
             return 2.0 * Math.Atan(D);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double NuToD(double nu)
+        public static double DFromNu(double nu)
         {
+            Check.Finite(nu);
+
             return Math.Tan(nu / 2.0);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double NuToE(double nu, double ecc)
+        public static double EFromNu(double nu, double ecc)
         {
+            Check.Finite(nu);
+            Check.NonNegativeFinite(ecc);
+
             return 2 * Math.Atan(Math.Sqrt((1 - ecc) / (1 + ecc)) * Math.Tan(nu / 2));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double NuToF(double nu, double ecc)
+        public static double FFromNu(double nu, double ecc)
         {
+            Check.Finite(nu);
+            Check.NonNegativeFinite(ecc);
+
             return 2 * Atanh(Math.Sqrt((ecc - 1) / (ecc + 1)) * Math.Tan(nu / 2));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double EToNu(double E, double ecc)
+        public static double NuFromE(double E, double ecc)
         {
+            Check.Finite(E);
+            Check.NonNegativeFinite(ecc);
+
             return 2 * Math.Atan(Math.Sqrt((1 + ecc) / (1 - ecc)) * Math.Tan(E / 2));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double FToNu(double F, double ecc)
+        public static double NuFromF(double F, double ecc)
         {
+            Check.Finite(F);
+            Check.NonNegativeFinite(ecc);
+
             return 2 * Math.Atan(Math.Sqrt((ecc + 1) / (ecc - 1)) * Math.Tanh(F / 2));
         }
 
-        public static double MToE(double M, double ecc)
+        public static double EFromM(double M, double ecc)
         {
+            Check.Finite(M);
+            Check.NonNegativeFinite(ecc);
+
             double E0;
             if ((-Math.PI < M && M < 0) || Math.PI < M)
             {
@@ -123,53 +176,62 @@ namespace MechJebLib.Core.Functions
             return NewtonElliptic(E0, M, ecc);
         }
 
-        public static double MToF(double M, double ecc)
+        public static double FFromM(double M, double ecc)
         {
             Check.Finite(M);
-            Check.Finite(ecc);
+            Check.NonNegativeFinite(ecc);
 
             double F0 = Asinh(M / ecc);
             return NewtonHyperbolic(F0, M, ecc);
         }
 
-        public static double MToD(double M)
+        public static double DFromM(double M)
         {
+            Check.Finite(M);
+
             double B = 3.0 * M / 2.0;
             double A = Math.Pow(B + Math.Sqrt(1.0 + Math.Pow(B, 2)), 2.0 / 3.0);
             return 2.0 * A * B / (1.0 + A + Math.Pow(A, 2));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double EToM(double E, double ecc)
+        public static double MFromE(double E, double ecc)
         {
+            Check.Finite(E);
+            Check.NonNegativeFinite(ecc);
+
             return E - ecc * Math.Sin(E);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double FToM(double F, double ecc)
+        public static double MFromF(double F, double ecc)
         {
+            Check.Finite(F);
+            Check.NonNegativeFinite(ecc);
+
             return ecc * Math.Sinh(F) - F;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double DToM(double D)
+        public static double MFromD(double D)
         {
+            Check.Finite(D);
+
             return D + Math.Pow(D, 3) / 3.0;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double NuToM(double nu, double ecc)
+        public static double MFromNu(double nu, double ecc)
         {
             Check.Finite(nu);
-            Check.PositiveFinite(ecc);
+            Check.NonNegativeFinite(ecc);
 
             if (ecc < 1)
-                return EToM(NuToE(nu, ecc), ecc);
+                return MFromE(EFromNu(nu, ecc), ecc);
 
             if (ecc > 1)
-                return FToM(NuToF(nu, ecc), ecc);
+                return MFromF(FFromNu(nu, ecc), ecc);
 
-            return DToM(NuToD(nu));
+            return MFromD(DFromNu(nu));
         }
     }
 }

--- a/MechJeb2/MechJebLib/Core/Functions/Interpolants.cs
+++ b/MechJeb2/MechJebLib/Core/Functions/Interpolants.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿/*
+ * Copyright Lamont Granquist (lamont@scriptkiddie.org)
+ * Dual licensed under the MIT (MIT-LICENSE) license
+ * and GPLv2 (GPLv2-LICENSE) license or any later version.
+ */
+
+using System.Collections.Generic;
 using MechJebLib.Primitives;
 
 namespace MechJebLib.Core.Functions

--- a/MechJeb2/MechJebLib/Core/Functions/Maneuvers.cs
+++ b/MechJeb2/MechJebLib/Core/Functions/Maneuvers.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿/*
+ * Copyright Lamont Granquist (lamont@scriptkiddie.org)
+ * Dual licensed under the MIT (MIT-LICENSE) license
+ * and GPLv2 (GPLv2-LICENSE) license or any later version.
+ */
+
+using System;
 using MechJebLib.Core.TwoBody;
 using MechJebLib.Primitives;
 using MechJebLib.Utils;

--- a/MechJeb2/MechJebLib/Core/Maths.cs
+++ b/MechJeb2/MechJebLib/Core/Maths.cs
@@ -423,7 +423,7 @@ namespace MechJebLib.Core
 
             double meanMotion = MeanMotion(mu, sma);
 
-            double manom = Angles.NuToM(nu, ecc);
+            double manom = Angles.MFromNu(nu, ecc);
 
             return Clamp2Pi(PI - manom) / meanMotion;
         }
@@ -434,7 +434,7 @@ namespace MechJebLib.Core
 
             double meanMotion = MeanMotion(mu, sma);
 
-            double manom = Angles.NuToM(nu, ecc);
+            double manom = Angles.MFromNu(nu, ecc);
 
             return Clamp2Pi(-manom) / meanMotion;
         }
@@ -445,8 +445,8 @@ namespace MechJebLib.Core
 
             double meanMotion = MeanMotion(mu, sma);
 
-            double manom1 = Angles.NuToM(nu1, ecc);
-            double manom2 = Angles.NuToM(nu2, ecc);
+            double manom1 = Angles.MFromNu(nu1, ecc);
+            double manom2 = Angles.MFromNu(nu2, ecc);
 
             if (ecc < 1)
                 return Clamp2Pi(manom2 - manom1) / meanMotion;

--- a/MechJeb2/MechJebLib/Core/TwoBody/Farnocchia.cs
+++ b/MechJeb2/MechJebLib/Core/TwoBody/Farnocchia.cs
@@ -88,7 +88,7 @@ namespace MechJebLib.Core.TwoBody
 
         public static double MToDNearParabolic(double M, double ecc, double tol = 1.48e-08, int maxiter = 50)
         {
-            double D0 = Angles.MToD(M);
+            double D0 = Angles.DFromM(M);
 
             for (int i = 0; i < maxiter; i++)
             {
@@ -116,8 +116,8 @@ namespace MechJebLib.Core.TwoBody
 
             if (ecc < 1 - delta)
             {
-                double E = Angles.NuToE(nu, ecc);
-                double M = Angles.EToM(E, ecc);
+                double E = Angles.EFromNu(nu, ecc);
+                double M = Angles.MFromE(E, ecc);
                 double n = Math.Sqrt(mu * Math.Pow(1 - ecc, 3) / Math.Pow(q, 3));
                 Check.Finite(M / n);
                 return M / n;
@@ -125,17 +125,17 @@ namespace MechJebLib.Core.TwoBody
 
             if (1 - delta <= ecc && ecc < 1)
             {
-                double E = Angles.NuToE(nu, ecc);
+                double E = Angles.EFromNu(nu, ecc);
                 if (delta <= 1 - ecc * Math.Cos(E))
                 {
-                    double M = Angles.EToM(E, ecc);
+                    double M = Angles.MFromE(E, ecc);
                     double n = Math.Sqrt(mu * Math.Pow(1 - ecc, 3) / Math.Pow(q, 3));
                     Check.Finite(M / n);
                     return M / n;
                 }
                 else
                 {
-                    double D = Angles.NuToD(nu);
+                    double D = Angles.DFromNu(nu);
                     double M = DToMNearParabolic(D, ecc);
                     double n = Math.Sqrt(mu / (2 * Math.Pow(q, 3)));
                     Check.Finite(M / n);
@@ -145,8 +145,8 @@ namespace MechJebLib.Core.TwoBody
 
             if (ecc == 1)
             {
-                double D = Angles.NuToD(nu);
-                double M = Angles.DToM(D);
+                double D = Angles.DFromNu(nu);
+                double M = Angles.MFromD(D);
                 double n = Math.Sqrt(mu / (2 * Math.Pow(q, 3)));
                 Check.Finite(M / n);
                 return M / n;
@@ -157,17 +157,17 @@ namespace MechJebLib.Core.TwoBody
 
             if (1 < ecc && ecc <= 1 + delta)
             {
-                double F = Angles.NuToF(nu, ecc);
+                double F = Angles.FFromNu(nu, ecc);
                 if (delta <= ecc * Math.Cosh(F) - 1)
                 {
-                    double M = Angles.FToM(F, ecc);
+                    double M = Angles.MFromF(F, ecc);
                     double n = Math.Sqrt(mu * Math.Pow(ecc - 1, 3) / Math.Pow(q, 3));
                     Check.Finite(M / n);
                     return M / n;
                 }
                 else
                 {
-                    double D = Angles.NuToD(nu);
+                    double D = Angles.DFromNu(nu);
                     double M = DToMNearParabolic(D, ecc);
                     double n = Math.Sqrt(mu / (2 * Math.Pow(q, 3)));
                     Check.Finite(M / n);
@@ -177,8 +177,8 @@ namespace MechJebLib.Core.TwoBody
 
             if (1 + delta < ecc)
             {
-                double F = Angles.NuToF(nu, ecc);
-                double M = Angles.FToM(F, ecc);
+                double F = Angles.FFromNu(nu, ecc);
+                double M = Angles.MFromF(F, ecc);
                 double n = Math.Sqrt(mu * Math.Pow(ecc - 1, 3) / Math.Pow(q, 3));
                 Check.Finite(M / n);
                 return M / n;
@@ -202,58 +202,58 @@ namespace MechJebLib.Core.TwoBody
             {
                 n  = Math.Sqrt(k * Math.Pow(1 - ecc, 3) / Math.Pow(q, 3));
                 M  = n * delta_t;
-                E  = Angles.MToE((M + Math.PI) % (2 * Math.PI) - Math.PI, ecc);
-                nu = Angles.EToNu(E, ecc);
+                E  = Angles.EFromM((M + Math.PI) % (2 * Math.PI) - Math.PI, ecc);
+                nu = Angles.NuFromE(E, ecc);
             }
             else if (1 - delta <= ecc && ecc < 1)
             {
                 E_delta = Math.Acos((1 - delta) / ecc);
                 n       = Math.Sqrt(k * Math.Pow(1 - ecc, 3) / Math.Pow(q, 3));
                 M       = n * delta_t;
-                if (Angles.EToM(E_delta, ecc) <= Math.Abs(M))
+                if (Angles.MFromE(E_delta, ecc) <= Math.Abs(M))
                 {
-                    E  = Angles.MToE((M + Math.PI) % (2 * Math.PI) - Math.PI, ecc);
-                    nu = Angles.EToNu(E, ecc);
+                    E  = Angles.EFromM((M + Math.PI) % (2 * Math.PI) - Math.PI, ecc);
+                    nu = Angles.NuFromE(E, ecc);
                 }
                 else
                 {
                     n  = Math.Sqrt(k / (2 * Math.Pow(q, 3)));
                     M  = n * delta_t;
                     D  = MToDNearParabolic(M, ecc);
-                    nu = Angles.DToNu(D);
+                    nu = Angles.NuFromD(D);
                 }
             }
             else if (ecc == 1)
             {
                 n  = Math.Sqrt(k / (2 * Math.Pow(q, 3)));
                 M  = n * delta_t;
-                D  = Angles.MToD(M);
-                nu = Angles.DToNu(D);
+                D  = Angles.DFromM(M);
+                nu = Angles.NuFromD(D);
             }
             else if (1 < ecc && ecc <= 1 + delta)
             {
                 F_delta = Acosh((1 + delta) / ecc);
                 n       = Math.Sqrt(k * Math.Pow(ecc - 1, 3) / Math.Pow(q, 3));
                 M       = n * delta_t;
-                if (Angles.FToM(F_delta, ecc) <= Math.Abs(M))
+                if (Angles.MFromF(F_delta, ecc) <= Math.Abs(M))
                 {
-                    F  = Angles.MToF(M, ecc);
-                    nu = Angles.FToNu(F, ecc);
+                    F  = Angles.FFromM(M, ecc);
+                    nu = Angles.NuFromF(F, ecc);
                 }
                 else
                 {
                     n  = Math.Sqrt(k / (2 * Math.Pow(q, 3)));
                     M  = n * delta_t;
                     D  = MToDNearParabolic(M, ecc);
-                    nu = Angles.DToNu(D);
+                    nu = Angles.NuFromD(D);
                 }
             }
             else
             {
                 n  = Math.Sqrt(k * Math.Pow(ecc - 1, 3) / Math.Pow(q, 3));
                 M  = n * delta_t;
-                F  = Angles.MToF(M, ecc);
-                nu = Angles.FToNu(F, ecc);
+                F  = Angles.FFromM(M, ecc);
+                nu = Angles.NuFromF(F, ecc);
             }
 
             return nu;

--- a/MechJeb2/MechJebLib/Utils/Check.cs
+++ b/MechJeb2/MechJebLib/Utils/Check.cs
@@ -90,6 +90,19 @@ namespace MechJebLib.Utils
         }
 
         [Conditional("DEBUG")]
+        public static void NonNegative(double d)
+        {
+            DoCheck(d >= 0);
+        }
+
+        [Conditional("DEBUG")]
+        public static void NonNegativeFinite(double d)
+        {
+            DoCheck(d >= 0);
+            DoCheck(IsFinite(d));
+        }
+
+        [Conditional("DEBUG")]
         public static void Negative(double d)
         {
             DoCheck(d < 0);
@@ -99,6 +112,19 @@ namespace MechJebLib.Utils
         public static void NegativeFinite(double d)
         {
             DoCheck(d < 0);
+            DoCheck(IsFinite(d));
+        }
+
+        [Conditional("DEBUG")]
+        public static void NonPositive(double d)
+        {
+            DoCheck(d <= 0);
+        }
+
+        [Conditional("DEBUG")]
+        public static void NonPositiveFinite(double d)
+        {
+            DoCheck(d <= 0);
             DoCheck(IsFinite(d));
         }
 


### PR DESCRIPTION
I like "EFromNu" slightly better since it makes this read better:

```
MFromE(EFromNu(nu, ecc), ecc);
```

That is obviously M...From...Nu

In the signature when using `From` it more matches the way that C# declares functions (return type before args).

Adds some missing copyright headers.