### PR TITLE
Add back the Ascent AP Toggle

### DIFF
--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -280,6 +280,23 @@ namespace MuMech
             }
         }
 
+        [KSPAction("#MechJeb_AscentAPtoggle")] //Ascent AP toggle
+        public void OnAscentAPToggleAction(KSPActionParam param)
+        {
+            MechJebCore masterMechJeb = vessel.GetMasterMechJeb();
+
+            MechJebModuleAscentBaseAutopilot autopilot = masterMechJeb.AscentSettings.AscentAutopilot;
+            MechJebModuleAscentMenu ascentMenu = GetComputerModule<MechJebModuleAscentMenu>();
+
+            if (autopilot == null || ascentMenu == null)
+                return;
+
+            if (autopilot.Enabled)
+                autopilot.aUsers.Remove(ascentMenu);
+            else
+                autopilot.Users.Add(ascentMenu);
+        }
+
         private void EngageTranslatronControl(MechJebModuleThrustController.TMode mode)
         {
             MechJebCore masterMechJeb = vessel.GetMasterMechJeb();


### PR DESCRIPTION
not sure why i deleted that, but it did have to change because of the restructuring of the ascent autopilots.