### PR TITLE
Run Qα limiter during pitch program again

### DIFF
--- a/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
@@ -370,13 +370,6 @@ namespace MuMech
             Core.Attitude.SetAxisControl(liftedOff, liftedOff, liftedOff && AscentSettings.ForceRoll && VesselState.altitudeBottom > AscentSettings.RollAltitude);
         }
 
-        // this is for initial pitch-over and bypasses AoA limiters
-        protected void PitchProgramAttitudeTo(double desiredPitch, double desiredHeading)
-        {
-            Core.Attitude.attitudeTo(desiredHeading, desiredPitch, AscentSettings.TurnRoll, this, fixCOT: true);
-            Core.Attitude.SetAxisControl(true, true, AscentSettings.ForceRoll);
-        }
-
         private Vector3d ApplyQAlphaAoALimiter(Vector3d desiredThrustVector)
         {
             double lim = MuUtils.Clamp(AscentSettings.LimitQa, 0, 10000);

--- a/MechJeb2/MechJebModuleAscentPVGAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentPVGAutopilot.cs
@@ -161,7 +161,7 @@ namespace MuMech
                 return;
             }
 
-            PitchProgramAttitudeTo(pitch, Core.Guidance.Heading);
+            AttitudeTo(pitch, Core.Guidance.Heading);
         }
 
         private bool CheckForGuidanceTransition(double pitch)


### PR DESCRIPTION
This reverts to previous behavior.

I tried fixing it so that zero Qα would work, but that would take more detailed patch to bypass Qα during initiation, but not pitchover, being careful that it would be smooth and not ratchet (so it would initiate by 3 degrees or so, but then not apply a zero Qα limit and try to go back to nearly vertical, etc).

Didn't have an actual bug to fix that behavior, so the bugs the fix introduced and got reported were worse.