### PR TITLE
Fix both checks that use IndexForKSPStage

### DIFF
--- a/MechJeb2/MechJebLib/PVG/Solution.cs
+++ b/MechJeb2/MechJebLib/PVG/Solution.cs
@@ -323,15 +323,17 @@ namespace MechJebLib.PVG
             return _tmax.Count - 1;
         }
 
-        public int IndexForKSPStage(int kspStage, bool includeCoasts = true)
+        public int IndexForKSPStage(int kspStage, bool coasting)
         {
             for (int i = 0; i < Phases.Count; i++)
             {
                 if (Phases[i].KSPStage != kspStage)
                     continue;
 
-                if (!Phases[i].Coast || includeCoasts)
-                    return i;
+                if (Phases[i].Coast != coasting)
+                    continue;
+
+                return i;
             }
 
             return -1;

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -169,7 +169,7 @@ namespace MuMech
             // is in the "past" in the Solution but you're burning down residuals and you don't know when
             // the stage will actually run out (assuming it isn't a burn before a coast or an optimized burntime
             // so that we burn past the end of the stage and into whatever residuals are available).
-            int solutionIndex = Solution.IndexForKSPStage(vessel.currentStage, false);
+            int solutionIndex = Solution.IndexForKSPStage(vessel.currentStage, core.guidance.IsCoasting());
             if (solutionIndex < 0)
                 return;
 

--- a/MechJeb2/MechJebModulePVGGlueBall.cs
+++ b/MechJeb2/MechJebModulePVGGlueBall.cs
@@ -174,16 +174,13 @@ namespace MuMech
                     return;
             }
 
-            if (_blockOptimizerUntilTime > vesselState.time)
-                return;
-
             // check for readiness (not terminal guidance and not finished)
             if (!core.guidance.IsReady())
                 return;
 
             if (core.guidance.Solution != null)
             {
-                int solutionIndex = core.guidance.Solution.IndexForKSPStage(vessel.currentStage);
+                int solutionIndex = core.guidance.Solution.IndexForKSPStage(vessel.currentStage, core.guidance.IsCoasting());
 
                 if (solutionIndex >= 0)
                 {
@@ -195,6 +192,9 @@ namespace MuMech
                     }
                 }
             }
+
+            if (_blockOptimizerUntilTime > vesselState.time)
+                return;
 
             Ascent.AscentBuilder ascentBuilder = Ascent.Builder()
                 .Initial(vesselState.orbitalPosition.WorldToV3Rotated(), vesselState.orbitalVelocity.WorldToV3Rotated(),


### PR DESCRIPTION
Changes the API to more sensibly just use the coast/burn boolean as a matcher, so we try to find exactly what we're looking for.

Also make sure that we're continuously updating the _blockOptimizerUntilTime code so that we get the 5 seconds of suspending the optimizer correctly between the coast and the burn when we're doing coast-before and therefore don't hit the staging callback.