### PR TITLE
Change some RCS "display" logic

### DIFF
--- a/MechJeb2/MechJebLib/Simulations/FuelFlowSimulation.cs
+++ b/MechJeb2/MechJebLib/Simulations/FuelFlowSimulation.cs
@@ -394,14 +394,13 @@ namespace MechJebLib.Simulations
                 _currentSegment.MaxRcsDeltaV += rcsDeltaV;
                 if (_currentSegment.RcsStartTMR == 0)
                     _currentSegment.RcsStartTMR = rcsThrust / startMass;
-
-                _currentSegment.RcsMass      += startMass - endMass;
-                _currentSegment.RcsDeltaTime += deltaTime;
             }
             else
             {
                 _currentSegment.MinRcsDeltaV += rcsDeltaV;
                 _currentSegment.RcsEndTMR    =  _currentSegment.RcsThrust / endMass;
+                _currentSegment.RcsMass      += startMass - endMass;
+                _currentSegment.RcsDeltaTime += deltaTime;
             }
         }
 

--- a/MechJeb2/MechJebStageStatsHelper.cs
+++ b/MechJeb2/MechJebStageStatsHelper.cs
@@ -138,7 +138,7 @@ namespace MuMech
             for (int i = 0; i < stats.AtmoStats.Count; i++)
                 if (infoItems.showEmpty)
                     stages.Add(i);
-                else if (infoItems.showRcs && stats.AtmoStats[i].MaxRcsDeltaV > 0)
+                else if (infoItems.showRcs && stats.AtmoStats[i].MinRcsDeltaV > 0)
                     stages.Add(i);
                 else if (!infoItems.showRcs && stats.AtmoStats[i].DeltaV > 0)
                     stages.Add(i);


### PR DESCRIPTION
If you have a stage which has RCS and a thruster that both pull the same fuel (e.g. MMH+NTO) then the "RCS ∆v max value" which is really the value-after-all-the-normal-engine-fuel-tanks-are-drained will be zero because the thruster drained all the shared RCS fuel.

So use the "min" values for stuff like resources burned and deltatime and the showEmpty button should key off the min value instead of max.