### PR TITLE
Zero residuals before doing RCS calcs

### DIFF
--- a/MechJeb2/MechJebLib/Simulations/FuelFlowSimulation.cs
+++ b/MechJeb2/MechJebLib/Simulations/FuelFlowSimulation.cs
@@ -36,6 +36,7 @@ namespace MechJebLib.Simulations
             while (vessel.CurrentStage >= 0) // FIXME: should stop mutating vessel.CurrentStage
             {
                 SimulateStage(vessel);
+                ClearResiduals(vessel);
                 ComputeRcsMaxValues(vessel);
                 FinishSegment(vessel);
                 vessel.Stage();
@@ -96,10 +97,11 @@ namespace MechJebLib.Simulations
             vessel.UpdateMass();
             vessel.UpdateEngineStats();
             vessel.UpdateActiveEngines();
-            UpdateResourceDrainsAndResiduals(vessel);
 
             GetNextSegment(vessel);
             ComputeRcsMinValues(vessel);
+
+            UpdateResourceDrainsAndResiduals(vessel);
             double currentThrust = vessel.ThrustMagnitude;
 
             for (int steps = MAXSTEPS; steps > 0; steps--)
@@ -113,6 +115,7 @@ namespace MechJebLib.Simulations
                 // prior > 0dV segment in the same kspStage we should add those together to reduce clutter.
                 if (Math.Abs(vessel.ThrustMagnitude - currentThrust) > 1e-12)
                 {
+                    ClearResiduals(vessel);
                     ComputeRcsMaxValues(vessel);
                     FinishSegment(vessel);
                     GetNextSegment(vessel);
@@ -232,6 +235,12 @@ namespace MechJebLib.Simulations
             _partsWithRCSDrains.Add(p);
             _partsWithRCSDrains2.Add(p);
             p.AddRCSDrain(resourceId, resourceConsumption);
+        }
+
+        private void ClearResiduals(SimVessel vessel)
+        {
+            foreach (SimPart part in _partsWithResourceDrains)
+                part.ClearResiduals();
         }
 
         private void UpdateResourceDrainsAndResiduals(SimVessel vessel)

--- a/MechJeb2/MechJebLib/Simulations/SimPart.cs
+++ b/MechJeb2/MechJebLib/Simulations/SimPart.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using MechJebLib.Utils;
+using static MechJebLib.Utils.Statics;
 
 namespace MechJebLib.Simulations
 {
@@ -129,6 +130,20 @@ namespace MechJebLib.Simulations
 
             resource.Residual     = Math.Max(resource.Residual, residual);
             Resources[resourceId] = resource;
+        }
+
+        public void ClearResiduals()
+        {
+            _resourceKeys.Clear();
+            foreach (int id in Resources.Keys)
+                _resourceKeys.Add(id);
+
+            foreach (int id in _resourceKeys)
+            {
+                SimResource resource = Resources[id];
+                resource.Residual = 0;
+                Resources[id] = resource;
+            }
         }
 
         public double ResidualThreshold(int resourceId) => Resources[resourceId].ResidualThreshold + ResourceRequestRemainingThreshold;

--- a/MechJeb2/MechJebLib/Simulations/SimResource.cs
+++ b/MechJeb2/MechJebLib/Simulations/SimResource.cs
@@ -26,14 +26,17 @@ namespace MechJebLib.Simulations
         public SimResource Drain(double resourceDrain)
         {
             _amount -= resourceDrain;
-            if (_amount < 0) _amount = 0;
+            if (_amount < 0)
+                _amount = 0;
+
             return this;
         }
 
         public SimResource RCSDrain(double rcsDrain)
         {
             _rcsAmount -= rcsDrain;
-            if (Amount < 0) _rcsAmount = _amount;
+            if (Amount < 0)
+                _rcsAmount = _amount;
 
             return this;
         }


### PR DESCRIPTION
ModuleRCS doesn't have residuals and this was causing infinite spinning.

Note that it makes me worried there's some sort of floating point round off error bug inherent to residuals, because it should have at least worked and gotten the wrong answer.