### PR TITLE
Multiple PVG fixes

### DIFF
--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -115,7 +115,7 @@ namespace MuMech
             bool hasRCS = Vessel.hasEnabledRCSModules() &&
                           VesselState.rcsThrustAvailable.Up > 0.1 * VesselState.rcsThrustAvailable.MaxMagnitude();
 
-            return hasRCS && Status != PVGStatus.TERMINAL_RCS;
+            return hasRCS && Status != PVGStatus.TERMINAL_RCS && Vessel.currentStage == _ascentSettings.LastStage;
         }
 
         private void HandleTerminal()
@@ -200,7 +200,18 @@ namespace MuMech
             Vector3d v1 = VesselState.orbitalVelocity + a0 * dt;
             Vector3d x1 = VesselState.orbitalPosition + VesselState.orbitalVelocity * dt + 0.5 * a0 * dt * dt;
 
+            bool shouldEndTerminal = false;
+
+            if (Status == PVGStatus.TERMINAL && VesselState.thrustCurrent == 0)
+            {
+                Debug.Log("[MechJebModuleGuidanceController] no thrust in TERMINAL state.");
+                shouldEndTerminal = true;
+            }
+
             if (Solution.TerminalGuidanceSatisfied(x1.WorldToV3Rotated(), v1.WorldToV3Rotated(), solutionIndex))
+                shouldEndTerminal = true;
+
+            if (shouldEndTerminal)
             {
                 if (WillDoRCSButNotYet())
                 {

--- a/MechJeb2/MechJebModulePVGGlueBall.cs
+++ b/MechJeb2/MechJebModulePVGGlueBall.cs
@@ -140,6 +140,10 @@ namespace MuMech
                     double dv = Core.StageStats.VacStats[mjPhase].DeltaV;
                     int kspStage = Core.StageStats.VacStats[mjPhase].KSPStage;
 
+                    // skip the current stage if we are doing a coast after it
+                    if (IsCurrentCoastAfterStage(kspStage))
+                        continue;
+
                     // skip the zero length stages
                     if (dv == 0)
                         continue;
@@ -241,6 +245,14 @@ namespace MuMech
             _task.Start();
 
             _blockOptimizerUntilTime = VesselState.time + 1;
+        }
+
+        private bool IsCurrentCoastAfterStage(int kspStage)
+        {
+            if (kspStage == Vessel.currentStage && Core.Guidance.IsCoasting() && !_ascentSettings.CoastBeforeFlag)
+                return true;
+
+            return false;
         }
     }
 }

--- a/MechJebLib/PVG/ResidualLayout.cs
+++ b/MechJebLib/PVG/ResidualLayout.cs
@@ -10,7 +10,7 @@ namespace MechJebLib.PVG
 {
     public class ResidualLayout
     {
-        public const int RESIDUAL_LAYOUT_LEN = 15;
+        public const int RESIDUAL_LAYOUT_LEN = 14;
 
         public  V3     R;
         public  V3     V;
@@ -18,7 +18,6 @@ namespace MechJebLib.PVG
         private V3     _terminal1;
         public  double M;
         public  double Bt;
-        public  double Pm;
 
         public (double a, double b, double c, double d, double e, double f) Terminal
         {
@@ -44,8 +43,7 @@ namespace MechJebLib.PVG
             other[10] = _terminal1[0];
             other[11] = _terminal1[1];
             other[12] = _terminal1[2];
-            other[13] = Pm;
-            other[14] = Bt;
+            other[13] = Bt;
         }
 
         public void CopyFrom(IList<double> other)
@@ -55,8 +53,7 @@ namespace MechJebLib.PVG
             M          = other[6];
             _terminal0 = new V3(other[7], other[8], other[9]);
             _terminal1 = new V3(other[10], other[11], other[12]);
-            Pm         = other[13];
-            Bt         = other[14];
+            Bt         = other[13];
         }
 
         public static ResidualLayout CreateFrom(IList<double> other)


### PR DESCRIPTION
1. don't do TERMINAL_RCS in anything other than the last stage
2. end the TERMINAL state if there's no thrust
3. skip the current stage in the stage dV iterations in the glueball if it is coasting and is coast after (not coast before).

plus a bit of mass costate removal