### PR TITLE
Behavioral changes to Node Executor

### DIFF
--- a/MechJeb2/MechJebModuleAttitudeController.cs
+++ b/MechJeb2/MechJebModuleAttitudeController.cs
@@ -183,7 +183,7 @@ namespace MuMech
             switch (reference)
             {
                 case AttitudeReference.INERTIAL_COT:
-                    rotRef = Quaternion.FromToRotation(thrustForward, VesselState.forward) * rotRef;
+                    rotRef = Quaternion.FromToRotation(thrustForward, VesselState.forward);
                     break;
                 case AttitudeReference.ORBIT:
                     rotRef = Quaternion.LookRotation(VesselState.orbitalVelocity.normalized, VesselState.up);

--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -160,26 +160,6 @@ namespace MuMech
                     GUILayout.Toggle(Core.Node.Autowarp, Localizer.Format("#MechJeb_Maneu_Autowarp"), GUILayout.ExpandWidth(true)); //"Auto-warp"
 
                 GUILayout.BeginVertical();
-                GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_Maneu_Tolerance"), GUILayout.ExpandWidth(false)); //"Tolerance:"
-                Core.Node.Tolerance.text = GUILayout.TextField(Core.Node.Tolerance.text, GUILayout.Width(35), GUILayout.ExpandWidth(false));
-                if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
-                {
-                    Core.Node.Tolerance.val += 0.1;
-                }
-
-                if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
-                {
-                    Core.Node.Tolerance.val -= Core.Node.Tolerance.val > 0.1 ? 0.1 : 0.0;
-                }
-
-                if (GUILayout.Button("R", GUILayout.ExpandWidth(false)))
-                {
-                    Core.Node.Tolerance.val = 0.1;
-                }
-
-                GUILayout.Label("m/s", GUILayout.ExpandWidth(false));
-                GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(Localizer.Format("#MechJeb_Maneu_Lead_time"), GUILayout.ExpandWidth(false)); //Lead time:

--- a/MechJeb2/MechJebModuleNodeEditor.cs
+++ b/MechJeb2/MechJebModuleNodeEditor.cs
@@ -283,9 +283,6 @@ namespace MuMech
                 GUILayout.BeginHorizontal();
                 Core.Node.Autowarp =
                     GUILayout.Toggle(Core.Node.Autowarp, Localizer.Format("#MechJeb_NodeEd_checkbox1"), GUILayout.ExpandWidth(true)); //"Auto-warp"
-                GUILayout.Label(Localizer.Format("#MechJeb_NodeEd_Label7"), GUILayout.ExpandWidth(false));                            //"Tolerance:"
-                Core.Node.Tolerance.text = GUILayout.TextField(Core.Node.Tolerance.text, GUILayout.Width(35), GUILayout.ExpandWidth(false));
-                GUILayout.Label("m/s", GUILayout.ExpandWidth(false));
                 GUILayout.EndHorizontal();
             }
 

--- a/MechJeb2/MechJebModuleRendezvousGuidance.cs
+++ b/MechJeb2/MechJebModuleRendezvousGuidance.cs
@@ -164,24 +164,6 @@ namespace MuMech
                 GUILayout.BeginHorizontal();
                 Core.Node.Autowarp =
                     GUILayout.Toggle(Core.Node.Autowarp, Localizer.Format("#MechJeb_RZplan_checkbox"), GUILayout.ExpandWidth(true)); //"Auto-warp"
-                GUILayout.Label(Localizer.Format("#MechJeb_RZplan_label9"), GUILayout.ExpandWidth(false));                           //"Tolerance:"
-                Core.Node.Tolerance.text = GUILayout.TextField(Core.Node.Tolerance.text, GUILayout.Width(35), GUILayout.ExpandWidth(false));
-                if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
-                {
-                    Core.Node.Tolerance.val += 0.1;
-                }
-
-                if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
-                {
-                    Core.Node.Tolerance.val -= Core.Node.Tolerance.val > 0.1 ? 0.1 : 0.0;
-                }
-
-                if (GUILayout.Button("R", GUILayout.ExpandWidth(false)))
-                {
-                    Core.Node.Tolerance.val = 0.1;
-                }
-
-                GUILayout.Label("m/s", GUILayout.ExpandWidth(false));
                 GUILayout.EndHorizontal();
             }
 

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -224,6 +224,7 @@ namespace MuMech
         public double thrustCurrent   => Vector3d.Dot(thrustVectorLastFrame, forward);
 
         // Forward direction of thrust (CoT-CoM).normalized
+        // FIXME: this is Vector3d.zero if throttle is zero!
         public Vector3d thrustForward;
 
         // Acceleration in the forward direction, for when dividing by mass is too complicated.
@@ -1657,6 +1658,7 @@ namespace MuMech
             public void AddNewEngine(ModuleEngines e, ModuleGimbal gimbal, List<EngineWrapper> enginesWrappers, ref Vector3d CoT, ref Vector3d DoT,
                 ref double CoTScalar)
             {
+                // FIXME: shouldn't we gather statistics on unignited engines???
                 if (!e.EngineIgnited || !e.isEnabled)
                 {
                     return;


### PR DESCRIPTION
The stock node executor no longer "hunts" for the last dribbling bit of the maneuver node and the "tolerance" setting has been eliminated.  There is a 1 second terminal guidance period where tracking is frozen and the burn terminates when the angle between the heading and the maneuver node is >= 90 degrees.

This also backs out the MANEUVER_COT and thrustForward stuff for asymmetric thrust vehicles.  This is because thrustForward isn't valid if the engines are off.  Don't know if VesselState needs fixing to fix thrustForward or if the node executor needs to switch modes based on thrust being on or not, but it feels like VesselState should be updated.

replaces #1771