### PR TITLE
Launch Ascent tweaks

### DIFF
--- a/MechJeb2/AttitudeControllers/BetterController.cs
+++ b/MechJeb2/AttitudeControllers/BetterController.cs
@@ -351,8 +351,11 @@ namespace MuMech.AttitudeControllers
 
                 _targetTorque[i] = _actuation[i] * _controlTorque[i];
 
-                if (Ac.ActuationControl[i] == 0)
+                if (Ac.ActuationControl[i] == 0 || _controlTorque[i] == 0 || Ac.AxisControl[i] == 0)
+                {
+                    _actuation[i] = 0;
                     Reset(i);
+                }
             }
         }
 
@@ -366,6 +369,7 @@ namespace MuMech.AttitudeControllers
         public override void Reset(int i)
         {
             _velPID[i].Reset();
+            _posPID[i].Reset();
             _error0[i]  = double.NaN;
         }
 

--- a/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
@@ -357,13 +357,24 @@ namespace MuMech
             else
                 Core.Attitude.attitudeTo(desiredThrustVector, AttitudeReference.INERTIAL_COT, this);
 
-            Core.Attitude.SetAxisControl(true, true, VesselState.altitudeBottom > AscentSettings.RollAltitude);
+            Core.Attitude.SetAxisControl(true, true, AscentSettings.ForceRoll);
         }
 
         // this handles vertical rise and bypasses AoA limiters and other inapplicable settings
-        protected void VerticalAttitude(double desiredHeading)
+        protected void VerticalHeadingTo(double desiredHeading)
         {
             Core.Attitude.attitudeTo(desiredHeading, 90, AscentSettings.VerticalRoll, this, fixCOT: true);
+            bool liftedOff = Vessel.LiftedOff() && !Vessel.Landed;
+
+            Core.Attitude.SetActuationControl(liftedOff, liftedOff, liftedOff);
+            Core.Attitude.SetAxisControl(liftedOff, liftedOff, liftedOff && AscentSettings.ForceRoll && VesselState.altitudeBottom > AscentSettings.RollAltitude);
+        }
+
+        // this is for initial pitch-over and bypasses AoA limiters
+        protected void PitchProgramAttitudeTo(double desiredPitch, double desiredHeading)
+        {
+            Core.Attitude.attitudeTo(desiredHeading, desiredPitch, AscentSettings.TurnRoll, this, fixCOT: true);
+            Core.Attitude.SetAxisControl(true, true, AscentSettings.ForceRoll);
         }
 
         private Vector3d ApplyQAlphaAoALimiter(Vector3d desiredThrustVector)

--- a/MechJeb2/MechJebModuleAscentClassicAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentClassicAutopilot.cs
@@ -84,11 +84,7 @@ namespace MuMech
             if (!IsVerticalAscent(VesselState.altitudeTrue, VesselState.speedSurface)) _mode = AscentMode.GRAVITY_TURN;
             if (Orbit.ApA > AscentSettings.DesiredOrbitAltitude) _mode                       = AscentMode.COAST_TO_APOAPSIS;
 
-            VerticalAttitude(OrbitalManeuverCalculator.HeadingForLaunchInclination(Vessel.orbit, AscentSettings.DesiredInclination, AscentSettings.DesiredOrbitAltitude.Val));
-
-            bool liftedOff = Vessel.LiftedOff() && !Vessel.Landed;
-
-            Core.Attitude.SetAxisControl(liftedOff, liftedOff, liftedOff && AscentSettings.ForceRoll && VesselState.altitudeBottom > AscentSettings.RollAltitude);
+            VerticalHeadingTo(OrbitalManeuverCalculator.HeadingForLaunchInclination(Vessel.orbit, AscentSettings.DesiredInclination, AscentSettings.DesiredOrbitAltitude.Val));
 
             Core.Thrust.TargetThrottle = 1.0F;
 

--- a/MechJeb2/MechJebModuleGuidanceController.cs
+++ b/MechJeb2/MechJebModuleGuidanceController.cs
@@ -6,6 +6,7 @@
 
 extern alias JetBrainsAnnotations;
 using System.Collections.Generic;
+using MechJebLib.Primitives;
 using MechJebLib.PVG;
 using MechJebLibBindings;
 using UnityEngine;
@@ -34,6 +35,7 @@ namespace MuMech
 
         public double Pitch;
         public double Heading;
+        public Vector3d Inertial = Vector3d.zero;
         public double Tgo;
         public double VGO;
         public double StartCoast;
@@ -333,9 +335,10 @@ namespace MuMech
 
             if (Status != PVGStatus.TERMINAL_RCS)
             {
-                (double pitch, double heading) = Solution.PitchAndHeading(VesselState.time);
+                (double pitch, double heading, V3 inertial) = Solution.PitchAndHeading(VesselState.time);
                 Pitch                          = Rad2Deg(pitch);
                 Heading                        = Rad2Deg(heading);
+                Inertial                       = inertial.V3ToWorldRotated();
                 Tgo                            = Solution.Tgo(VesselState.time);
                 VGO                            = Solution.Vgo(VesselState.time);
             }

--- a/MechJebLib/PVG/Solution.cs
+++ b/MechJebLib/PVG/Solution.cs
@@ -237,7 +237,7 @@ namespace MechJebLib.PVG
             return (_tmax[phase] - tbar) * _timeScale;
         }
 
-        public (double pitch, double heading) PitchAndHeading(double t)
+        public (double pitch, double heading, V3 inertial) PitchAndHeading(double t)
         {
             double tbar = (t - T0) / _timeScale;
             V3     u;
@@ -262,7 +262,7 @@ namespace MechJebLib.PVG
             }
 
             (double pitch, double heading) = Astro.ECIToPitchHeading(x.R, u);
-            return (pitch, heading);
+            return (pitch, heading, u);
         }
 
         public (V3 r, V3 v) TerminalStateVectors() => StateVectors(Tmax);


### PR DESCRIPTION
- flushes the pos pid state now in better controller on reset
- flushes state if we have no axis control or actuation
- sets actuation to zero under conditions when we flush
- adds angular deviation to "Stable Guidance" message
- fixes some bugs i introduced in the roll control on ascent
- bypasses the AoA limters for the pitchover maneuver (allows Qα-limit of zero again)