### PR TITLE
fix staging during terminal properly

### DIFF
--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -208,7 +208,7 @@ namespace MuMech
             bool shouldEndTerminal = false;
 
             // this handles ending TERMINAL guidance (but not TERMINAL_RCS) due to thrust fault in the last stage
-            if (Status == PVGStatus.TERMINAL && VesselState.thrustCurrent == 0 && _ascentSettings.LastStage.Val == Vessel.currentStage)
+            if (Status == PVGStatus.TERMINAL && VesselState.thrustCurrent == 0 && Vessel.currentStage < _ascentSettings.LastStage.Val)
             {
                 Debug.Log("[MechJebModuleGuidanceController] no thrust in last stage.");
                 shouldEndTerminal = true;


### PR DESCRIPTION
this check actually fires at the start of the next stage, so needs to be gated by current < last.

this makes me think we really need a check that we don't stage past the last stage ever, if i didn't already add that somewhere, mostly making this check redundant now.