### PR TITLE
better gate terminal_staging

### DIFF
--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -402,7 +402,7 @@ namespace MuMech
             }
 
             // if we have more un-optimized upper stages to burn, stage and use the TERMINAL_STAGING state
-            if (Solution.TerminalStage() != Vessel.currentStage)
+            if (Solution.TerminalStage() != Vessel.currentStage && _ascentSettings.OptimizeStage == Vessel.currentStage)
             {
                 ThrustOff();
                 Core.Staging.ImmediateStage();


### PR DESCRIPTION
This should only be used when in an optimized stage that isn't the upper stage of the rocket (more un-optimized, probably unguided stages sitting on top of a smarter booster with cutout logic).

This probably won't really fix the switch to terminal_staging problem when staging in terminal guidance issue.  I suspect it just cuts the engine and the rocket doesn't make its planned orbit.  The logic which ends terminal guidance when thrust is lost is ultimately at fault here (but that is also necessary for the case when there's literally thrust lost during terminal guidance, and you need to exit guidance entirely).