### PR TITLE
Make Moon Return work for initial hyperbolic

### DIFF
--- a/MechJeb2/Maneuver/OperationMoonReturn.cs
+++ b/MechJeb2/Maneuver/OperationMoonReturn.cs
@@ -28,21 +28,12 @@ namespace MuMech
                     o.referenceBody.displayName.LocalizeRemoveGender())); //<<1>> is not orbiting another body you could return to.
             }
 
-            var now = Planetarium.GetUniversalTime();
-            var planetmu = o.referenceBody.referenceBody.gravParameter;
-            var moonmu = o.referenceBody.gravParameter;
-            var moonr0 = o.referenceBody.orbit.getRelativePositionAtUT(now);
-            var moonv0 = o.referenceBody.orbit.getOrbitalVelocityAtUT(now);
-            var moonsoi = o.referenceBody.sphereOfInfluence;
-            var r0 = o.getRelativePositionAtUT(now);
-            var v0 = o.getOrbitalVelocityAtUT(now);
+            // fixed 30 second delay for hyperbolic orbits (this doesn't work for elliptical and i don't want to deal
+            // with requests to "fix" it by surfacing it as a tweakable).
+            double t0 = o.eccentricity >= 1 ? universalTime + 30 : universalTime;
 
-            Debug.Log($"ManeuverToReturnFromMoon({planetmu}, {moonmu}, {moonr0}, {moonv0}, {moonsoi}, {r0}, {v0}, double peR, double inc)");
-
-            (Vector3d dV, double ut) = OrbitalManeuverCalculator.DeltaVAndTimeForMoonReturnEjection(o, universalTime,
+            (Vector3d dV, double ut) = OrbitalManeuverCalculator.DeltaVAndTimeForMoonReturnEjection(o, t0,
                 o.referenceBody.referenceBody.Radius + MoonReturnAltitude);
-
-            Debug.Log($"dv: {dV.xzy} ut: {ut} now: {now}");
 
             return new List<ManeuverParameters>
             {

--- a/MechJeb2/MechJebLib/Core/FunctionImpls/RealSingleImpulseHyperbolicBurn.cs
+++ b/MechJeb2/MechJebLib/Core/FunctionImpls/RealSingleImpulseHyperbolicBurn.cs
@@ -13,9 +13,6 @@ using static MechJebLib.Utils.Statics;
 
 namespace MechJebLib.Core.FunctionImpls
 {
-    // The purpose of this module is to collect pure-math functions with minimal coupling to MechJeb and/or KSP.  Chunks of the OrbitalManeuverCalculator
-    // class should probably be moved here, where that class should be more tightly coupled to the maneuver node planner.
-    //
     public static class RealSingleImpulseHyperbolicBurn
     {
         /// <summary>
@@ -84,6 +81,9 @@ namespace MechJebLib.Core.FunctionImpls
 
             // eccentricity of the parking orbit.
             double ecc0 = ecc.magnitude;
+
+            if (ecc0 >= 1)
+                throw new Exception("SingleImpulseHyperbolicBurn does not work with a hyperbolic initial orbit");
 
             // semilatus rectum of parking orbit
             double p0 = a0 * (1 - ecc0 * ecc0);

--- a/MechJeb2/MechJebLib/Core/Functions/Angles.cs
+++ b/MechJeb2/MechJebLib/Core/Functions/Angles.cs
@@ -8,7 +8,6 @@ using System;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using MechJebLib.Utils;
-using Steamworks;
 using static MechJebLib.Utils.Statics;
 
 // ReSharper disable InconsistentNaming

--- a/MechJeb2/MechJebLib/Utils/Statics.cs
+++ b/MechJeb2/MechJebLib/Utils/Statics.cs
@@ -377,6 +377,20 @@ namespace MechJebLib.Utils
             return sb.ToString();
         }
 
+        public static double DoubleArrayMagnitude(IList<double> array)
+        {
+            int last = array.Count - 1;
+
+            double sumsq = 0;
+
+            for (int i = 0; i <= last; i++)
+            {
+                sumsq += array[i] * array[i];
+            }
+
+            return Math.Sqrt(sumsq);
+        }
+
         private static readonly string[] _posPrefix = { " ", "k", "M", "G", "T", "P", "E", "Z", "Y" };
         private static readonly string[] _negPrefix = { " ", "m", "μ", "n", "p", "f", "a", "z", "y" };
 

--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -80,6 +80,7 @@ namespace MuMech
 
             (V3 r, V3 v) = o.RightHandedStateVectorsAtUT(ut);
 
+
             V3 dv = Maneuvers.DeltaVToChangeApsis(o.referenceBody.gravParameter, r, v, newApR, false);
 
             return dv.V3ToWorld();
@@ -977,26 +978,14 @@ namespace MuMech
             double moonSOI = moon.sphereOfInfluence;
             (V3 r0, V3 v0) = o.RightHandedStateVectorsAtUT(ut);
 
+            double dtmin = (o.eccentricity >= 1) ? 0 : double.NegativeInfinity;
+
             (V3 dv, double dt, double newPeR) = Maneuvers.NextManeuverToReturnFromMoon(primary.gravParameter, moon.gravParameter, moonR0,
-                moonV0, moonSOI, r0, v0, targetPrimaryRadius, 0);
+                moonV0, moonSOI, r0, v0, targetPrimaryRadius, 0, dtmin: dtmin);
 
             Debug.Log($"Solved PeR from calcluator: {newPeR}");
 
             return (dv.V3ToWorld(), ut + dt);
-        }
-
-        public static Vector3d DeltaVAndTimeForMoonReturnEjectionOld(Orbit o, double UT, double targetPrimaryRadius, out double burnUT)
-        {
-            CelestialBody moon = o.referenceBody;
-            CelestialBody primary = moon.referenceBody;
-
-
-            //construct an orbit at the target radius around the primary, in the same plane as the moon. This is a fake target
-            var primaryOrbit = new Orbit(moon.orbit.inclination, moon.orbit.eccentricity, targetPrimaryRadius, moon.orbit.LAN,
-                moon.orbit.argumentOfPeriapsis, moon.orbit.meanAnomalyAtEpoch, moon.orbit.epoch, primary);
-
-
-            return DeltaVAndTimeForInterplanetaryTransferEjection(o, UT, primaryOrbit, false, out burnUT);
         }
 
         //Computes the delta-V of the burn at a given time required to zero out the difference in orbital velocities

--- a/MechJebLibTest/Maths/FunctionsTests.cs
+++ b/MechJebLibTest/Maths/FunctionsTests.cs
@@ -833,14 +833,31 @@ namespace MechJebLibTest.Maths
             var v0 = new V3(-666.230112925872, 539.234048888927, 0.000277598267012666);
             double peR = 6471000; //6.3781e6 + 60000;
 
+            var random = new Random();
+            r0 = new V3(6616710 * random.NextDouble() - 3308350, 6616710 * random.NextDouble() - 3308350, 6616710 * random.NextDouble() - 3308350);
+            v0 = new V3(2000 * random.NextDouble() - 1000, 2000 * random.NextDouble() - 1000, 2000 * random.NextDouble() - 1000);
+
+            r0 = new V3(1105140.06213014, -8431008.05414815, -4729658.84487529);
+            v0 = new V3(-293.374690393787, -1173.3597686151, -411.755491683683);
+
+            (double sma, double ecc, double inc, double lan, double argp, double tanom, _) =
+                MechJebLib.Core.Maths.KeplerianFromStateVectors(moonMu, r0, v0);
+
+            _testOutputHelper.WriteLine($"sma = {sma}, ecc = {ecc} r0 = {r0} v0 = {v0}");
+
             (V3 dv, double dt, double newPeR) =
-                Maneuvers.NextManeuverToReturnFromMoon(398600435436096, 4902800066163.8, moonR0, moonV0, 66167158.6569544, r0, v0, peR, 0);
+                Maneuvers.NextManeuverToReturnFromMoon(398600435436096, 4902800066163.8, moonR0, moonV0, 66167158.6569544, r0, v0, peR, 0, dtmin: 0);
 
             (V3 r1, V3 v1) = Shepperd.Solve(moonMu, dt, r0, v0);
 
             double tt1 = MechJebLib.Core.Maths.TimeToNextRadius(moonMu, r1, v1 + dv, moonSOI);
 
             (V3 r2, V3 v2) = Shepperd.Solve(moonMu, tt1, r1, v1 + dv);
+
+            (V3 rtest, V3 vtest) = Shepperd.Solve(moonMu, tt1*0.1, r1, v1 + dv);
+
+            _testOutputHelper.WriteLine($"rtest = {rtest}, vtest = {vtest}");
+            _testOutputHelper.WriteLine($"dv = {dv}, dt = {dt}, peR = {newPeR}");
 
             (V3 moonR2, V3 moonV2) = Shepperd.Solve(centralMu, dt + tt1, moonR0, moonV0);
 


### PR DESCRIPTION
It will solve for a 'cleanup burn' if the initial ejection burn was off, or the user wants to refine the targeting.