### PR TITLE
Fix classic launch inclination

### DIFF
--- a/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
@@ -329,7 +329,7 @@ namespace MuMech
         // this provides ground track heading based on desired inclination and is what most consumers should call
         protected void AttitudeTo(double desiredPitch)
         {
-            double desiredHeading = OrbitalManeuverCalculator.HeadingForLaunchInclination(Vessel.orbit, AscentSettings.DesiredInclination);
+            double desiredHeading = OrbitalManeuverCalculator.HeadingForLaunchInclination(Vessel.orbit, AscentSettings.DesiredInclination, AscentSettings.DesiredOrbitAltitude.Val);
             AttitudeTo(desiredPitch, desiredHeading);
         }
 

--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -101,12 +101,13 @@ namespace MuMech
         //Returned heading is in degrees and in the range 0 to 360.
         //If the given latitude is too large, so that an orbit with a given inclination never attains the
         //given latitude, then this function returns either 90 (if -90 < inclination < 90) or 270.
-        public static double HeadingForLaunchInclination(Orbit o, double inclinationDegrees)
+        public static double HeadingForLaunchInclination(Orbit o, double inclinationDegrees, double desiredApoapsis)
         {
             (V3 r, V3 v) = o.RightHandedStateVectorsAtUT(Planetarium.GetUniversalTime());
             double rotFreq = TAU / o.referenceBody.rotationPeriod;
 
-            return Rad2Deg(Simple.HeadingForLaunchInclination(o.referenceBody.gravParameter, r, v, Deg2Rad(inclinationDegrees), rotFreq));
+            return Rad2Deg(Simple.HeadingForLaunchInclination(o.referenceBody.gravParameter, r, v, Deg2Rad(inclinationDegrees), rotFreq, o.referenceBody.Radius
+            + desiredApoapsis));
         }
 
         //Computes the delta-V of the burn required to change an orbit's inclination to a given value

--- a/MechJebLib/FunctionImpls/RealDeltaVToChangeApoapsisPrograde.cs
+++ b/MechJebLib/FunctionImpls/RealDeltaVToChangeApoapsisPrograde.cs
@@ -29,27 +29,25 @@ namespace MechJebLib.FunctionImpls
             }
         }
 
-        private static readonly ThreadLocal<Args> _threadArgs =
-            new ThreadLocal<Args>(() => new Args());
-
+        private static readonly ThreadLocal<Args> _threadArgs = new ThreadLocal<Args>(() => new Args());
         private static readonly Func<double, object?, double> _f = F;
 
         private static double F(double x, object? o)
         {
             var args = (Args)o!;
-            return Astro.ApoapsisFromStateVectors(args.Mu, args.R, args.V.normalized * x) - args.NewApR;
+            return Astro.ApoapsisFromStateVectors(args.Mu, args.R, x * args.V.normalized) - args.NewApR;
         }
 
         public static V3 Run(double mu, V3 r, V3 v, double newApR)
         {
-            if (r.magnitude >= newApR)
+            if (r.magnitude >= newApR && newApR >= 0)
                 return V3.zero;
 
             Args args = _threadArgs.Value;
 
             args.Set(mu, r, v, newApR);
 
-            double vfm = BrentRoot.Solve(_f, 0, Astro.EscapeVelocity(mu, r.magnitude) - 1, args);
+            double vfm = BrentRoot.Solve(_f, 0, Astro.EscapeVelocity(mu, r.magnitude)-1, args);
 
             return vfm * v.normalized - v;
         }


### PR DESCRIPTION
I don't know what I thought I was doing in the Launch inclination stuff, but this mostly fixes it.  It drives the inclination error to zero as the vgo to raise the apoapsis goes to zero via proportional steering.

There still needs to be some terminal guidance handling, right now it gets all weird and spinny as the dv goes to zero.

Needs to have the AoA limiter turned off or the fadeout very high for accuracy.