### PR TITLE
Fix a problem where coast time doesn't count down

### DIFF
--- a/MechJeb2/MechJebModulePVGGlueBall.cs
+++ b/MechJeb2/MechJebModulePVGGlueBall.cs
@@ -206,7 +206,7 @@ namespace MuMech
                         double maxt = _ascentSettings.MaxCoast;
                         double mint = _ascentSettings.MinCoast;
 
-                        if (kspStage == Vessel.currentStage && Core.Guidance.IsCoasting())
+                        if (Core.Guidance.IsCoasting())
                         {
                             ct   = Math.Max(ct - (VesselState.time - Core.Guidance.StartCoast), 0);
                             maxt = Math.Max(maxt - (VesselState.time - Core.Guidance.StartCoast), 0);


### PR DESCRIPTION
When 'Coast after' is checked, the kspStage inside the loop is one past the vessel's current stage. Similarly, if autostaging hasn't staged to the point where the vessel's current stage is the coast stage, then this check will also fail. In either case the coast time will not tick down.

If we are coasting, then the timers should always be ticking down, whatever the current stage happens to be. Therefore, the Vessel.currentStage check is unnecessary.