### PR TITLE
Fix principia multi-node

### DIFF
--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -134,7 +134,7 @@ namespace MuMech
                         Core.Node.ExecuteOneNode(this);
                     }
 
-                    if (Vessel.patchedConicSolver.maneuverNodes.Count > 1)
+                    if (Vessel.patchedConicSolver.maneuverNodes.Count > 1 || VesselState.isLoadedPrincipia)
                     {
                         if (GUILayout.Button(Localizer.Format("#MechJeb_Maneu_button5"))) //Execute all nodes
                         {


### PR DESCRIPTION
The node executor now works with two maneuvers planned.

The button for multi-node shows up.

There's a bug that I don't know how to fix because there's at least one tick between the last maneuver node disappearing and the next maneuver node showing up.  So the multi-node executor sees no future nodes, so it quits.