### PR TITLE
Fix saving and loading of vessel-specific settings

### DIFF
--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -959,13 +959,15 @@ namespace MuMech
                 Profiler.BeginSample("MechJebCore.OnSave.sfsNode");
                 if (sfsNode != null) sfsNode.nodes.Add(local);
                 Profiler.EndSample();
+
+                // Vessel-specific settings don't get saved in the Editor.
+                // The reason for this is, that OnLoad has no way to determine the vessel name in the Editor; this means
+                // that the vessel settings get loaded at their default values, and then shortly afterward saved -
+                // overwriting the previously saved settings!
                 Profiler.BeginSample("MechJebCore.OnSave.type");
-                // The EDITOR => FLIGHT transition is annoying to handle. OnDestroy is called when HighLogic.LoadedSceneIsEditor is already false
-                // So we don't save in that case, which is not that bad since nearly nothing use vessel settings in the editor.
-                if (type != null && (vessel != null || (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch != null)))
+                if (type != null && vessel != null)
                 {
-                    string vesselName = HighLogic.LoadedSceneIsEditor && EditorLogic.fetch ? EditorLogic.fetch.shipNameField.text : vessel.vesselName;
-                    vesselName = string.Join("_", vesselName.Split(Path.GetInvalidFileNameChars())); // Strip illegal char from the filename
+                    string vesselName = string.Join("_", vessel.vesselName.Split(Path.GetInvalidFileNameChars())); // Strip illegal char from the filename
                     type.Save(MuUtils.GetCfgPath("mechjeb_settings_type_" + vesselName + ".cfg"));
                 }
 


### PR DESCRIPTION
When loading a craft file in the Editor, there's no vessel name available; thus, all vessel-specific settings (those with persistent pass TYPE) get loaded at their default values. A few seconds later, those get saved (with the ship name at the top of the screen), overwriting any previously vessel-specific settings with their default values.

Since there's no way to get a ship name in the OnLoad method (it gets called before the Editor has set the name from the .craft file), the best option is to simply not save the settings from inside the editor at all.