### PR TITLE
slightly better behavior in residual threshold calcs

### DIFF
--- a/MechJeb2/MechJebLib/Simulations/FuelFlowSimulation.cs
+++ b/MechJeb2/MechJebLib/Simulations/FuelFlowSimulation.cs
@@ -207,7 +207,7 @@ namespace MechJebLib.Simulations
                 if (resource.Free)
                     continue;
 
-                if (resource.Amount <= p.Resources[resourceId].ResidualThreshold)
+                if (resource.Amount <= p.ResidualThreshold(resource.Id))
                     continue;
 
                 if (usePriority)
@@ -304,7 +304,7 @@ namespace MechJebLib.Simulations
                 if (resource.Free)
                     continue;
 
-                if (resource.Amount <= p.Resources[resourceId].ResidualThreshold)
+                if (resource.Amount <= p.ResidualThreshold(resource.Id))
                     continue;
 
                 if (usePriority)


### PR DESCRIPTION
when we're checking if we're done with a tank we always need to be using the part.ResidualThreshold() which includes the resourceRequestRemainingThreshold floating point slop factor.