### PR TITLE
Tweak DecouplingAnalyzer algorithm

### DIFF
--- a/MechJeb2/MechJebLib/Simulations/DecouplingAnalyzer.cs
+++ b/MechJeb2/MechJebLib/Simulations/DecouplingAnalyzer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using MechJebLib.Simulations.PartModules;
+using static MechJebLib.Utils.Statics;
 
 namespace MechJebLib.Simulations
 {
@@ -29,10 +30,9 @@ namespace MechJebLib.Simulations
         // BUG: Does this even do anything?  What part has a inverseStage of -1?
         // BUG: Even if we change this to p.InverseStage <= 0 below what happens with the last decoupler when
         //      it should detatch the payload and so the part decoupled from it should be the root, not the part itself?
-        private static SimPart FindRootPart(IReadOnlyList<SimPart> parts)
-        {
-            return parts[0];
-            /*
+        private static SimPart FindRootPart(IReadOnlyList<SimPart> parts) => parts[0];
+
+        /*
             SimPart? rootPart = null;
 
             for (int i = 0; i < parts.Count; i++)
@@ -49,8 +49,6 @@ namespace MechJebLib.Simulations
 
             return rootPart;
             */
-        }
-
         private static void CalculateDecoupledInStageRecursively(SimVessel v, SimPart p, SimPart? parent, int inheritedDecoupledInStage)
         {
             int childDecoupledInStage = CalculateDecoupledInStage(v, p, parent, inheritedDecoupledInStage);
@@ -70,16 +68,66 @@ namespace MechJebLib.Simulations
             if (p.DecoupledInStage != int.MinValue)
                 return p.DecoupledInStage;
 
-            for (int i = 0; i < p.Modules.Count; i++)
+            if (p.InverseStage >= parentDecoupledInStage)
             {
-                SimPartModule m = p.Modules[i];
-
-                switch (m)
+                for (int i = 0; i < p.Modules.Count; i++)
                 {
-                    case SimModuleDecouple decouple:
-                        if (decouple is { IsDecoupled: false, StagingEnabled: true } && p.StagingOn)
-                        {
-                            if (decouple.IsOmniDecoupler)
+                    SimPartModule m = p.Modules[i];
+
+                    switch (m)
+                    {
+                        case SimModuleDecouple decouple:
+                            if (decouple is { IsDecoupled: false, StagingEnabled: true } && p.StagingOn)
+                            {
+                                if (decouple.IsOmniDecoupler)
+                                {
+                                    // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
+                                    p.DecoupledInStage = p.InverseStage;
+                                    TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
+                                    return p.DecoupledInStage;
+                                }
+
+                                if (decouple.AttachedPart != null)
+                                {
+                                    if (decouple.AttachedPart == parent && decouple.Staged)
+                                    {
+                                        // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
+                                        p.DecoupledInStage = p.InverseStage;
+                                        TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
+                                        return p.DecoupledInStage;
+                                    }
+                                    // We are still attached to our traversalParent.  The part we decouple is dropped when we decouple.
+                                    // The part and other children are dropped with the traversalParent.
+                                    p.DecoupledInStage = parentDecoupledInStage;
+                                    TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
+                                    CalculateDecoupledInStageRecursively(v, decouple.AttachedPart, p, p.InverseStage);
+                                    return p.DecoupledInStage;
+                                }
+                            }
+
+                            break;
+                        case SimModuleDockingNode dockingNode:
+                            if (dockingNode.StagingEnabled && p.StagingOn)
+                                if (dockingNode.AttachedPart != null)
+                                {
+                                    if (dockingNode.AttachedPart == parent && dockingNode.Staged)
+                                    {
+                                        // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
+                                        p.DecoupledInStage = p.InverseStage;
+                                        TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
+                                        return p.DecoupledInStage;
+                                    }
+                                    // We are still attached to our traversalParent.  The part we decouple is dropped when we decouple.
+                                    // The part and other children are dropped with the traversalParent.
+                                    p.DecoupledInStage = parentDecoupledInStage;
+                                    TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
+                                    CalculateDecoupledInStageRecursively(v, dockingNode.AttachedPart, p, p.InverseStage);
+                                    return p.DecoupledInStage;
+                                }
+
+                            break;
+                        case SimProceduralFairingDecoupler procFairingDecoupler:
+                            if (procFairingDecoupler is { IsDecoupled: false, StagingEnabled: true } && p.StagingOn)
                             {
                                 // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
                                 p.DecoupledInStage = p.InverseStage;
@@ -87,63 +135,14 @@ namespace MechJebLib.Simulations
                                 return p.DecoupledInStage;
                             }
 
-                            if (decouple.AttachedPart != null)
-                            {
-                                if (decouple.AttachedPart == parent && decouple.Staged)
-                                {
-                                    // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
-                                    p.DecoupledInStage = p.InverseStage;
-                                    TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
-                                    return p.DecoupledInStage;
-                                }
-
-                                // We are still attached to our traversalParent.  The part we decouple is dropped when we decouple.
-                                // The part and other children are dropped with the traversalParent.
-                                p.DecoupledInStage = parentDecoupledInStage;
-                                TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
-                                CalculateDecoupledInStageRecursively(v, decouple.AttachedPart, p, p.InverseStage);
-                                return p.DecoupledInStage;
-                            }
-                        }
-
-                        break;
-                    case SimModuleDockingNode dockingNode:
-                        if (dockingNode.StagingEnabled && p.StagingOn)
-                            if (dockingNode.AttachedPart != null)
-                            {
-                                if (dockingNode.AttachedPart == parent && dockingNode.Staged)
-                                {
-                                    // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
-                                    p.DecoupledInStage = p.InverseStage;
-                                    TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
-                                    return p.DecoupledInStage;
-                                }
-
-                                // We are still attached to our traversalParent.  The part we decouple is dropped when we decouple.
-                                // The part and other children are dropped with the traversalParent.
-                                p.DecoupledInStage = parentDecoupledInStage;
-                                TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
-                                CalculateDecoupledInStageRecursively(v, dockingNode.AttachedPart, p, p.InverseStage);
-                                return p.DecoupledInStage;
-                            }
-
-                        break;
-                    case SimProceduralFairingDecoupler procFairingDecoupler:
-                        if (procFairingDecoupler is { IsDecoupled: false, StagingEnabled: true } && p.StagingOn)
-                        {
-                            // We are decoupling our traversalParent. The part and its children are not part of the ship when we decouple
-                            p.DecoupledInStage = p.InverseStage;
+                            break;
+                        case SimLaunchClamp _:
+                            p.DecoupledInStage = p.InverseStage > parentDecoupledInStage
+                                ? p.InverseStage
+                                : parentDecoupledInStage;
                             TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
                             return p.DecoupledInStage;
-                        }
-
-                        break;
-                    case SimLaunchClamp _:
-                        p.DecoupledInStage = p.InverseStage > parentDecoupledInStage
-                            ? p.InverseStage
-                            : parentDecoupledInStage;
-                        TrackPartDecoupledInStage(v, p, p.DecoupledInStage);
-                        return p.DecoupledInStage;
+                    }
                 }
             }
 

--- a/MechJeb2/MechJebLib/Simulations/FuelFlowSimulation.cs
+++ b/MechJeb2/MechJebLib/Simulations/FuelFlowSimulation.cs
@@ -264,18 +264,21 @@ namespace MechJebLib.Simulations
                             break;
                         case SimFlowMode.ALL_VESSEL:
                         case SimFlowMode.ALL_VESSEL_BALANCE:
-                            UpdateResourceDrainsAndResidualsInParts(vessel.PartsRemainingInStage[vessel.CurrentStage], e.ResourceConsumptions[resourceId],
+                            UpdateResourceDrainsAndResidualsInParts(vessel.PartsRemainingInStage[vessel.CurrentStage],
+                                e.ResourceConsumptions[resourceId],
                                 resourceId, false, e.ModuleResiduals);
                             break;
                         case SimFlowMode.STAGE_PRIORITY_FLOW:
                         case SimFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
-                            UpdateResourceDrainsAndResidualsInParts(vessel.PartsRemainingInStage[vessel.CurrentStage], e.ResourceConsumptions[resourceId],
+                            UpdateResourceDrainsAndResidualsInParts(vessel.PartsRemainingInStage[vessel.CurrentStage],
+                                e.ResourceConsumptions[resourceId],
                                 resourceId, true, e.ModuleResiduals);
                             break;
                         case SimFlowMode.STAGE_STACK_FLOW:
                         case SimFlowMode.STAGE_STACK_FLOW_BALANCE:
                         case SimFlowMode.STACK_PRIORITY_SEARCH:
-                            UpdateResourceDrainsAndResidualsInParts(e.Part.CrossFeedPartSet, e.ResourceConsumptions[resourceId], resourceId, true, e.ModuleResiduals);
+                            UpdateResourceDrainsAndResidualsInParts(e.Part.CrossFeedPartSet, e.ResourceConsumptions[resourceId], resourceId, true,
+                                e.ModuleResiduals);
                             break;
                         case SimFlowMode.NULL:
                             break;
@@ -287,7 +290,8 @@ namespace MechJebLib.Simulations
 
         private readonly List<SimPart> _sources = new List<SimPart>();
 
-        private void UpdateResourceDrainsAndResidualsInParts(IList<SimPart> parts, double resourceConsumption, int resourceId, bool usePriority, double residual)
+        private void UpdateResourceDrainsAndResidualsInParts(IList<SimPart> parts, double resourceConsumption, int resourceId, bool usePriority,
+            double residual)
         {
             int maxPriority = int.MinValue;
 
@@ -303,7 +307,7 @@ namespace MechJebLib.Simulations
                 if (resource.Free)
                     continue;
 
-                if (resource.Amount <= residual * resource.MaxAmount + p.ResourceRequestRemainingThreshold )
+                if (resource.Amount <= residual * resource.MaxAmount + p.ResourceRequestRemainingThreshold)
                     continue;
 
                 if (usePriority)

--- a/MechJeb2/MechJebLib/Simulations/SimVessel.cs
+++ b/MechJeb2/MechJebLib/Simulations/SimVessel.cs
@@ -241,9 +241,10 @@ namespace MechJebLib.Simulations
 
             for (int i = 0; i <= CurrentStage; i++)
             {
-                foreach (SimPart part in PartsRemainingInStage[CurrentStage])
+                sb.AppendLine($"stage {i}:");
+                foreach (SimPart part in PartsRemainingInStage[i])
                     sb.Append(part);
-                sb.AppendLine();
+                sb.AppendLine("------------------------");
             }
 
             return sb.ToString();

--- a/MechJeb2/MechJebModulePVGGlueBall.cs
+++ b/MechJeb2/MechJebModulePVGGlueBall.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using MechJebLib.Core;
 using MechJebLib.PVG;
 using MechJebLib.Simulations;
@@ -20,6 +21,7 @@ namespace MuMech
     ///     This class isolates a bunch of glue between MJ and the PVG optimizer that I don't
     ///     yet understand how to write correctly.
     /// </summary>
+    [UsedImplicitly]
     public class MechJebModulePVGGlueBall : ComputerModule
     {
         private double _blockOptimizerUntilTime;
@@ -229,8 +231,7 @@ namespace MuMech
                 bool unguided = IsUnguided(kspStage);
 
                 ascentBuilder.AddStageUsingFinalMass(fuelStats.StartMass * 1000, fuelStats.EndMass * 1000, fuelStats.Isp, fuelStats.DeltaTime,
-                    kspStage, mjPhase,
-                    optimizeTime, unguided);
+                    kspStage, mjPhase, optimizeTime, unguided);
             }
 
             ascentBuilder.FixedBurnTime(!optimizedStageFound); // FIXME: can ascentbuilder just figure this out?


### PR DESCRIPTION
As we walk through the vessel we should never decrease the decoupledInStage value to a lower value based on the inverseStage of the decoupler.

If that happens then what we've done is fire a decoupler that is already decoupled.  In that case the decoupler is rendered "sterile" and is treated like just another part.

This is a departure from old behavior, but is necessary to get some analysis to be correct, and to agree with the autostaging behavior of mechjeb (and to make PVG work correctly).