### PR TITLE
Terminal Guidance correctness bug

### DIFF
--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -162,10 +162,7 @@ namespace MuMech
 
             int solutionIndex = Solution.IndexForKSPStage(vessel.currentStage);
             if (solutionIndex < 0)
-            {
-                Done();
                 return;
-            }
 
             // Only enter terminal guidance within 10 seconds of the current stage
             if (Solution.Tgo(vesselState.time, solutionIndex) > 10)


### PR DESCRIPTION
This seems a bit useless/dangerous to me.

We explicitly catch all the cases when we should exit terminal guidance above here.  While this will potentially blow up if we ever call it and grab a zero-dV stage or small ullage stage that is below minDV and isn't part of the solution.

It seems like we should just loop and wait for the stage and/or solution to update to something that agrees, or else loop until one of the explicit conditions at the top handles exiting properly.