### PR TITLE
PVG: Use Analytic for bootstrap and Integrator for converged

### DIFF
--- a/MechJeb2/MechJebLib/PVG/Integrators/VacuumThrustIntegrator.cs
+++ b/MechJeb2/MechJebLib/PVG/Integrators/VacuumThrustIntegrator.cs
@@ -30,7 +30,8 @@ namespace MechJebLib.PVG.Integrators
                 using var dy = ArrayWrapper.Rent(dyout);
 
                 double at = Phase.thrust / y.M;
-                if (Phase.Infinite) at *= 2;
+                if (Phase.Infinite)
+                    at *= 2;
 
                 double r2 = y.R.sqrMagnitude;
                 double r = Math.Sqrt(r2);
@@ -57,14 +58,18 @@ namespace MechJebLib.PVG.Integrators
 
         public void Integrate(Vn y0, Vn yf, Phase phase, double t0, double tf)
         {
-            _solver.ThrowOnMaxIter = true;
+            _solver.ThrowOnMaxIter = false;
+            _solver.Rtol           = 0;
+            _solver.Atol           = 1e-9;
             _ode.Phase             = phase;
             _solver.Solve(_ode.dydt, y0, yf, t0, tf);
         }
 
         public void Integrate(Vn y0, Vn yf, Phase phase, double t0, double tf, Solution solution)
         {
-            _solver.ThrowOnMaxIter = true;
+            _solver.ThrowOnMaxIter = false;
+            _solver.Rtol           = 0;
+            _solver.Atol           = 1e-9;
             _ode.Phase             = phase;
             var interpolant = Hn.Get(VacuumThrustKernel.N);
             _solver.Solve(_ode.dydt, y0, yf, t0, tf, interpolant);

--- a/MechJeb2/MechJebLib/Primitives/Vn.cs
+++ b/MechJeb2/MechJebLib/Primitives/Vn.cs
@@ -191,7 +191,8 @@ namespace MechJebLib.Primitives
         private static void Clear(Vn obj)
         {
             // do not resize the array to zero to avoid creating garbage
-            // we will return nonsense in the array values (not zeros) for performance
+            for (int i = 0; i < obj.Count; i++)
+                obj[i] = 0;
         }
 
         public static void Return(Vn obj)

--- a/MechJebLibTest/PVG/AscentTests/TheStandardTests.cs
+++ b/MechJebLibTest/PVG/AscentTests/TheStandardTests.cs
@@ -11,7 +11,7 @@ namespace MechJebLibTest.PVG
     {
         // This is fairly sensitive to initial bootstrapping and will often compute a negative coast instead of the optimal positive coast
         [Fact]
-        public void OptmizedBoosterWithCoastElliptical()
+        public void OptimizedBoosterWithCoastElliptical()
         {
             var r0 = new V3(-521765.111703417, -5568874.59934707, 3050608.87783524);
             var v0 = new V3(406.088016257895, -38.0495807832894, 0.000701038889818476);
@@ -63,6 +63,48 @@ namespace MechJebLibTest.PVG
             lanf.ShouldEqual(3.0481642123046941, 1e-7);
             argpf.ShouldEqual(1.8684926416804641, 1e-7);
             tanof.ShouldEqual(0.091089077094440363, 1e-7);
+
+            // re-run fully integrated instead of the analytic bootstrap
+            Ascent ascent2 = Ascent.Builder()
+                .Initial(r0, v0, u0, t0, mu, rbody)
+                .SetTarget(PeR, ApR, PeR, incT, 0, 0, false, false)
+                .AddStageUsingFinalMass(49119.7842689869, 7114.2513992454, 288.000034332275, 170.308460385726, 3)
+                .AddStageUsingFinalMass(2848.62586760223, 1363.71123994759, 270.15767003304, 116.391834883409, 1, true)
+                .AddOptimizedCoast(678.290157913434, 0, 450, 1)
+                .AddStageUsingFinalMass(678.290157913434, 177.582604389742, 230.039271734103, 53.0805126571005, 0, false, true)
+                .OldSolution(solution)
+                .Build();
+
+            ascent2.Run();
+
+            Optimizer pvg2 = ascent2.GetOptimizer() ?? throw new Exception("null optimzer");
+
+            using Solution solution2 = pvg2.GetSolution();
+
+            solution.Tgo(solution2.T0, 0).ShouldBePositive();
+            solution.Tgo(solution2.T0, 1).ShouldBePositive();
+            solution.Tgo(solution2.T0, 2).ShouldBePositive();
+            solution.Tgo(solution2.T0, 3).ShouldBePositive();
+
+            pvg2.Znorm.ShouldBeZero(1e-9);
+
+            (V3 rf2, V3 vf2) = solution2.TerminalStateVectors();
+
+            (double smaf2, double eccf2, double incf2, double lanf2, double argpf2, double tanof2, _) =
+                MechJebLib.Core.Maths.KeplerianFromStateVectors(mu, rf2, vf2);
+
+            solution2.R(t0).ShouldEqual(r0);
+            solution2.V(t0).ShouldEqual(v0);
+            solution2.M(t0).ShouldEqual(49119.7842689869);
+            solution2.Vgo(t0).ShouldEqual(9677.8444697307314, 1e-7);
+            solution2.Pv(t0).ShouldEqual(new V3(0.4936213839655178, -0.37228178807752599, 0.17701920733179485), 1e-7);
+
+            smaf2.ShouldEqual(11463499.98898875, 1e-7);
+            eccf2.ShouldEqual(0.4280978753095433, 1e-7);
+            incf2.ShouldEqual(incT, 1e-7);
+            lanf2.ShouldEqual(3.0481648247809443, 1e-7);
+            argpf2.ShouldEqual(1.8659359635671597, 1e-7);
+            tanof2.ShouldEqual(0.091785663682881768, 1e-7);
         }
     }
 }

--- a/MechJebLibTest/PVG/Integrators/VacuumThrustIntegratorTests.cs
+++ b/MechJebLibTest/PVG/Integrators/VacuumThrustIntegratorTests.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿using AssertExtensions;
 using MechJebLib.Primitives;
 using MechJebLib.PVG;
 using MechJebLib.PVG.Integrators;
-using static MechJebLib.Utils.Statics;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,11 +17,14 @@ namespace MechJebLibTest.PVG
         }
 
         [Fact]
-        void TestOne()
+        private void TestOne()
         {
-            double[] initial = { -0.081895706968361404, -0.87408474062734443, 0.47882038321543935, 0.051340280325144226, -0.0048104747381358367,
-                8.8629882392912712E-08, 0.48974601817567098, -0.36890385205553877, 0.17538607033093154, -0.080013188175758393, -0.91271362697981473,
-                0.49963482634661827, 1, 0, 0 };
+            double[] initial =
+            {
+                -0.081895706968361404, -0.87408474062734443, 0.47882038321543935, 0.051340280325144226, -0.0048104747381358367,
+                8.8629882392912712E-08, 0.48974601817567098, -0.36890385205553877, 0.17538607033093154, -0.080013188175758393,
+                -0.91271362697981473, 0.49963482634661827, 1, 0, 0
+            };
 
             double[] terminal =
             {
@@ -44,28 +46,26 @@ namespace MechJebLibTest.PVG
             var phase = Phase.NewStageUsingFinalMass(m0, 7114.2513992454, 288.000034332275, 170.308460385726, 3);
             Phase normalizedPhase = phase.Rescale(scale);
 
-            var integrator = new VacuumThrustAnalytic();
+            var integrator = new VacuumThrustIntegrator();
 
             integrator.Integrate(y0, yf, normalizedPhase, 0, 0.21143859334689075);
 
             using var expected = ArrayWrapper.Rent(terminal);
             using var actual = ArrayWrapper.Rent(yf);
 
-            _testOutputHelper.WriteLine($"{(actual.R - expected.R).magnitude/expected.R.magnitude}");
-            _testOutputHelper.WriteLine($"{(actual.V - expected.V).magnitude/expected.V.magnitude}");
-            _testOutputHelper.WriteLine($"{(actual.PV - expected.PV).magnitude/expected.PV.magnitude}");
-            _testOutputHelper.WriteLine($"{(actual.PR - expected.PR).magnitude/expected.PR.magnitude}\n");
+            _testOutputHelper.WriteLine($"{(actual.R - expected.R).magnitude / expected.R.magnitude}");
+            _testOutputHelper.WriteLine($"{(actual.V - expected.V).magnitude / expected.V.magnitude}");
+            _testOutputHelper.WriteLine($"{(actual.PV - expected.PV).magnitude / expected.PV.magnitude}");
+            _testOutputHelper.WriteLine($"{(actual.PR - expected.PR).magnitude / expected.PR.magnitude}\n");
             for (int i = 0; i < yf.Count; i++)
                 _testOutputHelper.WriteLine($"{yf[i] / terminal[i]}");
 
-            /*
             for (int i = 0; i < yf.Count; i++)
-                yf[i].ShouldEqual(terminal[i], EPS);
-                */
+                yf[i].ShouldEqual(terminal[i], 1e-8);
         }
 
         [Fact]
-        void TestTwo()
+        private void TestTwo()
         {
             double[] initial =
             {
@@ -76,9 +76,9 @@ namespace MechJebLibTest.PVG
 
             double[] terminal =
             {
-                0.047109712867170944,-0.89018657363287546,0.48099760897140348,0.81166191261810106,-0.075137083529584037,-0.00051053125862332409,
-                0.48808366292612443,-0.10550522395750975,0.03245889518210119,0.083822746636572881,-0.79455356115633813,0.42713133458266622,
-                0.036958492716224652,0,0.84081895291759234
+                0.047109712867170944, -0.89018657363287546, 0.48099760897140348, 0.81166191261810106, -0.075137083529584037,
+                -0.00051053125862332409, 0.48808366292612443, -0.10550522395750975, 0.03245889518210119, 0.083822746636572881,
+                -0.79455356115633813, 0.42713133458266622, 0.036958492716224652, 0, 0.84081895291759234
             };
 
             var r0 = new V3(-521765.111703417, -5568874.59934707, 3050608.87783524);
@@ -95,34 +95,32 @@ namespace MechJebLibTest.PVG
             var phase = Phase.NewStageUsingFinalMass(2848.62586760223, 1363.71123994759, 270.15767003304, 116.391834883409, 1, true);
             Phase normalizedPhase = phase.Rescale(scale);
 
-            var integrator = new VacuumThrustAnalytic();
+            var integrator = new VacuumThrustIntegrator();
 
             integrator.Integrate(y0, yf, normalizedPhase, 0, 0.10054655629279166);
 
             for (int i = 0; i < yf.Count; i++)
                 _testOutputHelper.WriteLine($"{yf[i] / terminal[i]}");
 
-            /*
             for (int i = 0; i < yf.Count; i++)
-                yf[i].ShouldEqual(terminal[i], EPS);
-                */
+                yf[i].ShouldEqual(terminal[i], 1e-6);
         }
 
         [Fact]
-        void TestThree()
+        private void TestThree()
         {
             double[] initial =
             {
-                0.27948091968562255,-0.87629682147680643,0.46162785861333505,0.76704862327676382,0.1675555528292863,-0.13002847184975891,
-                0.44534202722652572,0.11955432088272852,-0.087560284939524932,0.20710379113249269,-0.75262217242406393,0.39809178059136263,
-                0.013808898897445529,0,0.84081895291759234
+                0.27948091968562255, -0.87629682147680643, 0.46162785861333505, 0.76704862327676382, 0.1675555528292863, -0.13002847184975891,
+                0.44534202722652572, 0.11955432088272852, -0.087560284939524932, 0.20710379113249269, -0.75262217242406393, 0.39809178059136263,
+                0.013808898897445529, 0, 0.84081895291759234
             };
 
             double[] terminal =
             {
-                0.33879378309256369,-0.86100596113880579,0.45030618690420138,1.1111316964849096,0.31748261957072527,-0.22893330305695009,
-                0.43076249468051553,0.16903642775109523,-0.1136843605281575,0.23555616906817203,-0.74935670563088341,0.39487218757780468,
-                0.0036152964422362975,0,1.2230365666723386
+                0.33879378309256369, -0.86100596113880579, 0.45030618690420138, 1.1111316964849096, 0.31748261957072527, -0.22893330305695009,
+                0.43076249468051553, 0.16903642775109523, -0.1136843605281575, 0.23555616906817203, -0.74935670563088341, 0.39487218757780468,
+                0.0036152964422362975, 0, 1.2230365666723386
             };
 
             var r0 = new V3(-521765.111703417, -5568874.59934707, 3050608.87783524);
@@ -140,17 +138,15 @@ namespace MechJebLibTest.PVG
             Phase normalizedPhase = phase.Rescale(scale);
             normalizedPhase.u0 = new V3(0.94884816849167, 0.254723092521293, -0.186556423867935);
 
-            var integrator = new VacuumThrustAnalytic();
+            var integrator = new VacuumThrustIntegrator();
 
             integrator.Integrate(y0, yf, normalizedPhase, 0, 0.065899655865186896);
 
             for (int i = 0; i < yf.Count; i++)
                 _testOutputHelper.WriteLine($"{yf[i] / terminal[i]}");
 
-            /*
             for (int i = 0; i < yf.Count; i++)
-                yf[i].ShouldEqual(terminal[i], EPS);
-                */
+                yf[i].ShouldEqual(terminal[i], 1e-8);
         }
     }
 }


### PR DESCRIPTION
Makes bootstrapping fast and then makes it accurate.

Also can find issues with the integrator by having it be the actual second pass through.  It should be very definitive bug reports as long as people describe it properly or show a video.

Had to initialize the Vn's to zeros because otherwise weird things happen due to some kind of reuse bug.  Someting is getting +='d or something like that without being zero'd.  Really that's hard enough to track down that zero'ing everything makes a lot of sense.