### PR TITLE
Fix ToSI for floats

### DIFF
--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -180,7 +180,7 @@ namespace MuMech
                 }
             }
 
-            _stats = $"{Count} waypoints over {distance.ToSI(-1)}m";
+            _stats = $"{Count} waypoints over {distance.ToSI()}m";
         }
 
         public MechJebWaypointRoute(string name = "", CelestialBody body = null, string mode = "Rover")

--- a/MechJebLib/Utils/Statics.cs
+++ b/MechJebLib/Utils/Statics.cs
@@ -518,7 +518,7 @@ namespace MechJebLib.Utils
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ToSI(this float f, int maxPrecision = -99, int sigFigs = 4) => ((double)f).ToSI(maxPrecision, sigFigs);
+        public static string ToSI(this float f, int sigFigs = 4, int maxPrecision = int.MaxValue) => ((double)f).ToSI(sigFigs, maxPrecision);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Print(string message) => Logger.Print(message);


### PR DESCRIPTION
Fix `float.ToSI` to match the changes to `double.ToSI` in 02fab0d671985f54d3a22d769affa904db3294b6

The float version is only used at
https://github.com/MuMech/MechJeb2/blob/6150a7869e634d8307343fc32c0a1e10ebf21c2e/MechJeb2/MechJebModuleInfoItems.cs#L436
https://github.com/MuMech/MechJeb2/blob/6150a7869e634d8307343fc32c0a1e10ebf21c2e/MechJeb2/MechJebModuleTranslatron.cs#L125
https://github.com/MuMech/MechJeb2/blob/6150a7869e634d8307343fc32c0a1e10ebf21c2e/MechJeb2/MechJebModuleWaypointWindow.cs#L183

All three are relatively obscure, which is probably why it hasn't been noticed before.