### PR TITLE
Tune RCS ullaging more

### DIFF
--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -119,11 +119,15 @@ namespace MuMech
         private        double   _ignitionUT;
         private static bool     _isLoadedPrincipia => VesselState.isLoadedPrincipia;
         private        bool     _hasNodes          => Vessel.patchedConicSolver.maneuverNodes.Count > 0;
+        private        double   _ullageUntil;
 
         public override void Drive(FlightCtrlState s) => DoRCS(s);
 
         private void DoRCS(FlightCtrlState s)
         {
+            // seconds to continue to apply RCS after ullage has settled to VeryStable
+            const double MIN_RCS_TIME = 0.25;
+
             if (State == States.BURN && RCSOnly)
             {
                 Vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
@@ -136,6 +140,12 @@ namespace MuMech
 
             if (!Core.Thrust.AutoRCSUllaging)
                 return;
+
+            if (VesselState.lowestUllage >= 1.0 && VesselState.time > _ullageUntil)
+                return;
+
+            if (VesselState.lowestUllage < 1.0)
+                _ullageUntil = VesselState.time + MIN_RCS_TIME;
 
             if (!Vessel.hasEnabledRCSModules())
                 return;


### PR DESCRIPTION
Back to having the node executor ullage only for 1/4 second past 100% so that it doesn't excessively waste RCS during the LEAD time.