### PR TITLE
Only check for ullage on ModuleEnginesRF

### DIFF
--- a/MechJeb2/PartExtensions.cs
+++ b/MechJeb2/PartExtensions.cs
@@ -49,6 +49,8 @@ namespace MuMech
 
             try
             {
+                if (!VesselState.RFModuleEnginesRFType.IsInstanceOfType(eng))
+                    return false;
                 if (VesselState.RFignitedField.GetValue(eng) is bool ignited && ignited)
                     return false;
                 if (VesselState.RFignitionsField.GetValue(eng) is int ignitions && ignitions == 0)

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -16,6 +16,9 @@ namespace MuMech
 
         public static bool isLoadedRealFuels;
 
+        // RealFuels.ModuleEngineRF class
+        public static Type RFModuleEnginesRFType;
+
         // RealFuels.ModuleEngineRF ullageSet field to call via reflection
         public static FieldInfo RFullageSetField;
 
@@ -365,6 +368,13 @@ namespace MuMech
             if (isLoadedRealFuels)
             {
                 Debug.Log("MechJeb: RealFuels Assembly is loaded");
+                RFModuleEnginesRFType = ReflectionUtils.GetClassByReflection("RealFuels", "RealFuels.ModuleEnginesRF");
+                if (RFModuleEnginesRFType == null)
+                {
+                    Debug.LogWarning("MechJeb BUG: RealFuels loaded, but RealFuels ModuleEnginesRF was not found, disabling RF");
+                    isLoadedRealFuels = false;
+                }
+
                 RFullageSetField = ReflectionUtils.GetFieldByReflection("RealFuels", "RealFuels.ModuleEnginesRF", "ullageSet");
                 if (RFullageSetField == null)
                 {
@@ -1425,6 +1435,11 @@ namespace MuMech
                 // we report stable ullage for an unstable engine which is throttled up, so we let RF kill it
                 // instead of having MJ throttle it down.
                 if (e.getFlameoutState || !e.EngineIgnited || !e.isEnabled || e.requestedThrottle > 0.0F)
+                {
+                    return;
+                }
+
+                if (!RFModuleEnginesRFType.IsInstanceOfType(e))
                 {
                     return;
                 }

--- a/MechJebLibBindings/ReflectionUtils.cs
+++ b/MechJebLibBindings/ReflectionUtils.cs
@@ -114,5 +114,34 @@ namespace MechJebLibBindings
 
             return type.GetMethod(methodName, flags, null, args, null);
         }
+
+        public static Type? GetClassByReflection(string assemblyString, string className)
+        {
+            string assemblyName = "";
+
+            foreach (AssemblyLoader.LoadedAssembly loaded in AssemblyLoader.loadedAssemblies)
+            {
+                if (loaded.assembly.GetName().Name == assemblyString)
+                {
+                    assemblyName = loaded.assembly.FullName;
+                }
+            }
+
+            if (assemblyName == "")
+            {
+                Debug.Log("[MechJeb] ReflectionUtils: could not find assembly " + assemblyString);
+                return null;
+            }
+
+            var type = Type.GetType(className + ", " + assemblyName);
+
+            if (type == null)
+            {
+                Debug.Log("[MechJeb] ReflectionUtils: could not find type  " + className + ", " + assemblyName);
+                return null;
+            }
+
+            return type;
+        }
     }
 }


### PR DESCRIPTION
When trying to check for ullage on a non-ModuleEnginesRF engine, VesselState sets the reflection fields to null; this causes the autostaging code to spam NREs and refuse to work.

This change makes sure that an engine is a (subclass of) ModuleEnginesRF before trying to access the ullage field.

Fixes #1921 