### PR TITLE
Get the gimbal rate into the vessel state

### DIFF
--- a/MechJeb2/AttitudeControllers/BetterController.cs
+++ b/MechJeb2/AttitudeControllers/BetterController.cs
@@ -566,6 +566,11 @@ namespace MuMech.AttitudeControllers
             GUILayout.Label("MOI", GUILayout.ExpandWidth(true));
             GUILayout.Label(MuUtils.PrettyPrint(_vessel.MOI), GUILayout.ExpandWidth(false));
             GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Response Speed", GUILayout.ExpandWidth(true));
+            GUILayout.Label(MuUtils.PrettyPrint(Ac.VesselState.torqueResponseSpeed), GUILayout.ExpandWidth(false));
+            GUILayout.EndHorizontal();
         }
     }
 }


### PR DESCRIPTION
PIDs don't use it yet.

I'm very uncertain that I'm doing this correctly for the control surface, but it works correctly for gimbals, RCS, and RW.