### PR TITLE
Let multiple modules limit autostaging and add/remove independently

### DIFF
--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -300,7 +300,7 @@ namespace MuMech
             // RCS trim, autostaging will stage off the spent engine if there's no relights.  This is unwanted
             // since the insertion stage may still have RCS which is necessary to complete the mission.
             if (coastStage >= 0 && Vessel.currentStage == coastStage && Solution.WillCoast(VesselState.time))
-                Core.Staging.autostageLimitInternal = coastStage;
+                Core.Staging.AutoStageLimitRequest(coastStage, this);
 
             if (Solution.Coast(VesselState.time))
             {
@@ -321,7 +321,7 @@ namespace MuMech
                 return;
             }
 
-            Core.Staging.autostageLimitInternal = Solution.TerminalStage();
+            Core.Staging.AutoStageLimitRequest(Solution.TerminalStage(), this);
 
             ThrottleOn();
 

--- a/MechJeb2/MechJebModuleSpinupController.cs
+++ b/MechJeb2/MechJebModuleSpinupController.cs
@@ -37,8 +37,7 @@ namespace MuMech
             _state = SpinupState.FINISHED;
             Core.Attitude.SetOmegaTarget(roll: double.NaN);
             Core.Attitude.SetActuationControl();
-            // FIXME: this might overwrite someone else, but the only other consumer so far is the GuidanceController
-            Core.Staging.autostageLimitInternal = 0;
+            Core.Staging.AutoStageLimitRemove( this);
             Core.Attitude.Users.Remove(this);
             base.OnModuleDisabled();
         }
@@ -65,7 +64,7 @@ namespace MuMech
             if (_state == SpinupState.INITIALIZED)
                 return;
 
-            Core.Staging.autostageLimitInternal = Vessel.currentStage;
+            Core.Staging.AutoStageLimitRequest(Vessel.currentStage, this);
 
             if (VesselState.time < _startTime)
                 return;


### PR DESCRIPTION
This way they don't scribble over what each other wants, and the staging controller is responsible for tracking and satisfying multiple requests.