### PR TITLE
Fix Fairing Separation logic

### DIFF
--- a/MechJeb2/MechJebLib/Core/Maths.cs
+++ b/MechJeb2/MechJebLib/Core/Maths.cs
@@ -297,7 +297,7 @@ namespace MechJebLib.Core
 
         public static double LatitudeFromBCI(V3 r)
         {
-            return Math.Asin(Clamp(r.z / r.magnitude, -1, 1));
+            return SafeAsin(r.z / r.magnitude);
         }
 
         public static double LongitudeFromBCI(V3 r)

--- a/MechJeb2/PartExtensions.cs
+++ b/MechJeb2/PartExtensions.cs
@@ -231,6 +231,34 @@ namespace MuMech
             return false;
         }
 
+        /// <summary>
+        ///     Determines if a given part is a ProceduralFairingDecoupler
+        /// </summary>
+        /// <param name="p">the part to check</param>
+        /// <returns>if the part is a procfairing payload decoupler</returns>
+        public static bool IsProceduralFairing(this Part p)
+        {
+            if (!VesselState.isLoadedProceduralFairing) return false;
+            return p.Modules.Contains("ProceduralFairingDecoupler");
+        }
+
+        /// <summary>
+        ///     Determines if a given part is a ProceduralFairingDecoupler which is attached to a payload ProceduralFairingBase
+        /// </summary>
+        /// <param name="p">the part to check</param>
+        /// <returns>if the part is a procfairing payload decoupler</returns>
+        public static bool IsProceduralFairingPayloadFairing(this Part p)
+        {
+            if (!p.IsProceduralFairing()) return false;
+            Part basepart = p.parent;
+            if (basepart is null)
+                throw new Exception("ProceduralFairingDecoupler parent is null--fix your root staging?");
+            PartModule fairingbase = basepart.Modules.GetModule("ProceduralFairingBase");
+            if (fairingbase is null)
+                throw new Exception("ProceduralFairingBase not found in parent part, weird.");
+            return fairingbase.Fields["mode"].GetValue<string>(fairingbase) == "Payload";
+        }
+
         public static bool IsUnfiredDecoupler(this Part p, out Part decoupledPart)
         {
             foreach (PartModule m in p.Modules)


### PR DESCRIPTION
Fairing stages now must be:

- if a PF fairing is in the stage, all the parts in the stage must be PF payload fairings.

- if a stage has only decopulers, without children, that aren't launch clamps then it is considered a fairing stage.

this fixes the bug where any PF fairing in a stage would turn it into a fairing stage.

this also fixes things like RSB fairing decouplers, which are just normal decouplers and it is hard to identify them uniquely.

this may identify non-PF interstage fairings that are in a stage by themselves as payload fairings.  the workaround to that is to add the stack decoupler to that stage and stage them together (or an engine, or any other part which will prevent them being identified as a payload fairing).