### PR TITLE
FFS: always reset current stage if it is too high

### DIFF
--- a/MechJebLib/FuelFlowSimulation/SimVessel.cs
+++ b/MechJebLib/FuelFlowSimulation/SimVessel.cs
@@ -52,9 +52,12 @@ namespace MechJebLib.FuelFlowSimulation
             _savedStage = stage;
         }
 
-        public void ResetCurrentStage()
+        public void ResetCurrentStage(int stage)
         {
-            CurrentStage = _savedStage;
+            if (stage < _savedStage)
+                SetCurrentStage(stage);
+            else
+                CurrentStage = _savedStage;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/MechJebLibBindings/FuelFlowSimulation/SimVesselUpdater.cs
+++ b/MechJebLibBindings/FuelFlowSimulation/SimVesselUpdater.cs
@@ -60,7 +60,7 @@ namespace MechJebLibBindings.FuelFlowSimulation
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private void UpdateParts()
             {
-                _vessel.ResetCurrentStage();
+                _vessel.ResetCurrentStage(StageManager.CurrentStage);
 
                 // FIXME: could track only parts that matter to the sim (engines+tanks) and only loop over them here
                 foreach (SimPart part in _vessel.Parts)


### PR DESCRIPTION
The saved current stage can sometimes be too high, so always save it in the updater if it is higher than the actual current stage.

Probably fixes some tick-to-tick bugs in KSP's staging where the builder will get triggered and the stage hasn't been decremented yet.