### PR TITLE
Coast fixes

### DIFF
--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -295,13 +295,8 @@ namespace MuMech
             {
                 if (!IsCoasting())
                 {
-                    StartCoast = VesselState.time;
-                    // force RCS on at the state transition
-                    if (!Vessel.ActionGroups[KSPActionGroup.RCS])
-                        Vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
+                    DoCoast();
                 }
-
-                Status = PVGStatus.COASTING;
 
                 if (Solution.StageTimeLeft(VesselState.time) < UllageLeadTime)
                     RCSOn();
@@ -402,7 +397,7 @@ namespace MuMech
             if (Vessel.currentStage == Solution.CoastKSPStage() && Solution.WillCoast(VesselState.time))
             {
                 ThrustOff();
-                Status = PVGStatus.COASTING;
+                DoCoast();
                 return;
             }
 
@@ -426,6 +421,16 @@ namespace MuMech
             Status   = PVGStatus.FINISHED;
             Solution = null;
             Enabled  = false;
+        }
+
+        private void DoCoast()
+        {
+            StartCoast = VesselState.time;
+            // force RCS on at the state transition
+            if (!Vessel.ActionGroups[KSPActionGroup.RCS])
+                Vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
+
+            Status = PVGStatus.COASTING;
         }
 
         public void SetSolution(Solution solution)

--- a/MechJeb2/MechJebModulePVGGlueBall.cs
+++ b/MechJeb2/MechJebModulePVGGlueBall.cs
@@ -189,17 +189,19 @@ namespace MuMech
                 ascentBuilder.OldSolution(Core.Guidance.Solution);
 
             bool optimizedStageFound = false;
+            bool hasCoast = false;
 
             for (int mjPhase = Core.StageStats.VacStats.Count - 1; mjPhase >= _ascentSettings.LastStage; mjPhase--)
             {
                 FuelStats fuelStats = Core.StageStats.VacStats[mjPhase];
                 int kspStage = Core.StageStats.VacStats[mjPhase].KSPStage;
 
-                if (!Core.Guidance.HasGoodSolutionWithNoFutureCoast())
+                if (!hasCoast && !Core.Guidance.HasGoodSolutionWithNoFutureCoast())
                 {
                     if ((kspStage == _ascentSettings.CoastStage && _ascentSettings.CoastBeforeFlag) ||
                         (kspStage == _ascentSettings.CoastStage - 1 && !_ascentSettings.CoastBeforeFlag))
                     {
+                        hasCoast = true;
                         double ct = _ascentSettings.FixedCoastLength;
                         double maxt = _ascentSettings.MaxCoast;
                         double mint = _ascentSettings.MinCoast;


### PR DESCRIPTION
When the current stage (in case of 'coast before') or the next stage (in
case of 'coast after') occurs multiple times in the stage stats, PVG
inserts a coast before/after _each_ of them. This should not happen,
there should only ever be one coast stage.

When a coast is inserted immediately after the "Early shutoff stage",
RCS does not get enabled and the `StartCoast` variable doesn't get set;
this means that the coast time does not tick down.

This patch fixes both these issues.