### PR TITLE
Fix MissingMethodException in classic ascent guidance

### DIFF
--- a/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
@@ -397,7 +397,7 @@ namespace MuMech
             AscentSettings.LimitingAoA = Vessel.altitude < MainBody.atmosphereDepth && Vector3d.Angle(VesselState.surfaceVelocity, desiredThrustVector) > CurrentMaxAoA;
 
             if (AscentSettings.LimitingAoA)
-                desiredThrustVector = Vector3d.RotateTowards(VesselState.surfaceVelocity, desiredThrustVector, (float)(CurrentMaxAoA * Mathf.Deg2Rad), 1).normalized;
+                desiredThrustVector = Vector3.RotateTowards(VesselState.surfaceVelocity, desiredThrustVector, (float)(CurrentMaxAoA * Mathf.Deg2Rad), 1).normalized;
 
             return desiredThrustVector;
         }


### PR DESCRIPTION
While `Vector3d` has the `RotateTowards` method declared in its API, there's no implementation for it; it's declared as a "runtime builtin" method, but the runtime does not provide this method (unlike the `Vector3` version, which does have an implementation in the Unity runtime).

The result is a `MissingMethodException` whenever this method is called.

For reference, the same issue exists with the `Slerp` and `Orthonormalize` methods on `Vector3d`, which also will not work.

Fixes #1970 