### PR TITLE
ThrustController and StagingController cleanup

### DIFF
--- a/MechJeb2/LandingAutopilot/CoastToDeceleration.cs
+++ b/MechJeb2/LandingAutopilot/CoastToDeceleration.cs
@@ -37,7 +37,7 @@ namespace MuMech
 
             public override AutopilotStep OnFixedUpdate()
             {
-                Core.Thrust.targetThrottle = 0;
+                Core.Thrust.TargetThrottle = 0;
 
                 // If the atmospheric drag is has started to act on the vessel then we are in a position to start considering when to deploy the parachutes.
                 if (Core.Landing.DeployChutes)

--- a/MechJeb2/LandingAutopilot/CourseCorrection.cs
+++ b/MechJeb2/LandingAutopilot/CourseCorrection.cs
@@ -30,7 +30,7 @@ namespace MuMech
 
                 if (currentError < 150)
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
                     if (Core.Landing.RCSAdjustment)
                         Core.RCS.Enabled = true;
                     return new CoastToDeceleration(Core);
@@ -46,7 +46,7 @@ namespace MuMech
                 // If a parachute has already been deployed then we will not be able to control attitude anyway, so move back to the coast to deceleration step.
                 if (VesselState.parachuteDeployed)
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
                     return new CoastToDeceleration(Core);
                 }
 
@@ -75,7 +75,7 @@ namespace MuMech
                 }
                 else
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
                 }
 
                 return this;

--- a/MechJeb2/LandingAutopilot/DecelerationBurn.cs
+++ b/MechJeb2/LandingAutopilot/DecelerationBurn.cs
@@ -28,7 +28,7 @@ namespace MuMech
                     Core.Landing.Prediction.Trajectory.Any() ? Core.Landing.Prediction.Trajectory.First().UT : VesselState.time;
                 if (decelerationStartTime - VesselState.time > 5)
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
 
                     Status = Localizer.Format("#MechJeb_LandingGuidance_Status4"); //"Warping to start of braking burn."
 
@@ -56,7 +56,7 @@ namespace MuMech
                 if (Vector3d.Dot(VesselState.surfaceVelocity, VesselState.up) > 0
                     || Vector3d.Dot(VesselState.forward, desiredThrustVector) < 0.75)
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
                     Status                     = Localizer.Format("#MechJeb_LandingGuidance_Status5"); //"Braking"
                 }
                 else
@@ -73,8 +73,8 @@ namespace MuMech
                     double speedError = desiredSpeed - controlledSpeed;
                     double desiredAccel = speedError / SPEED_CORRECTION_TIME_CONSTANT + (desiredSpeedAfterDt - desiredSpeed) / VesselState.deltaT;
                     if (maxAccel - minAccel > 0)
-                        Core.Thrust.targetThrottle  = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.0F, 1.0F);
-                    else Core.Thrust.targetThrottle = 0;
+                        Core.Thrust.TargetThrottle  = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.0F, 1.0F);
+                    else Core.Thrust.TargetThrottle = 0;
                     Status = Localizer.Format("#MechJeb_LandingGuidance_Status6",
                         desiredSpeed >= double.MaxValue ? "∞" : Math.Abs(desiredSpeed).ToString("F1")); //"Braking: target speed = " +  + " m/s"
                 }

--- a/MechJeb2/LandingAutopilot/DeorbitBurn.cs
+++ b/MechJeb2/LandingAutopilot/DeorbitBurn.cs
@@ -19,9 +19,9 @@ namespace MuMech
             public override AutopilotStep Drive(FlightCtrlState s)
             {
                 if (_deorbitBurnTriggered && Core.Attitude.attitudeAngleFromTarget() < 5)
-                    Core.Thrust.targetThrottle = 1.0F;
+                    Core.Thrust.TargetThrottle = 1.0F;
                 else
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
 
                 return this;
             }
@@ -32,7 +32,7 @@ namespace MuMech
                 //in the orbit to deorbt; we already have deorbited.
                 if (Orbit.ApA < MainBody.RealMaxAtmosphereAltitude())
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
                     return new CourseCorrection(Core);
                 }
 

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -48,9 +48,9 @@ namespace MuMech
                 {
                     // if we have TWR < 1, just try as hard as we can to decelerate:
                     // (we need this special case because otherwise the calculations spit out NaN's)
-                    Core.Thrust.tmode         = MechJebModuleThrustController.TMode.KEEP_VERTICAL;
-                    Core.Thrust.trans_kill_h  = true;
-                    Core.Thrust.trans_spd_act = 0;
+                    Core.Thrust.Tmode       = MechJebModuleThrustController.TMode.KEEP_VERTICAL;
+                    Core.Thrust.TransKillH  = true;
+                    Core.Thrust.TransSpdAct = 0;
                 }
                 else if (minalt > 200)
                 {
@@ -58,22 +58,22 @@ namespace MuMech
                     {
                         // if we have positive vertical velocity, point up and don't thrust:
                         Core.Attitude.attitudeTo(Vector3d.up, AttitudeReference.SURFACE_NORTH, null);
-                        Core.Thrust.tmode         = MechJebModuleThrustController.TMode.DIRECT;
-                        Core.Thrust.trans_spd_act = 0;
+                        Core.Thrust.Tmode       = MechJebModuleThrustController.TMode.DIRECT;
+                        Core.Thrust.TransSpdAct = 0;
                     }
                     else if (VesselState.surfaceVelocity.magnitude > 5 && Vector3d.Angle(VesselState.forward, -VesselState.surfaceVelocity) > 45)
                     {
                         // if we're not facing approximately retrograde, turn to point retrograde and don't thrust:
                         Core.Attitude.attitudeTo(Vector3d.back, AttitudeReference.SURFACE_VELOCITY, null);
-                        Core.Thrust.tmode         = MechJebModuleThrustController.TMode.DIRECT;
-                        Core.Thrust.trans_spd_act = 0;
+                        Core.Thrust.Tmode       = MechJebModuleThrustController.TMode.DIRECT;
+                        Core.Thrust.TransSpdAct = 0;
                     }
                     else
                     {
                         //if we're above 200m, point retrograde and control surface velocity:
                         Core.Attitude.attitudeTo(Vector3d.back, AttitudeReference.SURFACE_VELOCITY, null);
 
-                        Core.Thrust.tmode = MechJebModuleThrustController.TMode.KEEP_SURFACE;
+                        Core.Thrust.Tmode = MechJebModuleThrustController.TMode.KEEP_SURFACE;
 
                         //core.thrust.trans_spd_act = (float)Math.Sqrt((vesselState.maxThrustAccel - vesselState.gravityForce.magnitude) * 2 * minalt) * 0.90F;
                         Vector3d estimatedLandingPosition = VesselState.CoM + VesselState.surfaceVelocity.sqrMagnitude /
@@ -82,18 +82,18 @@ namespace MuMech
                         _aggressivePolicy =
                             new GravityTurnDescentSpeedPolicy(terrainRadius, MainBody.GeeASL * 9.81,
                                 VesselState.limitedMaxThrustAccel); // this constant policy creation is wastefull...
-                        Core.Thrust.trans_spd_act =
+                        Core.Thrust.TransSpdAct =
                             (float)_aggressivePolicy.MaxAllowedSpeed(VesselState.CoM - MainBody.position, VesselState.surfaceVelocity);
                     }
                 }
                 else
                 {
                     // last 200 meters:
-                    Core.Thrust.trans_spd_act = -Mathf.Lerp(0,
+                    Core.Thrust.TransSpdAct = -Mathf.Lerp(0,
                         (float)Math.Sqrt((VesselState.limitedMaxThrustAccel - VesselState.localg) * 2 * 200) * 0.90F, (float)minalt / 200);
 
                     // take into account desired landing speed:
-                    Core.Thrust.trans_spd_act = (float)Math.Min(-Core.Landing.TouchdownSpeed, Core.Thrust.trans_spd_act);
+                    Core.Thrust.TransSpdAct = (float)Math.Min(-Core.Landing.TouchdownSpeed, Core.Thrust.TransSpdAct);
 
 //                    core.thrust.tmode = MechJebModuleThrustController.TMode.KEEP_VERTICAL;
 //                    core.thrust.trans_kill_h = true;
@@ -103,8 +103,8 @@ namespace MuMech
                     {
                         // if we're falling more or less straight down, control vertical speed and
                         // kill horizontal velocity
-                        Core.Thrust.tmode        = MechJebModuleThrustController.TMode.KEEP_VERTICAL;
-                        Core.Thrust.trans_kill_h = true;
+                        Core.Thrust.Tmode      = MechJebModuleThrustController.TMode.KEEP_VERTICAL;
+                        Core.Thrust.TransKillH = true;
                     }
                     else
                     {
@@ -112,8 +112,8 @@ namespace MuMech
                         // quite small but we might still need to decelerate. Control the total speed instead
                         // by thrusting directly retrograde
                         Core.Attitude.attitudeTo(Vector3d.back, AttitudeReference.SURFACE_VELOCITY, null);
-                        Core.Thrust.tmode         =  MechJebModuleThrustController.TMode.KEEP_SURFACE;
-                        Core.Thrust.trans_spd_act *= -1;
+                        Core.Thrust.Tmode       =  MechJebModuleThrustController.TMode.KEEP_SURFACE;
+                        Core.Thrust.TransSpdAct *= -1;
                     }
                 }
 

--- a/MechJeb2/LandingAutopilot/KillHorizontalVelocity.cs
+++ b/MechJeb2/LandingAutopilot/KillHorizontalVelocity.cs
@@ -20,7 +20,7 @@ namespace MuMech
                 Vector3d horizontalPointingDirection = Vector3d.Exclude(VesselState.up, VesselState.forward).normalized;
                 if (Vector3d.Dot(horizontalPointingDirection, VesselState.surfaceVelocity) > 0)
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
                     Core.Attitude.attitudeTo(Vector3.up, AttitudeReference.SURFACE_NORTH, Core.Landing);
                     return new FinalDescent(Core);
                 }
@@ -35,11 +35,11 @@ namespace MuMech
                 double maxAccel = -VesselState.localg + Vector3d.Dot(VesselState.forward, VesselState.up) * VesselState.maxThrustAccel;
                 if (maxAccel - minAccel > 0)
                 {
-                    Core.Thrust.targetThrottle = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.0F, 1.0F);
+                    Core.Thrust.TargetThrottle = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.0F, 1.0F);
                 }
                 else
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
                 }
 
                 //angle up and slightly away from vertical:

--- a/MechJeb2/LandingAutopilot/LowDeorbitBurn.cs
+++ b/MechJeb2/LandingAutopilot/LowDeorbitBurn.cs
@@ -26,11 +26,11 @@ namespace MuMech
             {
                 if (_deorbitBurnTriggered && Core.Attitude.attitudeAngleFromTarget() < 5)
                 {
-                    Core.Thrust.targetThrottle = Mathf.Clamp01((float)_lowDeorbitBurnMaxThrottle);
+                    Core.Thrust.TargetThrottle = Mathf.Clamp01((float)_lowDeorbitBurnMaxThrottle);
                 }
                 else
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
                 }
 
                 return this;
@@ -56,8 +56,10 @@ namespace MuMech
                     _deorbitBurnTriggered = true;
                 }
 
-                Status = Localizer.Format(_deorbitBurnTriggered ? "#MechJeb_LandingGuidance_Status11" : //"Executing low deorbit burn"
-                    "#MechJeb_LandingGuidance_Status12");                                               //"Moving to low deorbit burn point"
+                Status = Localizer.Format(_deorbitBurnTriggered
+                    ? "#MechJeb_LandingGuidance_Status11"
+                    :                                     //"Executing low deorbit burn"
+                    "#MechJeb_LandingGuidance_Status12"); //"Moving to low deorbit burn point"
 
                 //Warp toward deorbit burn if it hasn't been triggerd yet:
                 if (!_deorbitBurnTriggered && Core.Node.autowarp && rangeToTarget > 2 * triggerDistance)
@@ -100,7 +102,7 @@ namespace MuMech
                         {
                             if (_lowDeorbitEndConditionSet && !_lowDeorbitEndOnLandingSiteNearer)
                             {
-                                Core.Thrust.targetThrottle = 0;
+                                Core.Thrust.TargetThrottle = 0;
                                 return new DecelerationBurn(Core);
                             }
 
@@ -119,7 +121,7 @@ namespace MuMech
                         {
                             if (_lowDeorbitEndConditionSet && _lowDeorbitEndOnLandingSiteNearer)
                             {
-                                Core.Thrust.targetThrottle = 0;
+                                Core.Thrust.TargetThrottle = 0;
                                 return new DecelerationBurn(Core);
                             }
 

--- a/MechJeb2/LandingAutopilot/PlaneChange.cs
+++ b/MechJeb2/LandingAutopilot/PlaneChange.cs
@@ -37,11 +37,11 @@ namespace MuMech
             {
                 if (_planeChangeTriggered && Core.Attitude.attitudeAngleFromTarget() < 2)
                 {
-                    Core.Thrust.targetThrottle = Mathf.Clamp01((float)(_planeChangeDVLeft / (2 * Core.VesselState.maxThrustAccel)));
+                    Core.Thrust.TargetThrottle = Mathf.Clamp01((float)(_planeChangeDVLeft / (2 * Core.VesselState.maxThrustAccel)));
                 }
                 else
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
                 }
 
                 return this;
@@ -70,7 +70,7 @@ namespace MuMech
                     //burn normal+ or normal- to avoid dropping the Pe:
                     var burnDir = Vector3d.Exclude(VesselState.up, Vector3d.Exclude(VesselState.orbitalVelocity, deltaV));
                     _planeChangeDVLeft = UtilMath.Deg2Rad * Vector3d.Angle(finalVelocity, VesselState.orbitalVelocity) *
-                                        VesselState.speedOrbitHorizontal;
+                                         VesselState.speedOrbitHorizontal;
                     Core.Attitude.attitudeTo(burnDir, AttitudeReference.INERTIAL, Core.Landing);
                     Status = Localizer.Format("#MechJeb_LandingGuidance_Status14",
                         _planeChangeDVLeft.ToString("F0")); //"Executing low orbit plane change of about " +  + " m/s"

--- a/MechJeb2/LandingAutopilot/UntargetedDeorbit.cs
+++ b/MechJeb2/LandingAutopilot/UntargetedDeorbit.cs
@@ -14,12 +14,12 @@ namespace MuMech
             {
                 if (Orbit.PeA < -0.1 * MainBody.Radius)
                 {
-                    Core.Thrust.targetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0;
                     return new FinalDescent(Core);
                 }
 
                 Core.Attitude.attitudeTo(Vector3d.back, AttitudeReference.ORBIT_HORIZONTAL, Core.Landing);
-                Core.Thrust.targetThrottle = Core.Attitude.attitudeAngleFromTarget() < 5 ? 1 : 0;
+                Core.Thrust.TargetThrottle = Core.Attitude.attitudeAngleFromTarget() < 5 ? 1 : 0;
 
                 Status = Localizer.Format("#MechJeb_LandingGuidance_Status16"); //"Doing deorbit burn."
 

--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -265,7 +265,7 @@ namespace MuMech
 
                 if (moduleTranslatron is { hidden: false })
                 {
-                    Thrust.trans_kill_h = !Thrust.trans_kill_h;
+                    Thrust.TransKillH = !Thrust.TransKillH;
                 }
                 else
                 {
@@ -335,7 +335,7 @@ namespace MuMech
             MechJebModuleTranslatron moduleTranslatron = masterMechJeb.GetComputerModule<MechJebModuleTranslatron>();
 
             if (moduleTranslatron is { hidden: false })
-                Thrust.trans_spd_act = (relative ? Thrust.trans_spd_act : 0) + speed;
+                Thrust.TransSpdAct = (relative ? Thrust.TransSpdAct : 0) + speed;
             else
                 Debug.LogError("MechJeb couldn't find MechJebModuleTranslatron for translatron control via action group.");
         }

--- a/MechJeb2/MechJebModuleAirplaneAutopilot.cs
+++ b/MechJeb2/MechJebModuleAirplaneAutopilot.cs
@@ -234,11 +234,11 @@ namespace MuMech
                 double tAct = AccelerationPIDController.Compute(AErr);
                 if (!double.IsNaN(tAct))
                 {
-                    Core.Thrust.targetThrottle = (float)MuUtils.Clamp(tAct, 0, 1);
+                    Core.Thrust.TargetThrottle = (float)MuUtils.Clamp(tAct, 0, 1);
                 }
                 else
                 {
-                    Core.Thrust.targetThrottle = 0.0f;
+                    Core.Thrust.TargetThrottle = 0.0f;
                     AccelerationPIDController.Reset();
                 }
             }

--- a/MechJeb2/MechJebModuleAscentClassicAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentClassicAutopilot.cs
@@ -98,7 +98,7 @@ namespace MuMech
 
             Core.Attitude.SetAxisControl(liftedOff, liftedOff, liftedOff && VesselState.altitudeBottom > AscentSettings.RollAltitude);
 
-            Core.Thrust.targetThrottle = 1.0F;
+            Core.Thrust.TargetThrottle = 1.0F;
 
             if (!Vessel.LiftedOff() || Vessel.Landed) Status = Localizer.Format("#MechJeb_Ascent_status6");  //"Awaiting liftoff"
             else Status                                      = Localizer.Format("#MechJeb_Ascent_status18"); //"Vertical ascent"
@@ -121,8 +121,8 @@ namespace MuMech
             }
 
 
-            Core.Thrust.targetThrottle = ThrottleToRaiseApoapsis(Orbit.ApR, AscentSettings.DesiredOrbitAltitude + MainBody.Radius);
-            if (Core.Thrust.targetThrottle < 1.0F)
+            Core.Thrust.TargetThrottle = ThrottleToRaiseApoapsis(Orbit.ApR, AscentSettings.DesiredOrbitAltitude + MainBody.Radius);
+            if (Core.Thrust.TargetThrottle < 1.0F)
             {
                 // follow surface velocity to reduce flipping
                 AttitudeTo(SrfvelPitch());
@@ -139,7 +139,7 @@ namespace MuMech
                 /* form an isosceles triangle with unit vectors pointing in the desired and actual flight path angle directions and find the length of the base */
                 double velocityError = 2 * Math.Sin((desiredFlightPathAngle - actualFlightPathAngle) / 2);
 
-                double difficulty = VesselState.surfaceVelocity.magnitude * 0.02 / VesselState.ThrustAccel(Core.Thrust.targetThrottle);
+                double difficulty = VesselState.surfaceVelocity.magnitude * 0.02 / VesselState.ThrustAccel(Core.Thrust.TargetThrottle);
                 difficulty = MuUtils.Clamp(difficulty, 0.1, 1.0);
                 double steerOffset = AscentSettings.CorrectiveSteeringGain * difficulty * velocityError;
 
@@ -155,7 +155,7 @@ namespace MuMech
 
         private void DriveCoastToApoapsis()
         {
-            Core.Thrust.targetThrottle = 0;
+            Core.Thrust.TargetThrottle = 0;
 
             if (VesselState.altitudeASL > MainBody.RealMaxAtmosphereAltitude())
             {
@@ -172,14 +172,14 @@ namespace MuMech
                 return;
             }
 
-            Core.Thrust.targetThrottle = 0;
+            Core.Thrust.TargetThrottle = 0;
 
             // follow surface velocity to reduce flipping
             AttitudeTo(SrfvelPitch());
 
             if (Orbit.ApA < AscentSettings.DesiredOrbitAltitude)
             {
-                Core.Thrust.targetThrottle = ThrottleToRaiseApoapsis(Orbit.ApR, AscentSettings.DesiredOrbitAltitude + MainBody.Radius);
+                Core.Thrust.TargetThrottle = ThrottleToRaiseApoapsis(Orbit.ApR, AscentSettings.DesiredOrbitAltitude + MainBody.Radius);
             }
 
             if (Core.Node.autowarp)

--- a/MechJeb2/MechJebModuleAscentGTAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentGTAutopilot.cs
@@ -81,7 +81,7 @@ namespace MuMech
 
             Core.Attitude.SetAxisControl(liftedOff, liftedOff, liftedOff && VesselState.altitudeBottom > AscentSettings.RollAltitude);
 
-            Core.Thrust.targetThrottle = 1.0F;
+            Core.Thrust.TargetThrottle = 1.0F;
 
             if (!Vessel.LiftedOff() || Vessel.Landed) Status = Localizer.Format("#MechJeb_Ascent_status6");  //"Awaiting liftoff"
             else Status                                      = Localizer.Format("#MechJeb_Ascent_status18"); //"Vertical ascent"
@@ -118,8 +118,8 @@ namespace MuMech
             AttitudeTo(90 - AscentSettings.TurnStartPitch);
 
 
-            Core.Thrust.targetThrottle = ThrottleToRaiseApoapsis(Orbit.ApR, AscentSettings.IntermediateAltitude + MainBody.Radius);
-            if (Core.Thrust.targetThrottle < 1.0F)
+            Core.Thrust.TargetThrottle = ThrottleToRaiseApoapsis(Orbit.ApR, AscentSettings.IntermediateAltitude + MainBody.Radius);
+            if (Core.Thrust.TargetThrottle < 1.0F)
             {
                 Status = Localizer.Format("#MechJeb_Ascent_status19"); //"Fine tuning intermediate altitude"
                 return;
@@ -162,8 +162,8 @@ namespace MuMech
             // srfvelPitch == zero AoA
             AttitudeTo(SrfvelPitch() * pitchfade);
 
-            Core.Thrust.targetThrottle = ThrottleToRaiseApoapsis(Orbit.ApR, AscentSettings.IntermediateAltitude + MainBody.Radius);
-            if (Core.Thrust.targetThrottle < 1.0F)
+            Core.Thrust.TargetThrottle = ThrottleToRaiseApoapsis(Orbit.ApR, AscentSettings.IntermediateAltitude + MainBody.Radius);
+            if (Core.Thrust.TargetThrottle < 1.0F)
             {
                 Status = Localizer.Format("#MechJeb_Ascent_status19"); //"Fine tuning intermediate altitude"
                 return;
@@ -192,14 +192,14 @@ namespace MuMech
 
             AttitudeTo(0); /* FIXME: corrective steering */
 
-            Core.Thrust.targetThrottle = FixedTimeToAp() < AscentSettings.HoldAPTime ? 1.0F : 0.1F;
+            Core.Thrust.TargetThrottle = FixedTimeToAp() < AscentSettings.HoldAPTime ? 1.0F : 0.1F;
 
             Status = Localizer.Format("#MechJeb_Ascent_status24"); //"Holding AP"
         }
 
         private void DriveCoastToApoapsis()
         {
-            Core.Thrust.targetThrottle = 0;
+            Core.Thrust.TargetThrottle = 0;
 
             if (VesselState.altitudeASL > MainBody.RealMaxAtmosphereAltitude())
             {
@@ -216,7 +216,7 @@ namespace MuMech
                 return;
             }
 
-            Core.Thrust.targetThrottle = 0;
+            Core.Thrust.TargetThrottle = 0;
 
             // follow surface velocity to reduce flipping
             AttitudeTo(SrfvelPitch());
@@ -224,7 +224,7 @@ namespace MuMech
             if (Orbit.ApA < AscentSettings.DesiredOrbitAltitude)
             {
                 Core.Warp.WarpPhysicsAtRate(1);
-                Core.Thrust.targetThrottle = ThrottleToRaiseApoapsis(Orbit.ApR, AscentSettings.DesiredOrbitAltitude + MainBody.Radius);
+                Core.Thrust.TargetThrottle = ThrottleToRaiseApoapsis(Orbit.ApR, AscentSettings.DesiredOrbitAltitude + MainBody.Radius);
             }
             else
             {

--- a/MechJeb2/MechJebModuleAscentSettings.cs
+++ b/MechJeb2/MechJebModuleAscentSettings.cs
@@ -353,29 +353,29 @@ namespace MuMech
             Core.Settings.rssMode = true;
 
             /* set the thrust controller to sane RO/RSS defaults */
-            Core.Thrust.limitToPreventUnstableIgnition = false;
-            Core.Thrust.autoRCSUllaging                = true;
-            Core.Thrust.minThrottle.val                = 0.05;
-            Core.Thrust.limiterMinThrottle             = true;
-            Core.Thrust.limitThrottle                  = false;
-            Core.Thrust.limitAcceleration              = false;
-            Core.Thrust.limitToPreventOverheats        = false;
-            Core.Thrust.limitDynamicPressure           = false;
-            Core.Thrust.maxDynamicPressure.val         = 20000;
+            Core.Thrust.LimitToPreventUnstableIgnition = false;
+            Core.Thrust.AutoRCSUllaging                = true;
+            Core.Thrust.MinThrottle.val                = 0.05;
+            Core.Thrust.LimiterMinThrottle             = true;
+            Core.Thrust.LimitThrottle                  = false;
+            Core.Thrust.LimitAcceleration              = false;
+            Core.Thrust.LimitToPreventOverheats        = false;
+            Core.Thrust.LimitDynamicPressure           = false;
+            Core.Thrust.MaxDynamicPressure.val         = 20000;
 
             /* reset all of the staging controller, and turn on hotstaging and drop solids */
             Autostage                                  = true;
-            Core.Staging.autostagePreDelay.val         = 0.0;
-            Core.Staging.autostagePostDelay.val        = 0.5;
-            Core.Staging.autostageLimit.val            = 0;
-            Core.Staging.fairingMaxDynamicPressure.val = 5000;
-            Core.Staging.fairingMinAltitude.val        = 50000;
-            Core.Staging.clampAutoStageThrustPct.val   = 0.99;
-            Core.Staging.fairingMaxAerothermalFlux.val = 1135;
-            Core.Staging.hotStaging                    = true;
-            Core.Staging.hotStagingLeadTime.val        = 1.0;
-            Core.Staging.dropSolids                    = true;
-            Core.Staging.dropSolidsLeadTime.val        = 1.0;
+            Core.Staging.AutostagePreDelay.val         = 0.0;
+            Core.Staging.AutostagePostDelay.val        = 0.5;
+            Core.Staging.AutostageLimit.val            = 0;
+            Core.Staging.FairingMaxDynamicPressure.val = 5000;
+            Core.Staging.FairingMinAltitude.val        = 50000;
+            Core.Staging.ClampAutoStageThrustPct.val   = 0.99;
+            Core.Staging.FairingMaxAerothermalFlux.val = 1135;
+            Core.Staging.HotStaging                    = true;
+            Core.Staging.HotStagingLeadTime.val        = 1.0;
+            Core.Staging.DropSolids                    = true;
+            Core.Staging.DropSolidsLeadTime.val        = 1.0;
         }
 
         private const double LAUNCH_LAN_DIFFERENCE            = 0;

--- a/MechJeb2/MechJebModuleAscentSettingsMenu.cs
+++ b/MechJeb2/MechJebModuleAscentSettingsMenu.cs
@@ -32,9 +32,9 @@ namespace MuMech
 
             if (_ascentSettings.AscentType == AscentType.PVG)
             {
-                Core.Thrust.limitThrottle           = false;
-                Core.Thrust.limitToTerminalVelocity = false;
-                Core.Thrust.electricThrottle        = false;
+                Core.Thrust.LimitThrottle           = false;
+                Core.Thrust.LimitToTerminalVelocity = false;
+                Core.Thrust.ElectricThrottle        = false;
             }
 
             _ascentSettings.ForceRoll = GUILayout.Toggle(_ascentSettings.ForceRoll, CachedLocalizer.Instance.MechJeb_Ascent_checkbox2); //Force Roll

--- a/MechJeb2/MechJebModuleAttitudeController.cs
+++ b/MechJeb2/MechJebModuleAttitudeController.cs
@@ -187,7 +187,7 @@ namespace MuMech
             Vector3d thrustForward = VesselState.thrustForward;
 
             // the off-axis thrust modifications get into a fight with the differential throttle so do not use them when diffthrottle is used
-            if (Core.Thrust.differentialThrottle)
+            if (Core.Thrust.DifferentialThrottle)
                 thrustForward = VesselState.forward;
 
             switch (reference)
@@ -331,8 +331,8 @@ namespace MuMech
                 return;
 
             torque = VesselState.torqueAvailable;
-            if (Core.Thrust.differentialThrottle &&
-                Core.Thrust.differentialThrottleSuccess == MechJebModuleThrustController.DifferentialThrottleStatus.Success)
+            if (Core.Thrust.DifferentialThrottle &&
+                Core.Thrust.DifferentialThrottleSuccess == MechJebModuleThrustController.DifferentialThrottleStatus.SUCCESS)
                 torque += VesselState.torqueDiffThrottle * Vessel.ctrlState.mainThrottle / 2.0;
 
             // Inertia is a bad name. It's the "angular distance to stop"
@@ -386,7 +386,7 @@ namespace MuMech
                     Part.vessel.Autopilot.SAS.SetTargetOrientation(RequestedAttitude * Vector3.up, true);
                 }
 
-                Core.Thrust.differentialThrottleDemandedTorque = Vector3d.zero;
+                Core.Thrust.DifferentialThrottleDemandedTorque = Vector3d.zero;
             }
             else
             {
@@ -401,8 +401,8 @@ namespace MuMech
                 act = new Vector3d(s.pitch, s.roll, s.yaw);
 
                 // Feed the control torque to the differential throttle
-                if (Core.Thrust.differentialThrottleSuccess == MechJebModuleThrustController.DifferentialThrottleStatus.Success)
-                    Core.Thrust.differentialThrottleDemandedTorque =
+                if (Core.Thrust.DifferentialThrottleSuccess == MechJebModuleThrustController.DifferentialThrottleStatus.SUCCESS)
+                    Core.Thrust.DifferentialThrottleDemandedTorque =
                         -Vector3d.Scale(act, VesselState.torqueDiffThrottle * Vessel.ctrlState.mainThrottle);
             }
         }
@@ -466,7 +466,7 @@ namespace MuMech
             {
                 timeCount = 0;
                 if (RCS_auto && (absErr.x > 3.0 || absErr.y > 3.0 || absErr.z > 3.0) &&
-                    Core.Thrust.limiter != MechJebModuleThrustController.LimitMode.UnstableIgnition)
+                    Core.Thrust.Limiter != MechJebModuleThrustController.LimitMode.UNSTABLE_IGNITION)
                     if (attitudeRCScontrol)
                         Part.vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
             }

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -396,7 +396,7 @@ namespace MuMech
 
         private void ThrottleOn()
         {
-            Core.Thrust.targetThrottle = 1.0F;
+            Core.Thrust.TargetThrottle = 1.0F;
         }
 
         private void RCSOn()

--- a/MechJeb2/MechJebModuleMenu.cs
+++ b/MechJeb2/MechJebModuleMenu.cs
@@ -371,7 +371,7 @@ namespace MuMech
                     {
                         MechJebModuleThrustWindow w = Core.GetComputerModule<MechJebModuleThrustWindow>();
 
-                        if (Core.Staging.Enabled && Core.Staging.autostagingOnce)
+                        if (Core.Staging.Enabled && Core.Staging.AutostagingOnce)
                         {
                             if (Core.Staging.Users.Contains(w))
                             {
@@ -383,7 +383,7 @@ namespace MuMech
                         {
                             Core.Staging.AutostageOnce(w);
                         }
-                    }, () => Core.Staging.Enabled && Core.Staging.autostagingOnce);
+                    }, () => Core.Staging.Enabled && Core.Staging.AutostagingOnce);
 
                     CreateFeatureButton(maneuverPlannerModule, "Auto_Warp", "MechJeb Auto-warp", b =>
                     {

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -130,7 +130,7 @@ namespace MuMech
 
         public override void Drive(FlightCtrlState s)
         {
-            if (!burnTriggered && nearingBurn && Core.Thrust.limitToPreventUnstableIgnition &&
+            if (!burnTriggered && nearingBurn && Core.Thrust.LimitToPreventUnstableIgnition &&
                 VesselState.lowestUllage != VesselState.UllageState.VeryStable)
             {
                 if (Vessel.hasEnabledRCSModules())
@@ -212,7 +212,7 @@ namespace MuMech
 
                 nearingBurn = timeToNode - spool - leadTime <= 0;
 
-                Core.Thrust.targetThrottle = 0;
+                Core.Thrust.TargetThrottle = 0;
 
                 if (burnTriggered)
                 {
@@ -312,7 +312,7 @@ namespace MuMech
 
                 nearingBurn = timeToNode - halfBurnTime - leadTime <= 0;
 
-                Core.Thrust.targetThrottle = 0;
+                Core.Thrust.TargetThrottle = 0;
 
                 if (burnTriggered)
                 {
@@ -364,9 +364,9 @@ namespace MuMech
                     {
                         // We staged again before autostagePreDelay is elapsed.
                         // Add the remaining wait time
-                        if (burnTime - lastStageBurnTime < Core.Staging.autostagePreDelay && mjPhase != stats.VacStats.Count - 1)
-                            burnTime += Core.Staging.autostagePreDelay - (burnTime - lastStageBurnTime);
-                        burnTime          += Core.Staging.autostagePreDelay;
+                        if (burnTime - lastStageBurnTime < Core.Staging.AutostagePreDelay && mjPhase != stats.VacStats.Count - 1)
+                            burnTime += Core.Staging.AutostagePreDelay - (burnTime - lastStageBurnTime);
+                        burnTime          += Core.Staging.AutostagePreDelay;
                         lastStageBurnTime =  burnTime;
                     }
 

--- a/MechJeb2/MechJebModuleThrustWindow.cs
+++ b/MechJeb2/MechJebModuleThrustWindow.cs
@@ -28,7 +28,7 @@ namespace MuMech
             if (Core.Staging.Enabled)
             {
                 GUILayout.Label(Localizer.Format("#MechJeb_Utilities_label1",
-                    Core.Staging.autostagingOnce
+                    Core.Staging.AutostagingOnce
                         ? Localizer.Format("#MechJeb_Utilities_label1_1")
                         : " ")); //"Autostaging"<<1>>"Active" -------<<1>>" once ":""
             }
@@ -69,15 +69,15 @@ namespace MuMech
                 Core.Thrust.AutoRCsUllageInfoItem();
             }
 
-            Core.Thrust.smoothThrottle =
-                GUILayout.Toggle(Core.Thrust.smoothThrottle, Localizer.Format("#MechJeb_Utilities_checkbox2")); //"Smooth throttle"
-            Core.Thrust.manageIntakes =
-                GUILayout.Toggle(Core.Thrust.manageIntakes, Localizer.Format("#MechJeb_Utilities_checkbox3")); //"Manage air intakes"
+            Core.Thrust.SmoothThrottle =
+                GUILayout.Toggle(Core.Thrust.SmoothThrottle, Localizer.Format("#MechJeb_Utilities_checkbox2")); //"Smooth throttle"
+            Core.Thrust.ManageIntakes =
+                GUILayout.Toggle(Core.Thrust.ManageIntakes, Localizer.Format("#MechJeb_Utilities_checkbox3")); //"Manage air intakes"
             GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));
             try
             {
                 GUILayout.Label(Localizer.Format("#MechJeb_Utilities_label2")); //"Jet safety margin"
-                Core.Thrust.flameoutSafetyPct.text = GUILayout.TextField(Core.Thrust.flameoutSafetyPct.text, 5);
+                Core.Thrust.FlameoutSafetyPct.text = GUILayout.TextField(Core.Thrust.FlameoutSafetyPct.text, 5);
                 GUILayout.Label("%");
             }
             finally
@@ -85,25 +85,25 @@ namespace MuMech
                 GUILayout.EndHorizontal();
             }
 
-            Core.Thrust.DifferentialThrottle();
+            Core.Thrust.DifferentialThrottleMenu();
 
-            if (Core.Thrust.differentialThrottle && Vessel.LiftedOff())
+            if (Core.Thrust.DifferentialThrottle && Vessel.LiftedOff())
             {
-                switch (Core.Thrust.differentialThrottleSuccess)
+                switch (Core.Thrust.DifferentialThrottleSuccess)
                 {
-                    case MechJebModuleThrustController.DifferentialThrottleStatus.MoreEnginesRequired:
+                    case MechJebModuleThrustController.DifferentialThrottleStatus.MORE_ENGINES_REQUIRED:
                         GUILayout.Label(Localizer.Format("#MechJeb_Utilities_label3"),
                             GuiUtils.yellowLabel); //"Differential throttle failed\nMore engines required"
                         break;
-                    case MechJebModuleThrustController.DifferentialThrottleStatus.AllEnginesOff:
+                    case MechJebModuleThrustController.DifferentialThrottleStatus.ALL_ENGINES_OFF:
                         GUILayout.Label(Localizer.Format("#MechJeb_Utilities_label4"),
                             GuiUtils.yellowLabel); //"Differential throttle failed\nNo active engine"
                         break;
-                    case MechJebModuleThrustController.DifferentialThrottleStatus.SolverFailed:
+                    case MechJebModuleThrustController.DifferentialThrottleStatus.SOLVER_FAILED:
                         GUILayout.Label(Localizer.Format("#MechJeb_Utilities_label5"),
                             GuiUtils.yellowLabel); //"Differential throttle failed\nCannot find solution"
                         break;
-                    case MechJebModuleThrustController.DifferentialThrottleStatus.Success:
+                    case MechJebModuleThrustController.DifferentialThrottleStatus.SUCCESS:
                         break;
                 }
             }
@@ -132,7 +132,7 @@ namespace MuMech
 
         public override bool isActive()
         {
-            return Core.Thrust.limiter != MechJebModuleThrustController.LimitMode.None;
+            return Core.Thrust.Limiter != MechJebModuleThrustController.LimitMode.NONE;
         }
 
         public override string GetName()

--- a/MechJeb2/MechJebModuleTranslatron.cs
+++ b/MechJeb2/MechJebModuleTranslatron.cs
@@ -90,7 +90,7 @@ namespace MuMech
                     autoMode  = false;
                 }
 
-                var newMode = (MechJebModuleThrustController.TMode)GUILayout.SelectionGrid((int)Core.Thrust.tmode, trans_texts, 2, buttonStyle);
+                var newMode = (MechJebModuleThrustController.TMode)GUILayout.SelectionGrid((int)Core.Thrust.Tmode, trans_texts, 2, buttonStyle);
                 SetMode(newMode);
 
                 float
@@ -98,7 +98,7 @@ namespace MuMech
                         ? 5
                         : 1; // change by 5 if the mod_key is held down, else by 1 -- would be better if it actually worked...
 
-                Core.Thrust.trans_kill_h = GUILayout.Toggle(Core.Thrust.trans_kill_h, Localizer.Format("#MechJeb_Trans_kill_h"),
+                Core.Thrust.TransKillH = GUILayout.Toggle(Core.Thrust.TransKillH, Localizer.Format("#MechJeb_Trans_kill_h"),
                     GUILayout.ExpandWidth(true));
                 GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));
                 GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_Trans_spd"), trans_spd, "", 37);
@@ -125,14 +125,14 @@ namespace MuMech
 
                 if (GUILayout.Button(Localizer.Format("#MechJeb_Trans_spd_act") + ":", buttonStyle, GUILayout.ExpandWidth(true)) || change)
                 {
-                    Core.Thrust.trans_spd_act  = (float)trans_spd.val;
+                    Core.Thrust.TransSpdAct    = (float)trans_spd.val;
                     GUIUtility.keyboardControl = 0;
                 }
             }
 
-            if (Core.Thrust.tmode != MechJebModuleThrustController.TMode.OFF)
+            if (Core.Thrust.Tmode != MechJebModuleThrustController.TMode.OFF)
             {
-                GUILayout.Label(Localizer.Format("#MechJeb_Trans_current_spd") + Core.Thrust.trans_spd_act.ToSI() + "m/s",
+                GUILayout.Label(Localizer.Format("#MechJeb_Trans_current_spd") + Core.Thrust.TransSpdAct.ToSI() + "m/s",
                     GUILayout.ExpandWidth(true));
             }
 
@@ -157,13 +157,13 @@ namespace MuMech
 
         public void SetMode(MechJebModuleThrustController.TMode newMode)
         {
-            MechJebModuleThrustController.TMode oldMode = Core.Thrust.tmode;
-            Core.Thrust.tmode = newMode;
-            if (Core.Thrust.tmode != oldMode)
+            MechJebModuleThrustController.TMode oldMode = Core.Thrust.Tmode;
+            Core.Thrust.Tmode = newMode;
+            if (Core.Thrust.Tmode != oldMode)
             {
-                Core.Thrust.trans_spd_act = Convert.ToInt16(trans_spd);
-                windowPos                 = new Rect(windowPos.x, windowPos.y, 10, 10);
-                if (Core.Thrust.tmode == MechJebModuleThrustController.TMode.OFF)
+                Core.Thrust.TransSpdAct = Convert.ToInt16(trans_spd);
+                windowPos               = new Rect(windowPos.x, windowPos.y, 10, 10);
+                if (Core.Thrust.Tmode == MechJebModuleThrustController.TMode.OFF)
                 {
                     Core.Thrust.Users.Remove(this);
                 }
@@ -240,12 +240,12 @@ namespace MuMech
         {
             // Fix the Translatron behavior which kill HS.
             // TODO : proper fix that register the attitude controler outside of Drive
-            if (!Core.Attitude.Users.Contains(this) && Core.Thrust.trans_kill_h && Core.Thrust.tmode != MechJebModuleThrustController.TMode.OFF)
+            if (!Core.Attitude.Users.Contains(this) && Core.Thrust.TransKillH && Core.Thrust.Tmode != MechJebModuleThrustController.TMode.OFF)
             {
                 Core.Attitude.Users.Add(this);
             }
 
-            if (Core.Attitude.Users.Contains(this) && (!Core.Thrust.trans_kill_h || Core.Thrust.tmode == MechJebModuleThrustController.TMode.OFF))
+            if (Core.Attitude.Users.Contains(this) && (!Core.Thrust.TransKillH || Core.Thrust.Tmode == MechJebModuleThrustController.TMode.OFF))
             {
                 Core.Attitude.Users.Remove(this);
             }
@@ -267,10 +267,10 @@ namespace MuMech
                     case AbortStage.BURNUP:
                         if (Planetarium.GetUniversalTime() - burnUpTime < 2 || VesselState.speedVertical < 10)
                         {
-                            Core.Thrust.tmode = MechJebModuleThrustController.TMode.DIRECT;
+                            Core.Thrust.Tmode = MechJebModuleThrustController.TMode.DIRECT;
                             Core.Attitude.attitudeTo(Vector3d.up, AttitudeReference.SURFACE_NORTH, this);
                             double int_error = Math.Abs(Vector3d.Angle(VesselState.up, VesselState.forward));
-                            Core.Thrust.trans_spd_act = int_error < 90 ? 100 : 0;
+                            Core.Thrust.TransSpdAct = int_error < 90 ? 100 : 0;
                         }
                         else
                         {


### PR DESCRIPTION
as per all the other cleanup PRs the renames are intentional code breaks, any changes in visibility can be reverted to public (just submit a PR to revert it and tag it with UsedImplicitly and maybe a comment on what uses it)