### PR TITLE
Fix DeltaV Stats and planes in RF

### DIFF
--- a/MechJeb2/MechJebLib/Simulations/PartModules/SimModuleEngines.cs
+++ b/MechJeb2/MechJebLib/Simulations/PartModules/SimModuleEngines.cs
@@ -59,6 +59,7 @@ namespace MechJebLib.Simulations.PartModules
         public double ModuleResiduals;
         public double ModuleSpoolupTime;
         public bool   NoPropellants;
+        public bool   isModuleEnginesRF;
 
         public readonly H1 ThrustCurve                 = H1.Get(true);
         public readonly H1 ThrottleIspCurve            = H1.Get(true);

--- a/MechJeb2/MechJebLib/Simulations/SimVesselBuilder.cs
+++ b/MechJeb2/MechJebLib/Simulations/SimVesselBuilder.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using KSP.UI;
@@ -251,9 +252,15 @@ namespace MechJebLib.Simulations
                 part.IsEngine         = true;
 
                 engine.ModuleSpoolupTime = 0;
+                engine.isModuleEnginesRF = false;
 
-                if (_rfSpoolUpTime != null && _rfSpoolUpTime.GetValue(kspEngine) is float floatVal)
-                    engine.ModuleSpoolupTime = floatVal;
+                if (ReflectionUtils.isAssemblyLoaded("RealFuels"))
+                {
+                    engine.isModuleEnginesRF = Type.GetType("RealFuels.ModuleEnginesRF, RealFuels") == engine.GetType();
+
+                    if(engine.isModuleEnginesRF && _rfSpoolUpTime!.GetValue(kspEngine) is float floatVal)
+                        engine.ModuleSpoolupTime = floatVal;
+                }
 
                 return engine;
             }

--- a/MechJeb2/MechJebLib/Simulations/SimVesselUpdater.cs
+++ b/MechJeb2/MechJebLib/Simulations/SimVesselUpdater.cs
@@ -171,7 +171,7 @@ namespace MechJebLib.Simulations
                 engine.NoPropellants    = kspEngine is { flameout: true, statusL2: "No propellants" };
                 engine.ModuleResiduals  = 0;
 
-                if (_rfPredictedMaximumResiduals != null && _rfPredictedMaximumResiduals.GetValue(kspEngine) is double doubleVal)
+                if (engine.isModuleEnginesRF && _rfPredictedMaximumResiduals!.GetValue(kspEngine) is double doubleVal)
                     engine.ModuleResiduals = doubleVal;
 
                 part.EngineResiduals = Math.Max(part.EngineResiduals, engine.ModuleResiduals);


### PR DESCRIPTION
When RF is loaded ModuleEngines can still be non-RF module engines so all the reflection needs to be conditional on checking we've got a valid ModuleEnginesRF.

Old code used to do this by handling exceptions, new code sets up a boolean to check the type dynamically.  On build we take the hit of doing expensive dynamic type reflection, but tick to tick in update we use the boolean.