### PR TITLE
Fix node executor ullage

### DIFF
--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -134,9 +134,7 @@ namespace MuMech
             if (State != States.LEAD || RCSOnly)
                 return;
 
-            s.Z = 0.0F;
-
-            if (!Core.Thrust.LimitToPreventUnstableIgnition || VesselState.lowestUllage == VesselState.UllageState.VeryStable)
+            if (!Core.Thrust.AutoRCSUllaging || VesselState.lowestUllage == VesselState.UllageState.VeryStable)
                 return;
 
             if (!Vessel.hasEnabledRCSModules())


### PR DESCRIPTION
should allow people to manually ullage and should now check for the proper boolean and actually do RCS ullage in the LEAD time state for you.