### PR TITLE
Better PVG+StageStats integration

### DIFF
--- a/MechJeb2/MechJebLib/Simulations/SimVessel.cs
+++ b/MechJeb2/MechJebLib/Simulations/SimVessel.cs
@@ -34,6 +34,8 @@ namespace MechJebLib.Simulations
         public double ATMPressure;
         public double ATMDensity;
         public double MachNumber;
+        public double T;
+        public V3     R, V, U;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetConditions(double atmDensity, double atmPressure, double machNumber)
@@ -41,6 +43,15 @@ namespace MechJebLib.Simulations
             ATMDensity  = atmDensity;
             ATMPressure = atmPressure;
             MachNumber  = machNumber;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetInitial(double t, V3 r, V3 v, V3 u)
+        {
+            T = t;
+            R = r;
+            V = v;
+            U = u;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -228,7 +239,7 @@ namespace MechJebLib.Simulations
         {
             var sb = new StringBuilder();
 
-            for(int i = 0; i <= CurrentStage; i++)
+            for (int i = 0; i <= CurrentStage; i++)
             {
                 foreach (SimPart part in PartsRemainingInStage[CurrentStage])
                     sb.Append(part);

--- a/MechJeb2/MechJebLib/Simulations/SimVesselManager.cs
+++ b/MechJeb2/MechJebLib/Simulations/SimVesselManager.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using MechJebLib.Primitives;
 
 namespace MechJebLib.Simulations
 {
@@ -20,6 +21,11 @@ namespace MechJebLib.Simulations
         private readonly Dictionary<Part, SimPart>             _partMapping              = new Dictionary<Part, SimPart>();
         private readonly Dictionary<SimPart, Part>             _inversePartMapping       = new Dictionary<SimPart, Part>();
         private readonly Dictionary<SimPartModule, PartModule> _inversePartModuleMapping = new Dictionary<SimPartModule, PartModule>();
+
+        public double T => _vessel.T;
+        public V3     R => _vessel.R;
+        public V3     V => _vessel.V;
+        public V3     U => _vessel.U;
 
         public SimVesselManager()
         {
@@ -41,15 +47,12 @@ namespace MechJebLib.Simulations
             _builder.UpdateEngineSet();
         }
 
-        public void Update()
-        {
-            _updater.Update();
-        }
+        public void Update() => _updater.Update();
 
-        public void SetConditions(double atmDensity, double atmPressure, double machNumber)
-        {
+        public void SetConditions(double atmDensity, double atmPressure, double machNumber) =>
             _vessel.SetConditions(atmDensity, atmPressure, machNumber);
-        }
+
+        public void SetInitial(double t, V3 r, V3 v, V3 u) => _vessel.SetInitial(t, r, v, u);
 
         public void StartFuelFlowSimulationJob()
         {

--- a/MechJeb2/MechJebModulePVGGlueBall.cs
+++ b/MechJeb2/MechJebModulePVGGlueBall.cs
@@ -175,9 +175,8 @@ namespace MuMech
                 return;
 
             Ascent.AscentBuilder ascentBuilder = Ascent.Builder()
-                .Initial(VesselState.orbitalPosition.WorldToV3Rotated(), VesselState.orbitalVelocity.WorldToV3Rotated(),
-                    VesselState.forward.WorldToV3Rotated(),
-                    VesselState.time, MainBody.gravParameter, MainBody.Radius)
+                .Initial(Core.StageStats.VacR, Core.StageStats.VacV, Core.StageStats.VacU, Core.StageStats.VacT
+                    , MainBody.gravParameter, MainBody.Radius)
                 .SetTarget(peR, apR, attR, Deg2Rad(inclination), Deg2Rad(lan), fpa, attachAltFlag, lanflag)
                 .TerminalConditions(Maths.HmagFromApsides(MainBody.gravParameter, peR, apR));
 


### PR DESCRIPTION
Save off the initial conditions at the time that the stage stats simulation starts running.  Then when the results of that are fed into PVG, use those initial conditions so that the PVG simulation is consistent and not using stagestats results from one tick and initial conditions from another.

This should reduce visual 'flicker' in the predictions display at the very least.  It might increase accuracy.

It does allow the update cycle of stage stats to be tweaked for performance without really affecting PVG accuracy.  PVG producing results that are a few 100ms stale doesn't really matter since it produces the whole interpolated future trajectory.