### PR TITLE
Fix more residuals handling

### DIFF
--- a/MechJeb2/MechJebLib/Simulations/PartModules/SimModuleEngines.cs
+++ b/MechJeb2/MechJebLib/Simulations/PartModules/SimModuleEngines.cs
@@ -129,7 +129,7 @@ namespace MechJebLib.Simulations.PartModules
         private bool PartHasResource(SimPart part, int resourceId)
         {
             if (part.TryGetResource(resourceId, out SimResource resource))
-                return resource.Amount > part.ResidualThreshold(resourceId);
+                return resource.Amount > part.Resources[resourceId].MaxAmount * ModuleResiduals + part.ResourceRequestRemainingThreshold;
             return false;
         }
 

--- a/MechJeb2/MechJebLib/Simulations/PartModules/SimModuleRCS.cs
+++ b/MechJeb2/MechJebLib/Simulations/PartModules/SimModuleRCS.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using MechJebLib.Primitives;
 using MechJebLib.Utils;
+using static MechJebLib.Utils.Statics;
 
 namespace MechJebLib.Simulations.PartModules
 {
@@ -87,16 +88,16 @@ namespace MechJebLib.Simulations.PartModules
 
         // FIXME: aggressively duplicates ModuleEngines code and should be moved to SimPart
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool PartHasResource(SimPart part, int resourceId)
+        private static bool PartHasResource(SimPart part, int resourceId)
         {
             if (part.TryGetResource(resourceId, out SimResource resource))
-                return resource.Amount > part.ResidualThreshold(resourceId);
+                return resource.Amount > part.ResourceRequestRemainingThreshold;
             return false;
         }
 
         // FIXME: aggressively duplicates ModuleEngines code and should be moved to SimPart
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool PartsHaveResource(IReadOnlyList<SimPart> parts, int resourceId)
+        private static bool PartsHaveResource(IReadOnlyList<SimPart> parts, int resourceId)
         {
             for (int i = 0; i < parts.Count; i++)
                 if (PartHasResource(parts[i], resourceId))

--- a/MechJeb2/MechJebLib/Simulations/SimVessel.cs
+++ b/MechJeb2/MechJebLib/Simulations/SimVessel.cs
@@ -225,15 +225,13 @@ namespace MechJebLib.Simulations
         public override string ToString()
         {
             var sb = new StringBuilder();
-            for (int i = 0; i < Parts.Count; i++)
-                sb.Append(Parts[i]);
 
-
-            sb.Append("Parts: ");
-            foreach (SimPart part in PartsRemainingInStage[CurrentStage])
-                sb.Append($" {part.Name}");
-            sb.AppendLine();
-
+            for(int i = 0; i <= CurrentStage; i++)
+            {
+                foreach (SimPart part in PartsRemainingInStage[CurrentStage])
+                    sb.Append(part);
+                sb.AppendLine();
+            }
 
             return sb.ToString();
         }


### PR DESCRIPTION
Correctly resets residuals on every step and ModuleRCS drawing from an "empty" tank shared with a thruster will have some non-zero delta-V from the leftover residuals.