### PR TITLE
Fix "phase angle from mark" and  "phase angle to target"

### DIFF
--- a/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
@@ -246,7 +246,7 @@ namespace MuMech
                 if (Vessel.patchedConicSolver.maneuverNodes.Count == 0)
                 {
                     MechJebModuleFlightRecorder recorder = Core.GetComputerModule<MechJebModuleFlightRecorder>();
-                    if (recorder != null) AscentSettings.LaunchPhaseAngle.Val    = recorder.PhaseAngleFromMark;
+                    if (recorder != null) AscentSettings.LaunchPhaseAngle.Val    = recorder.PhaseAngleFromMark();
                     if (recorder != null) AscentSettings.LaunchLANDifference.Val = VesselState.orbitLAN - recorder.MarkLAN;
 
                     //finished circularize

--- a/MechJeb2/MechJebModuleInfoItems.cs
+++ b/MechJeb2/MechJebModuleInfoItems.cs
@@ -692,7 +692,8 @@ namespace MuMech
             if (Core.Target.TargetOrbit.referenceBody != Orbit.referenceBody) return "N/A";
             if (double.IsNaN(Core.Target.TargetOrbit.semiMajorAxis)) { return "N/A"; }
 
-            return Orbit.PhaseAngle(Core.Target.TargetOrbit, VesselState.time).ToString("F2") + "º";
+            double phaseAngle = 360 - Core.Target.TargetOrbit.PhaseAngle(Orbit, VesselState.time);
+            return phaseAngle.ToString("F2") + "º";
         }
 
         [ValueInfoItem("#MechJeb_TargetPlanetPhaseAngle", InfoItem.Category.Target)] //Target planet phase angle


### PR DESCRIPTION
### Background information
The "phase angle from mark" and "phase angle to target" can be  used when trying to directly launch to rendez-vous with a target that is already in orbit. You write down the "phase angle from mark" after a test launch, revert to launch, and then launch again when the "phase angle to target" is 360° - the saved "phase angle from mark". This will make sure that, when you reach orbit, you are immediately close to the target vessel.

Launching directly to a rendez-vous using this phase angle information, requires that the ascent autopilot can launch into the plane of the target while starting outside the plane (i.e. perform a dog-leg on the way to orbit). PVG can do this (for small offsets) with the "override warp to plane" button; I don't know whether any of the other ascent guidance modes support this.

The other case where the "phase angle to target" can be used, is when performing a co-planar rendez-vous. You want to start your Hohmann transfer when the phase difference reaches a specific value, which depends on the orbital altitudes.

### Phase angle from mark
The previous calculation only worked when the target is in an equatorial orbit and the mark is placed exactly on the equator. The updated version calculates the phase angle correctly even when either of those conditions is not met.

### Phase angle to target
In the case where the target is in an inclined orbit, you need the "phase angle to target" in the target's plane (which will be the active vessel's plane after launch); the phase angle in the vessel's "orbit" when on the launch pad is not useful.

### Backwards compatibility
On the ground, away from the equator and/or with the target in an inclined orbit, the target plane phase angle is strictly more useful.

When on the ground on the equator, and with the target in an equatorial orbit, both phase angles are the same. This is the most common case pre-launch in the stock solar system.

Between two co-planar orbits, both values are the same. 

Between two orbits that are _not_ co-planar, the values will be different. Neither value is more useful than the other, it's just a matter of convention in which plane you measure the angle. I can't think of any case where the difference matters.