### PR TITLE
PVG coast fixes

### DIFF
--- a/MechJeb2/MechJebLib/PVG/Solution.cs
+++ b/MechJeb2/MechJebLib/PVG/Solution.cs
@@ -328,7 +328,7 @@ namespace MechJebLib.PVG
         {
             for (int i = 0; i < Phases.Count; i++)
             {
-                if (Phases[i].KSPStage == kspStage)
+                if (Phases[i].KSPStage == kspStage && !Phases[i].Coast)
                     return i;
             }
 

--- a/MechJeb2/MechJebModulePVGGlueBall.cs
+++ b/MechJeb2/MechJebModulePVGGlueBall.cs
@@ -222,9 +222,9 @@ namespace MuMech
 
                         if (i == vessel.currentStage && core.guidance.IsCoasting())
                         {
-                            ct   = Math.Max(ct - vesselState.time - core.guidance.StartCoast, 0);
-                            maxt = Math.Max(maxt - vesselState.time - core.guidance.StartCoast, 0);
-                            mint = Math.Max(mint - vesselState.time - core.guidance.StartCoast, 0);
+                            ct   = Math.Max(ct - (vesselState.time - core.guidance.StartCoast), 0);
+                            maxt = Math.Max(maxt - (vesselState.time - core.guidance.StartCoast), 0);
+                            mint = Math.Max(mint - (vesselState.time - core.guidance.StartCoast), 0);
                         }
 
                         if (_ascentSettings.FixedCoast)


### PR DESCRIPTION
This fixes two small issues that make coasts not work.

The first is that coasts complete immediately, caused by a sign error in `MechJebModulePVGGlueBall.SetTarget`. This causes the coast time-to-go to become 0 in the first guidance update during the coast.

The second issue causes PVG to immediately transition to FINISHED upon completion of the coast when `CoastBeforeFlag` is set.

The cause can be found in `MechJebModuleGuidanceController.HandleTerminal`. Suppose that `vessel.currentStage == _ascentSettings.CoastStage`, `CoastBeforeFlag` is set, and we're currently at the exact point where the coast ends. In the first tick after ignition, and before the next PVG optimizer update, `IndexForKSPStage(vessel.currentStage)` will return the index of the coast phase. The time-to-go in the coast phase is less than 10 s, and guidance will switch to terminal mode. Then, the `Solution.TerminalGuidanceSatisfied` call will compare the current state with that expected at the end of the coast, it will return true, and guidance will end.

The fix is to make `IndexForKSPStage` always return the index of the phase in which the stage is burning, not the coast phase (if that occurs first). Then, at ignition, time-to-go is the burn time of the stage and guidance will not switch to terminal mode.

The only other current use of this method is in `MechJebModulePVGGlueBall.SetTarget`. Here, it is used for a check to block the optimizer during staging events. Without the change, this blocks the optimizer for a few seconds around the end of the coast and ignition of the stage; with the change, it keeps running.