### PR TITLE
Optimize crossfeed sources collection in FuelFlowSimulation

### DIFF
--- a/MechJeb2/FuelFlowSimulation.cs
+++ b/MechJeb2/FuelFlowSimulation.cs
@@ -57,7 +57,11 @@ namespace MuMech
             {
                 Part p = parts[i];
                 FuelNode node = _nodeLookup[p];
-                node.AddCrossfeedSouces(p.crossfeedPartSet.GetParts(), _nodeLookup);
+                if (node.isEngine)
+                {
+                    HashSet<Part> set = p.crossfeedPartSet.GetParts();
+                    node.AddCrossfeedSources(set, _nodeLookup);
+                }
                 if (node.decoupledInStage >= _simStage) _simStage = node.decoupledInStage + 1;
             }
 

--- a/MechJeb2/FuelNode.cs
+++ b/MechJeb2/FuelNode.cs
@@ -112,6 +112,7 @@ namespace MuMech
             public bool   isthrottleLocked;
             public bool   activatesEvenIfDisconnected;
             public bool   isDrawingResources = true; // Is the engine actually using any resources
+            public bool   hasResources;
             public double maxThrust;
 
             private double resourceRequestRemainingThreshold;
@@ -280,6 +281,7 @@ namespace MuMech
                         freeResources[r.info.id] = true;
                 }
 
+                hasResources = resources.Count > 0 || freeResources.Count > 0;
                 engineInfos.Clear();
 
                 // determine if we've got at least one useful ModuleEngine
@@ -572,14 +574,14 @@ namespace MuMech
                 }
             }
 
-            public void AddCrossfeedSouces(HashSet<Part> parts, Dictionary<Part, FuelNode> nodeLookup)
+            public void AddCrossfeedSources(HashSet<Part> parts, Dictionary<Part, FuelNode> nodeLookup)
             {
                 using (HashSet<Part>.Enumerator it = parts.GetEnumerator())
                 {
                     while (it.MoveNext())
                     {
                         FuelNode fuelnode;
-                        if (nodeLookup.TryGetValue(it.Current, out fuelnode))
+                        if (nodeLookup.TryGetValue(it.Current, out fuelnode) && fuelnode.hasResources)
                             crossfeedSources.Add(fuelnode);
                     }
                 }


### PR DESCRIPTION
With a vessel that has 300 parts in a single stage, collecting the part information in FFS takes about 20-30ms. To make matters worse, the exact same process is done twice for vacuum and atmospheric stats.
The main culprit is this part of the code where it iterates over 307 parts times 307 items inside the crossfeed set (94k in total!!!).
![img](https://cdn.discordapp.com/attachments/512556346869284864/1104533176753336380/image.png)

The proposed fix is to only process crossfeed for parts that are engines. Additionally only parts that have resources are added to the crossfeed sources.
The changes will bring the time down to 4-6ms for running the code for vac and atm combined.