### PR TITLE
Ignore un-stageable parts in fairing check

### DIFF
--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -646,7 +646,7 @@ namespace MuMech
         private bool HasFairingUncached(int inverseStage)
         {
             _partsInStage.Clear();
-            Vessel.parts.Slinq().Where((p, s) => p.inverseStage == s, inverseStage).AddTo(_partsInStage);
+            Vessel.parts.Slinq().Where((p, s) => p.hasStagingIcon && p.inverseStage == s, inverseStage).AddTo(_partsInStage);
 
             // proc parts are reasonably easy, but all the parts in the stage must be payload fairings for them to
             // be treated as payload fairings here.  a payload fairing and a stack decoupler will bypass the fairing


### PR DESCRIPTION
Parts like aerodynamic fins and fuel tanks are never stageable, but they still have an assigned `inverseStage`. Those parts should be ignored when checking whether all parts in a stage have some particular property.

Will probably fix fairings "randomly" failing to stage correctly on some vessels.

For example, the following KOS script lists all parts in each stage. It confirms that many parts like fuel tanks, probe cores, fins etc. still get assigned a stage, even though they aren't in the staging list and don't do anything when their stage is activated.

```
set parts_in_stage to lexicon().

for part in ship:parts {
    if parts_in_stage:haskey(part:stage) {
        parts_in_stage[part:stage]:add(part).
    } else {
        set parts_in_stage[part:stage] to list(part).
    }
}

set max_stage to -1000.
set min_stage to 1000.
for key in parts_in_stage:keys {
    set max_stage to max(max_stage, key).
    set min_stage to min(min_stage, key).
}

for i in range(min_stage, max_stage + 1) {
    print "Stage " + i.
    for p in parts_in_stage[i] {
        print "  " + p:name.
    }
}
```