### PR TITLE
RCS Fuel Flow

### DIFF
--- a/MechJeb2/MechJebLib/Simulations/PartModules/SimModuleRCS.cs
+++ b/MechJeb2/MechJebLib/Simulations/PartModules/SimModuleRCS.cs
@@ -1,7 +1,10 @@
 ﻿#nullable enable
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using MechJebLib.Primitives;
 using MechJebLib.Utils;
+using static MechJebLib.Utils.Statics;
 
 namespace MechJebLib.Simulations.PartModules
 {
@@ -12,15 +15,20 @@ namespace MechJebLib.Simulations.PartModules
         public readonly         Dictionary<int, SimFlowMode> PropellantFlowModes  = new Dictionary<int, SimFlowMode>();
         public readonly         Dictionary<int, double>      ResourceConsumptions = new Dictionary<int, double>();
 
+        public readonly H1 AtmosphereCurve = H1.Get(true);
+
         public double G;
         public double Isp;
         public double Thrust;
         public bool   RcsEnabled;
+        public double ISPMult;
+        public double ThrustPercentage;
+        public double MaxFuelFlow;
+        public double MassFlowRate;
 
-        public override void Dispose()
-        {
-            _pool.Release(this);
-        }
+        private double _atmPressure => Part.Vessel.ATMPressure;
+
+        public override void Dispose() => _pool.Release(this);
 
         public static SimModuleRCS Borrow(SimPart part)
         {
@@ -29,21 +37,143 @@ namespace MechJebLib.Simulations.PartModules
             return clamp;
         }
 
-        private static SimModuleRCS New()
+        private static SimModuleRCS New() => new SimModuleRCS();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void UpdateRCSStatus()
         {
-            return new SimModuleRCS();
+            if (CanDrawResources())
+                return;
+
+            RcsEnabled = false;
+        }
+
+        // FIXME: aggressively duplicates ModuleEngines code and should be moved to SimPart
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool CanDrawResources()
+        {
+            foreach (int resourceId in ResourceConsumptions.Keys)
+                switch (PropellantFlowModes[resourceId])
+                {
+                    case SimFlowMode.NO_FLOW:
+                        if (!PartHasResource(Part, resourceId))
+                            return false;
+                        break;
+                    case SimFlowMode.ALL_VESSEL:
+                    case SimFlowMode.ALL_VESSEL_BALANCE:
+                    case SimFlowMode.STAGE_PRIORITY_FLOW:
+                    case SimFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
+                        if (!PartsHaveResource(Part.Vessel.Parts, resourceId))
+                            return false;
+                        break;
+                    case SimFlowMode.STAGE_STACK_FLOW:
+                    case SimFlowMode.STAGE_STACK_FLOW_BALANCE:
+                    case SimFlowMode.STACK_PRIORITY_SEARCH:
+                        if (!PartsHaveResource(Part.CrossFeedPartSet, resourceId))
+                            return false;
+                        break;
+                    case SimFlowMode.NULL:
+                        return false;
+                    default:
+                        return false;
+                }
+
+            return true;
+        }
+
+        // FIXME: aggressively duplicates ModuleEngines code and should be moved to SimPart
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool PartHasResource(SimPart part, int resourceId)
+        {
+            if (part.TryGetResource(resourceId, out SimResource resource))
+                return resource.Amount > part.ResidualThreshold(resourceId);
+            return false;
+        }
+
+        // FIXME: aggressively duplicates ModuleEngines code and should be moved to SimPart
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool PartsHaveResource(IReadOnlyList<SimPart> parts, int resourceId)
+        {
+            for (int i = 0; i < parts.Count; i++)
+                if (PartHasResource(parts[i], resourceId))
+                    return true;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Update()
+        {
+            Isp = AtmosphereCurve.Evaluate(_atmPressure);
+            double exhaustVel = Isp * G * ISPMult;
+            MassFlowRate = MaxFuelFlow * (ThrustPercentage * 0.01);
+            Thrust       = exhaustVel * MassFlowRate;
+            SetConsumptionRates();
         }
 
         public void Activate()
         {
-            if (StagingEnabled && ModuleIsEnabled)
-            {
-                RcsEnabled = true;
-            }
+            RcsEnabled = true;
         }
 
         private static void Clear(SimModuleRCS m)
         {
+            m.Propellants.Clear();
+            m.PropellantFlowModes.Clear();
+            m.ResourceConsumptions.Clear();
+            m.AtmosphereCurve.Clear();
+        }
+
+        // FIXME: direct copypasta from SimModuleEngines
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SetConsumptionRates()
+        {
+            ResourceConsumptions.Clear();
+            PropellantFlowModes.Clear();
+
+            double totalDensity = 0;
+
+            for (int j = 0; j < Propellants.Count; j++)
+            {
+                SimPropellant p = Propellants[j];
+                double density = p.density;
+
+                // skip zero density (eC, air intakes, etc) assuming those are available and infinite
+                if (density <= 0)
+                    continue;
+
+                PropellantFlowModes.TryAdd(p.id, p.FlowMode);
+
+                // ignoreForIsp fuels are not part of the total density
+                if (p.ignoreForIsp)
+                    continue;
+
+                totalDensity += p.ratio * density;
+            }
+
+            // this is also the volume flow rate of the non-ignoreForIsp fuels.  although this is a bit janky since the p.ratios in most
+            // stock engines sum up to 2, not 1 (1.1 + 0.9), so this is not per-liter but per-summed-ratios (the massflowrate you get out
+            // of the atmosphere curves (above) are also similarly adjusted by these ratios -- it is a bit of a horror show).
+            double volumeFlowRate = MassFlowRate / totalDensity;
+
+            for (int j = 0; j < Propellants.Count; j++)
+            {
+                SimPropellant p = Propellants[j];
+                double density = PartResourceLibrary.Instance.GetDefinition(p.id).density;
+
+                // this is the individual propellant volume rate.  we are including the ignoreForIsp fuels in this loop and this will
+                // correctly calculate the volume rates of all the propellants, in L/sec.  if you sum these it'll be larger than the
+                // volumeFlowRate by including both the ignoreForIsp fuels and if the ratios sum up to more than one.
+                double propVolumeRate = p.ratio * volumeFlowRate;
+
+                // skip zero density here as well
+                if (density <= 0)
+                    continue;
+
+                if (ResourceConsumptions.ContainsKey(p.id))
+                    ResourceConsumptions[p.id] += propVolumeRate;
+                else
+                    ResourceConsumptions.Add(p.id, propVolumeRate);
+            }
         }
     }
 }

--- a/MechJeb2/MechJebLib/Simulations/SimVesselBuilder.cs
+++ b/MechJeb2/MechJebLib/Simulations/SimVesselBuilder.cs
@@ -7,6 +7,7 @@ using KSP.UI.Screens;
 using MechJebLib.Simulations.PartModules;
 using MuMech;
 using UnityEngine;
+using static MechJebLib.Utils.Statics;
 
 namespace MechJebLib.Simulations
 {
@@ -70,6 +71,8 @@ namespace MechJebLib.Simulations
                     {
                         if (m is SimModuleEngines e)
                             _vessel.EnginesDroppedInStage[part.DecoupledInStage].Add(e);
+                        if (m is SimModuleRCS r)
+                            _vessel.RCSDroppedInStage[part.DecoupledInStage].Add(r);
                     }
                 }
             }
@@ -259,7 +262,12 @@ namespace MechJebLib.Simulations
             {
                 var rcs = SimModuleRCS.Borrow(part);
 
-                rcs.G = kspModuleRCS.G;
+                rcs.G                = kspModuleRCS.G;
+                rcs.ISPMult          = kspModuleRCS.ispMult;
+                rcs.ThrustPercentage = kspModuleRCS.thrustPercentage;
+                rcs.MaxFuelFlow      = kspModuleRCS.maxFuelFlow;
+
+                rcs.AtmosphereCurve.LoadH1(kspModuleRCS.atmosphereCurve);
 
                 rcs.Propellants.Clear();
 

--- a/MechJeb2/MechJebLib/Simulations/SimVesselUpdater.cs
+++ b/MechJeb2/MechJebLib/Simulations/SimVesselUpdater.cs
@@ -231,9 +231,10 @@ namespace MechJebLib.Simulations
                     return;
                 }
 
-                rcs.Isp        = kspModuleRCS.atmosphereCurve.Evaluate(0) * kspModuleRCS.ispMult;
-                rcs.Thrust     = kspModuleRCS.flowMult * kspModuleRCS.maxFuelFlow * rcs.Isp * rcs.G;
-                rcs.RcsEnabled = kspModuleRCS.rcsEnabled;
+                rcs.IsEnabled    = kspModuleRCS.isEnabled;
+                rcs.Isp          = kspModuleRCS.atmosphereCurve.Evaluate(0) * kspModuleRCS.ispMult;
+                rcs.Thrust       = kspModuleRCS.flowMult * kspModuleRCS.maxFuelFlow * rcs.Isp * rcs.G;
+                rcs.RcsEnabled   = kspModuleRCS.rcsEnabled;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This doesn't complete the RCS fuel flow simulation, but it gets to the point of correctly activating RCS modules and setting up resource drains.

It supports all the same features as engines, so if anyone added nonISP fuel to RCS or zero density resources, or different fuel 'modes' that it should all work correctly.

Now the question is the shape of the algorithm that uses it to actually drain the resources and compute deltaV values.