### PR TITLE
PID tuning

### DIFF
--- a/MechJeb2/MechJebLib/Control/PIDLoop.cs
+++ b/MechJeb2/MechJebLib/Control/PIDLoop.cs
@@ -4,6 +4,7 @@
  * and GPLv2 (GPLv2-LICENSE) license or any later version.
  */
 
+using System;
 using static MechJebLib.Utils.Statics;
 
 #nullable enable
@@ -21,8 +22,10 @@ namespace MuMech.MechJebLib.Control
         public double C         { get; set; } = 1;
         public double SmoothIn  { get; set; } = 1.0;
         public double SmoothOut { get; set; } = 1.0;
+        public double Deadband  { get; set; } = 0;
         public double MinOutput { get; set; } = double.MinValue;
         public double MaxOutput { get; set; } = double.MaxValue;
+        public bool   Clegg     { get; set; } = true;
 
         // internal state for PID filter
         private double _d1, _d2;
@@ -31,22 +34,36 @@ namespace MuMech.MechJebLib.Control
         private double _m1 = double.NaN;
         private double _o1 = double.NaN;
 
+        // for zero crossing logic
+        private double _delta1 = double.NaN;
+
         public double Update(double reference, double measured)
         {
             // lowpass filter the input
             measured = _m1.IsFinite() ? _m1 + SmoothIn * (measured - _m1) : measured;
 
-            double ep = B * reference - measured;
-            double ei = reference - measured;
-            double ed = C * reference - measured;
+            double delta = reference - measured;
+
+            if (Math.Abs(delta) < Deadband)
+                delta = 0;
+            else
+                delta -= Math.Sign(delta) * Deadband;
+
+            // clegg filtering on zero-crossing to remove integral windup
+            if (_delta1.IsFinite() && Clegg && ((delta < 0 && _delta1 > 0) || (delta > 0 && _delta1 < 0)))
+                _d1 = _d2 = 0;
+
+            double ep = B * delta;
+            double ei = delta;
+            double ed = C * delta;
 
             // trapezoidal PID with derivative filtering as a digital biquad filter
             double a0 = 2 * N * Ts + 4;
             double a1 = -8 / a0;
             double a2 = (-2 * N * Ts + 4) / a0;
-            double b0 = (4 * Kp*ep + 4 * Kd*ed * N + 2 * Ki*ei * Ts + 2 * Kp*ep * N * Ts + Ki*ei * N * Ts * Ts) / a0;
-            double b1 = (2 * Ki*ei * N * Ts * Ts - 8 * Kp*ep - 8 * Kd*ed * N) / a0;
-            double b2 = (4 * Kp*ep + 4 * Kd*ed * N - 2 * Ki*ei * Ts - 2 * Kp*ep * N * Ts + Ki*ei * N * Ts * Ts) / a0;
+            double b0 = (4 * Kp * ep + 4 * Kd * ed * N + 2 * Ki * ei * Ts + 2 * Kp * ep * N * Ts + Ki * ei * N * Ts * Ts) / a0;
+            double b1 = (2 * Ki * ei * N * Ts * Ts - 8 * Kp * ep - 8 * Kd * ed * N) / a0;
+            double b2 = (4 * Kp * ep + 4 * Kd * ed * N - 2 * Ki * ei * Ts - 2 * Kp * ep * N * Ts + Ki * ei * N * Ts * Ts) / a0;
 
             // if we have NaN values saved into internal state that needs to be cleared here or it won't reset
             if (!_d1.IsFinite())
@@ -63,7 +80,8 @@ namespace MuMech.MechJebLib.Control
             // low pass filter the output
             _o1 = _o1.IsFinite() ? _o1 + SmoothOut * (u0 - _o1) : u0;
 
-            _m1 = measured;
+            _m1     = measured;
+            _delta1 = delta;
 
             return _o1;
         }
@@ -71,8 +89,7 @@ namespace MuMech.MechJebLib.Control
         public void Reset()
         {
             _d1 = _d2 = 0;
-            _m1 = double.NaN;
-            _o1 = double.NaN;
+            _m1 = _o1 = _delta1 = double.NaN;
         }
     }
 }

--- a/MechJeb2/MechJebModuleAscentPVGAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentPVGAutopilot.cs
@@ -14,7 +14,7 @@ namespace MuMech
         public MechJebModuleAscentPVGAutopilot(MechJebCore core) : base(core)
         {
         }
-        
+
         private MechJebModuleAscentSettings _ascentSettings => core.ascentSettings;
 
         public override void OnModuleEnabled()
@@ -132,9 +132,9 @@ namespace MuMech
             double dt = MET - _pitchStartTime;
             double theta = dt * AscentSettings.PitchRate;
             double pitch = 90 - theta;
-            
-            // we need to initiate by at least 10 degrees, then transition to zerolift when srfvel catches up
-            if (vesselState.currentPitch > SrfvelPitch() && vesselState.currentPitch < 80)
+
+            // we need to initiate by at least 3 degrees, then transition to zerolift when srfvel catches up
+            if (vesselState.currentPitch > SrfvelPitch() && vesselState.currentPitch < 87)
             {
                 _mode = AscentMode.ZEROLIFT;
                 return;


### PR DESCRIPTION
- revert the likely somewhat poor idea I had for adding an integral term to the position PID

- refactor the position controller to more clearly allow setting Kp directly rather than whatever `PosFactor` was.

- bump up position Kp from around 0.7 to 2.0 which helps with rockets at physwarp going through max-Q

- add deadband and clegg crossing logic to the PID controller and use that to add some stability to the attitude controller around zero.

closes #1636 maybe, IDK there's not enough info there.