### PR TITLE
RCS fuel flow fixes and missing last stage in the VAB

### DIFF
--- a/MechJebLib/FuelFlowSimulation/DecouplingAnalyzer.cs
+++ b/MechJebLib/FuelFlowSimulation/DecouplingAnalyzer.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using MechJebLib.FuelFlowSimulation.PartModules;
+using static MechJebLib.Utils.Statics;
 
 namespace MechJebLib.FuelFlowSimulation
 {
@@ -168,6 +169,10 @@ namespace MechJebLib.FuelFlowSimulation
 
         private static void TrackPartDecoupledInStage(SimVessel v, SimPart part, int stage)
         {
+            // in the VAB the CurrentStage often is 1 too low, this hack fixes that.
+            if (stage + 1 > v.CurrentStage)
+                v.SetCurrentStage(stage + 1);
+
             for (int i = stage + 1; i <= v.CurrentStage; i++)
                 v.PartsRemainingInStage[i].Add(part);
         }

--- a/MechJebLib/FuelFlowSimulation/PartModules/SimModuleEngines.cs
+++ b/MechJebLib/FuelFlowSimulation/PartModules/SimModuleEngines.cs
@@ -98,6 +98,8 @@ namespace MechJebLib.FuelFlowSimulation.PartModules
             if (NoPropellants)
                 return false;
 
+            SimVessel vessel = Part.Vessel;
+
             foreach (int resourceId in ResourceConsumptions.Keys)
                 switch (PropellantFlowModes[resourceId])
                 {
@@ -109,7 +111,7 @@ namespace MechJebLib.FuelFlowSimulation.PartModules
                     case SimFlowMode.ALL_VESSEL_BALANCE:
                     case SimFlowMode.STAGE_PRIORITY_FLOW:
                     case SimFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
-                        if (!PartsHaveResource(Part.Vessel.Parts, resourceId))
+                        if (!PartsHaveResource(vessel.PartsRemainingInStage[vessel.CurrentStage], resourceId))
                             return false;
                         break;
                     case SimFlowMode.STAGE_STACK_FLOW:
@@ -191,6 +193,8 @@ namespace MechJebLib.FuelFlowSimulation.PartModules
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool WouldDropAccessibleFuelTank(int stageNum)
         {
+            SimVessel vessel = Part.Vessel;
+
             foreach (int resourceId in ResourceConsumptions.Keys)
                 switch (PropellantFlowModes[resourceId])
                 {
@@ -202,7 +206,7 @@ namespace MechJebLib.FuelFlowSimulation.PartModules
                     case SimFlowMode.ALL_VESSEL_BALANCE:
                     case SimFlowMode.STAGE_PRIORITY_FLOW:
                     case SimFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
-                        if (DrawingFuelFromPartsDroppedInStage(Part.Vessel.Parts, resourceId, stageNum))
+                        if (DrawingFuelFromPartsDroppedInStage(vessel.PartsRemainingInStage[vessel.CurrentStage], resourceId, stageNum))
                             return true;
                         break;
                     case SimFlowMode.STAGE_STACK_FLOW:

--- a/MechJebLib/FuelFlowSimulation/PartModules/SimModuleRCS.cs
+++ b/MechJebLib/FuelFlowSimulation/PartModules/SimModuleRCS.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using MechJebLib.Primitives;
 using MechJebLib.Utils;
+using static MechJebLib.Utils.Statics;
 
 namespace MechJebLib.FuelFlowSimulation.PartModules
 {
@@ -59,6 +60,8 @@ namespace MechJebLib.FuelFlowSimulation.PartModules
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool CanDrawResources()
         {
+            SimVessel vessel = Part.Vessel;
+
             foreach (int resourceId in ResourceConsumptions.Keys)
                 switch (PropellantFlowModes[resourceId])
                 {
@@ -70,7 +73,7 @@ namespace MechJebLib.FuelFlowSimulation.PartModules
                     case SimFlowMode.ALL_VESSEL_BALANCE:
                     case SimFlowMode.STAGE_PRIORITY_FLOW:
                     case SimFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
-                        if (!PartsHaveResource(Part.Vessel.Parts, resourceId))
+                        if (!PartsHaveResource(vessel.PartsRemainingInStage[vessel.CurrentStage], resourceId))
                             return false;
                         break;
                     case SimFlowMode.STAGE_STACK_FLOW:

--- a/MechJebLib/FuelFlowSimulation/SimVessel.cs
+++ b/MechJebLib/FuelFlowSimulation/SimVessel.cs
@@ -10,6 +10,7 @@ using System.Text;
 using MechJebLib.FuelFlowSimulation.PartModules;
 using MechJebLib.Primitives;
 using MechJebLib.Utils;
+using static MechJebLib.Utils.Statics;
 
 namespace MechJebLib.FuelFlowSimulation
 {
@@ -28,6 +29,7 @@ namespace MechJebLib.FuelFlowSimulation
 
         public bool   HasLaunchClamp;
         public int    CurrentStage;
+        private int   _savedStage;
         public double MainThrottle = 1.0;
         public double Mass;
         public V3     ThrustCurrent;
@@ -40,6 +42,20 @@ namespace MechJebLib.FuelFlowSimulation
         public double MachNumber;
         public double T;
         public V3     R, V, U;
+
+        // CurrentStage gets scribbled over by the FuelFlowSimulation, SetCurrentStage() is intended to be used in
+        // the VesselBuilder and DecouplingAnalyzer to figure out the right value, ResetCurrentStage() is called by
+        // the VesselUpdater to reset it back.
+        public void SetCurrentStage(int stage)
+        {
+            CurrentStage = stage;
+            _savedStage = stage;
+        }
+
+        public void ResetCurrentStage()
+        {
+            CurrentStage = _savedStage;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetConditions(double atmDensity, double atmPressure, double machNumber)

--- a/MechJebLib/Utils/DictOfLists.cs
+++ b/MechJebLib/Utils/DictOfLists.cs
@@ -26,7 +26,7 @@ namespace MechJebLib.Utils
         public void Clear()
         {
             // careful:  not every value in this dict is always valid and we don't clear them out here.
-            // not implemeting IDictionary and the ability to iterate over Keys is deliberate.
+            // not implementing IDictionary and the ability to iterate over Keys is deliberate.
             foreach (List<TValue> list in _dict.Values)
                 list.Clear();
         }

--- a/MechJebLibBindings/FuelFlowSimulation/SimVesselBuilder.cs
+++ b/MechJebLibBindings/FuelFlowSimulation/SimVesselBuilder.cs
@@ -116,7 +116,7 @@ namespace MechJebLibBindings.FuelFlowSimulation
 
             internal void BuildParts()
             {
-                _vessel.CurrentStage = StageManager.CurrentStage;
+                _vessel.SetCurrentStage(StageManager.CurrentStage);
 
                 foreach (Part kspPart in _kspVessel.Parts)
                 {

--- a/MechJebLibBindings/FuelFlowSimulation/SimVesselUpdater.cs
+++ b/MechJebLibBindings/FuelFlowSimulation/SimVesselUpdater.cs
@@ -60,7 +60,7 @@ namespace MechJebLibBindings.FuelFlowSimulation
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private void UpdateParts()
             {
-                _vessel.CurrentStage = StageManager.CurrentStage;
+                _vessel.ResetCurrentStage();
 
                 // FIXME: could track only parts that matter to the sim (engines+tanks) and only loop over them here
                 foreach (SimPart part in _vessel.Parts)


### PR DESCRIPTION
In the ALL_VESSEL checks, it needs to be looking at "PartsRemainingInStage" rather than Vessel.Parts since the latter isn't updated as the Sim runs.

This also affects ModuleEngines as well, but typically engines don't use ALL_VESSEL flow, so it seems like it affects RCS.

This also should fix bugs with the bottom stage being missing in the VAB.

closes #1919 