### PR TITLE
Ascent optimizer algorithm changes

### DIFF
--- a/MechJeb2/Maneuver/TransferCalculator.cs
+++ b/MechJeb2/Maneuver/TransferCalculator.cs
@@ -372,16 +372,13 @@ namespace MuMech
             //
             alglib.minnlccreatef(VARS, x, DIFFSTEP, out alglib.minnlcstate state);
             alglib.minnlcsetstpmax(state, 1e-3);
-            double rho = 250.0;
             int outerits = 5;
-            alglib.minnlcsetalgoaul(state, rho, outerits);
+            alglib.minnlcsetalgoaul2(state, outerits);
             //alglib.minnlcsetalgoslp(state);
             //alglib.minnlcsetalgosqp(state);
             alglib.minnlcsetcond(state, EPSX, MAXITS);
 
             alglib.minnlcsetnlc(state, EQUALITYCONSTRAINTS, INEQUALITYCONSTRAINTS);
-
-            alglib.minnlcsetprecexactrobust(state, 0);
 
             alglib.minnlcoptimize(state, PeriapsisObjective, null, null);
             alglib.minnlcresults(state, out x, out alglib.minnlcreport rep);

--- a/MechJebLib/PVG/Phase.cs
+++ b/MechJebLib/PVG/Phase.cs
@@ -22,6 +22,7 @@ namespace MechJebLib.PVG
         public          double maxt;
         public          double mint;
         public          double ve;
+        public          double c => ve; // alias for normalized ve
         public readonly double a0;
         public          double tau;
         public          double mdot;
@@ -151,11 +152,11 @@ namespace MechJebLib.PVG
             return phase;
         }
 
-        public static Phase NewFixedCoast(double m0, double ct, int kspStage, int mjPhase) => new Phase(m0, 0, 0, m0, ct, kspStage, mjPhase);
+        public static Phase NewFixedCoast(double m0, double ct, int kspStage, int mjPhase) => new Phase(m0, 0, double.PositiveInfinity, m0, ct, kspStage, mjPhase);
 
         public static Phase NewOptimizedCoast(double m0, double mint, double maxt, int kspStage, int mjPhase)
         {
-            var phase = new Phase(m0, 0, 0, m0, mint, kspStage, mjPhase) { OptimizeTime = true, mint = mint, maxt = maxt };
+            var phase = new Phase(m0, 0, double.PositiveInfinity, m0, mint, kspStage, mjPhase) { OptimizeTime = true, mint = mint, maxt = maxt };
             return phase;
         }
 

--- a/MechJebLibTest/PVGTests/AscentTests/BuggyTests.cs
+++ b/MechJebLibTest/PVGTests/AscentTests/BuggyTests.cs
@@ -2,6 +2,7 @@
 using MechJebLib.Functions;
 using MechJebLib.Primitives;
 using MechJebLib.PVG;
+using MechJebLib.Utils;
 using Xunit;
 using Xunit.Abstractions;
 using static MechJebLib.Utils.Statics;
@@ -22,6 +23,7 @@ namespace MechJebLibTest.PVGTests.AscentTests
         [Fact]
         public void SubOrbitalThor()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
             var r0 = new V3(1470817.12150277, -5396417.72296515, 3050610.07863681);
             var v0 = new V3(393.513790634158, 107.250777770179, 0.00161788515083675);
             var u0 = new V3(0.23076841882078, -0.846631607518583, 0.47954249382019);
@@ -73,6 +75,7 @@ namespace MechJebLibTest.PVGTests.AscentTests
         [Fact]
         private void BuggyDelta4ExtremelyHeavy()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
             // this is a buggy rocket, not an actual delta4 heavy, but it is being used to test that
             // some of the worst possible targets still converge and to test the fallback from failure
             // with the analytic thrust integrals to doing numerical integration.
@@ -102,28 +105,12 @@ namespace MechJebLibTest.PVGTests.AscentTests
 
             pvg.Znorm.ShouldBeZero(1e-9);
             Assert.Equal(8, pvg.LmStatus);
-
-            // re-run fully integrated instead of the analytic bootstrap
-            Ascent ascent2 = Ascent.Builder()
-                .Initial(r0, v0, u0, t0, mu, rbody)
-                .SetTarget(6571000, 6571000, 6571000, 0.558505360638185, 0, 0.349065850398866, true, false)
-                .AddStageUsingFinalMass(731995.326793174 - decmass, 328918.196876464 - decmass, 408.091742854086, 159.080051443926, 4, 4)
-                .AddStageUsingFinalMass(268744.821741949 - decmass, 168530.570801559 - decmass, 408.091702159863, 118.652885602609, 2, 2)
-                .AddStageUsingFinalMass(40763.8839289468 - decmass, 13796.4420050909 - decmass, 465.500076480742, 1118.13132581707, 1, 1, true)
-                .FixedBurnTime(false)
-                .OldSolution(solution)
-                .Build();
-
-            ascent2.Run();
-
-            Optimizer pvg2 = ascent2.GetOptimizer() ?? throw new Exception("null optimzer");
-
-            using Solution solution2 = pvg2.GetSolution();
         }
 
         [Fact]
         private void BiggerEarlyRocketMaybe()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
             var r0 = new V3(-4230937.57027061, -3658393.88789034, 3050613.04457008);
             var v0 = new V3(266.772640873606, -308.526291373473, 0.00117499917444357);
             var u0 = new V3(-0.664193346276844, -0.574214958863673, 0.478669494390488);
@@ -147,22 +134,6 @@ namespace MechJebLibTest.PVGTests.AscentTests
 
             pvg.Znorm.ShouldBeZero(1e-9);
             Assert.Equal(8, pvg.LmStatus);
-
-            // re-run fully integrated instead of the analytic bootstrap
-            Ascent ascent2 = Ascent.Builder()
-                .Initial(r0, v0, u0, t0, mu, rbody)
-                .SetTarget(6621000, 6623000, 6621000, 0.558505360638185, 0, 0.349065850398866, false, false)
-                .AddStageUsingFinalMass(51814.6957082437, 12381.5182945184, 277.252333393375, 139.843831752395, 2, 2)
-                .AddStageUsingFinalMass(9232.92402212159, 887.216491554419, 252.019434034823, 529.378964006269, 1, 1, true)
-                .FixedBurnTime(false)
-                .OldSolution(solution)
-                .Build();
-
-            ascent2.Run();
-
-            Optimizer pvg2 = ascent2.GetOptimizer() ?? throw new Exception("null optimzer");
-
-            using Solution solution2 = pvg2.GetSolution();
         }
     }
 }

--- a/MechJebLibTest/PVGTests/AscentTests/TheStandardTests.cs
+++ b/MechJebLibTest/PVGTests/AscentTests/TheStandardTests.cs
@@ -2,17 +2,27 @@
 using MechJebLib.Functions;
 using MechJebLib.Primitives;
 using MechJebLib.PVG;
+using MechJebLib.Utils;
 using Xunit;
+using Xunit.Abstractions;
 using static MechJebLib.Utils.Statics;
 
 namespace MechJebLibTest.PVGTests.AscentTests
 {
     public class TheStandardTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public TheStandardTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         // This is fairly sensitive to initial bootstrapping and will often compute a negative coast instead of the optimal positive coast
         [Fact]
         public void OptimizedBoosterWithCoastElliptical()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
             var r0 = new V3(-521765.111703417, -5568874.59934707, 3050608.87783524);
             var v0 = new V3(406.088016257895, -38.0495807832894, 0.000701038889818476);
             var u0 = new V3(-0.0820737379089317, -0.874094973679233, 0.478771328926086);
@@ -54,57 +64,15 @@ namespace MechJebLibTest.PVGTests.AscentTests
             solution.R(t0).ShouldEqual(r0);
             solution.V(t0).ShouldEqual(v0);
             solution.M(t0).ShouldEqual(49119.7842689869);
-            solution.Vgo(t0).ShouldEqual(9595.3503336684062, 1e-7);
-            solution.Pv(t0).ShouldEqual(new V3(0.4907116486773232, -0.35249571092720933, 0.16642316543642413), 1e-7);
+            solution.Vgo(t0).ShouldEqual(9673.8952125677752, 1e-7);
+            solution.Pv(t0).normalized.ShouldEqual(new V3(0.76795016838086438, -0.57846262219206013, 0.27501551521775636), 1e-7);
 
             smaf.ShouldEqual(11463499.98898875, 1e-7);
             eccf.ShouldEqual(0.4280978753095433, 1e-7);
             incf.ShouldEqual(incT, 1e-7);
-            lanf.ShouldEqual(3.0481642123046941, 1e-7);
-            argpf.ShouldEqual(1.8684926416804641, 1e-7);
+            lanf.ShouldEqual(3.0481683004886317, 1e-7);
+            argpf.ShouldEqual(1.9887149934489514, 1e-7);
             tanof.ShouldEqual(0.091089077094440363, 1e-7);
-
-            // re-run fully integrated instead of the analytic bootstrap
-            Ascent ascent2 = Ascent.Builder()
-                .Initial(r0, v0, u0, t0, mu, rbody)
-                .SetTarget(PeR, ApR, PeR, incT, 0, 0, false, false)
-                .AddStageUsingFinalMass(49119.7842689869, 7114.2513992454, 288.000034332275, 170.308460385726, 3, 3)
-                .AddStageUsingFinalMass(2848.62586760223, 1363.71123994759, 270.15767003304, 116.391834883409, 1, 1, true)
-                .AddOptimizedCoast(678.290157913434, 0, 450, 1, 1)
-                .AddStageUsingFinalMass(678.290157913434, 177.582604389742, 230.039271734103, 53.0805126571005, 0, 0, false, true)
-                .OldSolution(solution)
-                .Build();
-
-            ascent2.Run();
-
-            Optimizer pvg2 = ascent2.GetOptimizer() ?? throw new Exception("null optimzer");
-
-            using Solution solution2 = pvg2.GetSolution();
-
-            solution.Tgo(solution2.T0, 0).ShouldBePositive();
-            solution.Tgo(solution2.T0, 1).ShouldBePositive();
-            solution.Tgo(solution2.T0, 2).ShouldBePositive();
-            solution.Tgo(solution2.T0, 3).ShouldBePositive();
-
-            pvg2.Znorm.ShouldBeZero(1e-9);
-
-            (V3 rf2, V3 vf2) = solution2.TerminalStateVectors();
-
-            (double smaf2, double eccf2, double incf2, double lanf2, double argpf2, double tanof2, _) =
-                Astro.KeplerianFromStateVectors(mu, rf2, vf2);
-
-            solution2.R(t0).ShouldEqual(r0);
-            solution2.V(t0).ShouldEqual(v0);
-            solution2.M(t0).ShouldEqual(49119.7842689869);
-            solution2.Vgo(t0).ShouldEqual(9677.8444697307314, 1e-7);
-            solution2.Pv(t0).ShouldEqual(new V3(0.4936213839655178, -0.37228178807752599, 0.17701920733179485), 1e-7);
-
-            smaf2.ShouldEqual(11463499.98898875, 1e-7);
-            eccf2.ShouldEqual(0.4280978753095433, 1e-7);
-            incf2.ShouldEqual(incT, 1e-7);
-            lanf2.ShouldEqual(3.0481648247809443, 1e-7);
-            argpf2.ShouldEqual(1.8659359635671597, 1e-7);
-            tanof2.ShouldEqual(0.091785663682881768, 1e-7);
         }
     }
 }

--- a/MechJebLibTest/PVGTests/AscentTests/Titan2Tests.cs
+++ b/MechJebLibTest/PVGTests/AscentTests/Titan2Tests.cs
@@ -28,6 +28,7 @@ namespace MechJebLibTest.PVGTests.AscentTests
         [Fact]
         public void FlightPathAngle4AllRocket()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
             var r0 = new V3(5593203.65707947, 0, 3050526.81522927);
             var v0 = new V3(0, 407.862893197274, 0);
             double t0 = 0;
@@ -61,15 +62,15 @@ namespace MechJebLibTest.PVGTests.AscentTests
 
             solution.Constant(0).ShouldBeZero(1e-7);
             solution.Constant(solution.Tmax).ShouldBeZero(1e-7);
-            solution.Vgo(0).ShouldEqual(9327.0948576056289, 1e-7);
-            solution.Pv(0).ShouldEqual(new V3(0.24913591286181805, 0.23909088173239779, 0.13587844086293846), 1e-7);
+            solution.Vgo(0).ShouldEqual(9369.7098971395462, 1e-7);
+            solution.Pv(0).normalized.ShouldEqual(new V3(0.68052484128120905, 0.6317658413531414, 0.37115746267392064), 1e-7);
 
             pvg.Znorm.ShouldBeZero(1e-9);
             smaf.ShouldEqual(8616511.1913318466, 1e-7);
             eccf.ShouldEqual(0.23913520746130185, 1e-7);
             incf.ShouldEqual(incT, 1e-7);
             lanf.ShouldEqual(Deg2Rad(270), 1e-7);
-            argpf.ShouldEqual(1.7637313812499942, 1e-7);
+            argpf.ShouldEqual(1.7643342507444935, 1e-7);
             ClampPi(tanof).ShouldBeZero(1e-7);
         }
 
@@ -77,6 +78,7 @@ namespace MechJebLibTest.PVGTests.AscentTests
         [Fact]
         public void Kepler3()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
             var r0 = new V3(5593203.65707947, 0, 3050526.81522927);
             var v0 = new V3(0, 407.862893197274, 0);
             double t0 = 0;
@@ -110,22 +112,23 @@ namespace MechJebLibTest.PVGTests.AscentTests
 
             solution.Constant(0).ShouldBeZero(1e-7);
             solution.Constant(solution.Tmax).ShouldBeZero(1e-7);
-            solution.Vgo(0).ShouldEqual(9291.2315891261242, 1e-7);
-            solution.Pv(0).ShouldEqual(new V3(0.25236763236272763, 0.24870860524790397, 0.13764101483910374), 1e-7);
+            solution.Vgo(0).ShouldEqual(9334.0379052112639, 1e-7);
+            solution.Pv(0).normalized.ShouldEqual(new V3(0.67311315112262493, 0.64198533000545521, 0.36711513431559445), 1e-7);
 
             pvg.Znorm.ShouldBeZero(1e-9);
             smaf.ShouldEqual(8616511.1913318466, 1e-7);
             eccf.ShouldEqual(0.23913520746130185, 1e-7);
             incf.ShouldEqual(incT, 1e-7);
             lanf.ShouldEqual(Deg2Rad(270), 1e-7);
-            argpf.ShouldEqual(1.6667949762852059, 1e-7);
-            ClampPi(tanof).ShouldEqual(0.090826664012324976, 1e-7);
+            argpf.ShouldEqual(1.6625138637074874, 1e-7);
+            ClampPi(tanof).ShouldEqual(0.095809701921327317, 1e-7);
         }
 
         // extreme 1010 x 1012 and still get free attachment
         [Fact]
         public void Kepler3ExtremeElliptical()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
             var r0 = new V3(5593203.65707947, 0, 3050526.81522927);
             var v0 = new V3(0, 407.862893197274, 0);
             double t0 = 0;
@@ -161,21 +164,21 @@ namespace MechJebLibTest.PVGTests.AscentTests
             solution.Constant(0).ShouldBeZero(1e-3);
             solution.Constant(solution.Tmax).ShouldBeZero(1e-3);
 
-            solution.Vgo(0).ShouldEqual(18968.729888080918, 1e-7);
-            solution.Pv(0).ShouldEqual(new V3(0.39420604314896607, 0.024122181832433174, 0.21558209101216347), 1e-7);
+            solution.Vgo(0).ShouldEqual(18968.70290317855, 1e-7);
+            solution.Pv(0).normalized.ShouldEqual(new V3(0.87665284452812542, 0.053626948091188488, 0.47812544443814259), 1e-7);
 
             double aprf = Astro.ApoapsisFromKeplerian(smaf, eccf);
             double perf = Astro.PeriapsisFromKeplerian(smaf, eccf);
 
-            perf.ShouldEqual(PeR, 1e-9);
-            aprf.ShouldEqual(ApR, 1e-9);
+            perf.ShouldEqual(PeR, 1e-8);
+            aprf.ShouldEqual(ApR, 1e-8);
 
             pvg.Znorm.ShouldBeZero(1e-5);
             smaf.ShouldEqual(7381999.9997271635, 1e-5);
-            eccf.ShouldEqual(0.00013546395462809413, 1e-5);
+            eccf.ShouldEqual(0.00013546395462809413, 1e-4);
             incf.ShouldEqual(incT, 1e-5);
             lanf.ShouldEqual(Deg2Rad(270), 1e-2);
-            argpf.ShouldEqual(1.5561731710314275, 1e-5);
+            argpf.ShouldEqual(1.6234662617637516, 1e-5);
             tanof.ShouldEqual(0.036325746839258599, 1e-5);
         }
 
@@ -183,6 +186,7 @@ namespace MechJebLibTest.PVGTests.AscentTests
         [Fact]
         public void Kepler3MoreExtremerElliptical()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
             var r0 = new V3(5593203.65707947, 0, 3050526.81522927);
             var v0 = new V3(0, 407.862893197274, 0);
             double t0 = 0;
@@ -273,8 +277,8 @@ namespace MechJebLibTest.PVGTests.AscentTests
 
             solution.Constant(0).ShouldBeZero(1e-4);
             solution.Constant(solution.Tmax).ShouldBeZero(1e-4);
-            solution.Vgo(0).ShouldEqual(8498.6702629355023, 1e-7);
-            solution.Pv(0).ShouldEqual(new V3(0.24008912999871768, 0.21525232653820714, 0.1309443327389036), 1e-7);
+            solution.Vgo(0).ShouldEqual(8518.1366714811684, 1e-7);
+            solution.Pv(0).normalized.ShouldEqual(new V3(0.69734975209707417, 0.6074944955387559, 0.38033374967291772), 1e-7);
 
             double aprf = Astro.ApoapsisFromKeplerian(smaf, eccf);
             double perf = Astro.PeriapsisFromKeplerian(smaf, eccf);


### PR DESCRIPTION
It now always returns a fully numerical solution and has some other tweaks

Some tests are busted, still working on the fallout

I think this fixes builds as well, think I tested the last PR against a old version of alglib