### PR TITLE
Back to C# 8.0

### DIFF
--- a/MechJeb2/MechJeb2.csproj
+++ b/MechJeb2/MechJeb2.csproj
@@ -15,7 +15,7 @@
         <TargetFrameworkProfile />
         <NuGetPackageImportStamp>
         </NuGetPackageImportStamp>
-        <LangVersion>9</LangVersion>
+        <LangVersion>8</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
I think @sarbian would have to update the compilers on jankins

But then that doesn't give any good feedback if the features are busted on the older KSP runtime, so maybe that wasn't a good idea.