### PR TITLE
Update VesselState.cs

### DIFF
--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -1384,7 +1384,8 @@ namespace MuMech
             public readonly Vector6 torqueDiffThrottle = new Vector6();
 
             // lowestUllage is always VeryStable without RealFuels installed
-            public double lowestUllage;
+            // Don't wait for Update, set it now so we don't invite a race condition.
+            public double lowestUllage = 1.0;
 
             public struct FuelRequirement
             {


### PR DESCRIPTION
There's a bug reported #1860  where RCS keeps turning on when unwanted for non-Real Fuels users and requires turning off AutoRCSUllaging. This may be enough to fix it but this could use other sanity checks elsewhere. Also, RCS ullaging should either

* Check for Core.Attitude.RCS_auto = true or else don't enable RCS!
* Put in code to turn RCS back off when ullaging is completed.