### PR TITLE
prevent PID windup during PVG staging/spoolup

### DIFF
--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -99,6 +99,11 @@ namespace MuMech
                 return;
             }
 
+            // RO/RF: if we are spooling up engines, then flush the PID integrators to prevent windup
+            if (Status == PVGStatus.BURNING || Status == PVGStatus.TERMINAL)
+                if (VesselState.thrustCurrent < VesselState.thrustMinimum)
+                    Core.Attitude.Controller.Reset();
+
             HandleTerminal();
 
             HandleSpinup();


### PR DESCRIPTION
if we're supposed to have engines on (burning/terminal) but the thrust is below minimum thrust, then flush the pids to prevent integral windup.