### PR TITLE
Move StagingController check for dead engine into MJLibBindings

### DIFF
--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using KSP.UI.Screens;
 using MechJebLib.FuelFlowSimulation;
+using MechJebLibBindings;
 using Smooth.Slinq;
 using UnityEngine;
 

--- a/MechJeb2/PartExtensions.cs
+++ b/MechJeb2/PartExtensions.cs
@@ -67,33 +67,6 @@ namespace MuMech
             return false;
         }
 
-        public static bool UnrestartableDeadEngine(this Part p)
-        {
-            if (!VesselState.isLoadedRealFuels) // stock doesn't have this concept
-                return false;
-
-            ModuleEngines eng = p.FindModuleImplementing<ModuleEngines>();
-
-            if (eng is null) // this case probably doesn't make any sense
-                return false;
-
-            if (eng.finalThrust > 0)
-                return false;
-
-            try
-            {
-                if (VesselState.RFignitedField.GetValue(eng) is bool ignited && ignited)
-                    return false;
-                if (VesselState.RFignitionsField.GetValue(eng) is int ignitions)
-                    return ignitions == 0;
-            }
-            catch (ArgumentException)
-            {
-            }
-
-            return false;
-        }
-
         public static double FlowRateAtConditions(this ModuleEngines e, double throttle, double flowMultiplier)
         {
             float minFuelFlow = e.minFuelFlow;

--- a/MechJebLibBindings/FuelFlowSimulation/SimVesselUpdater.cs
+++ b/MechJebLibBindings/FuelFlowSimulation/SimVesselUpdater.cs
@@ -161,6 +161,8 @@ namespace MechJebLibBindings.FuelFlowSimulation
                     return;
                 }
 
+                // we need to check for launch clamps since non-airlightable engines have zero restarts but magically start
+                // when the vessel has a launch clamp
                 engine.UnrestartableDeadEngine = kspEngine.UnrestartableDeadEngine() && !_vessel.HasLaunchClamp;
                 engine.IsEnabled               = kspEngine.isEnabled;
                 engine.IsOperational           = kspEngine.isOperational;


### PR DESCRIPTION
this should make it more accurate since it'll now support the infinite propellant cheat and it checks all the module engines, not just the first one, plus it just cleans the code up.