### PR TITLE
Add MultFlow to FuelFlowSimulation

### DIFF
--- a/MechJebLib/FuelFlowSimulation/PartModules/SimModuleEngines.cs
+++ b/MechJebLib/FuelFlowSimulation/PartModules/SimModuleEngines.cs
@@ -36,6 +36,7 @@ namespace MechJebLib.FuelFlowSimulation.PartModules
 
         public bool   IsOperational;
         public double FlowMultiplier;
+        public double MultFlow;
         public V3     ThrustCurrent;
         public V3     ThrustMax;
         public V3     ThrustMin;
@@ -246,12 +247,12 @@ namespace MechJebLib.FuelFlowSimulation.PartModules
 
             double thrustLimiter = ThrottleLimiter / 100f;
 
-            double maxThrust = MaxFuelFlow * FlowMultiplier * ISP * G * MultIsp;
-            double minThrust = MinFuelFlow * FlowMultiplier * ISP * G * MultIsp;
+            double maxThrust = MaxFuelFlow * FlowMultiplier * ISP * G * MultIsp * MultFlow;
+            double minThrust = MinFuelFlow * FlowMultiplier * ISP * G * MultIsp * MultFlow;
 
             double eMaxThrust = minThrust + (maxThrust - minThrust) * thrustLimiter;
             double eMinThrust = ThrottleLocked ? eMaxThrust : minThrust;
-            double eCurrentThrust = MassFlowRate * ISP * G * MultIsp;
+            double eCurrentThrust = MassFlowRate * ISP * G * MultIsp * MultFlow;
 
             for (int i = 0; i < ThrustDirectionVectors.Count; i++)
             {

--- a/MechJebLibBindings/FuelFlowSimulation/SimVesselBuilder.cs
+++ b/MechJebLibBindings/FuelFlowSimulation/SimVesselBuilder.cs
@@ -214,7 +214,6 @@ namespace MechJebLibBindings.FuelFlowSimulation
                 engine.ThrottleLocked       = kspEngine.throttleLocked;
                 engine.MaxFuelFlow          = kspEngine.maxFuelFlow;
                 engine.MinFuelFlow          = kspEngine.minFuelFlow;
-                engine.FlowMultiplier       = kspEngine.flowMultiplier;
                 engine.G                    = kspEngine.g;
                 engine.MaxThrust            = kspEngine.maxThrust;
                 engine.MinThrust            = kspEngine.minThrust;

--- a/MechJebLibBindings/FuelFlowSimulation/SimVesselUpdater.cs
+++ b/MechJebLibBindings/FuelFlowSimulation/SimVesselUpdater.cs
@@ -168,6 +168,8 @@ namespace MechJebLibBindings.FuelFlowSimulation
                 engine.IsOperational             = kspEngine.isOperational;
                 engine.ThrottleLimiter           = kspEngine.thrustPercentage;
                 engine.MultIsp                   = kspEngine.multIsp;
+                engine.FlowMultiplier            = kspEngine.flowMultiplier;
+                engine.MultFlow                  = kspEngine.multFlow;
                 engine.NoPropellants             = kspEngine is { flameout: true, statusL2: "No propellants" };
                 engine.ModuleResiduals           = 0;
 


### PR DESCRIPTION
Also moves MultFlow and FlowMultiplier to the Updater instead of the Builder so it gets updated on every tick.

May or may not fix TF loss of thrust failures from not showing up in the DV display.