### PR TITLE
Landing guidance improvements

### DIFF
--- a/MechJeb2/LandingAutopilot/DecelerationBurn.cs
+++ b/MechJeb2/LandingAutopilot/DecelerationBurn.cs
@@ -48,7 +48,7 @@ namespace MuMech
                     return this;
                 }
 
-                if(!_decelerationBurnTriggered)
+                if (!_decelerationBurnTriggered)
                     _decelerationBurnTriggered = true;
 
                 Vector3d desiredThrustVector = -VesselState.surfaceVelocity.normalized;
@@ -61,7 +61,7 @@ namespace MuMech
                 if (Vector3d.Dot(VesselState.surfaceVelocity, VesselState.up) > 0
                     || Vector3d.Dot(VesselState.forward, desiredThrustVector) < 0.75)
                 {
-                    Core.Thrust.TargetThrottle = 0.01F;
+                    Core.Thrust.TargetThrottle = Core.Landing.MinAllowedThrottle();
                     Status                     = Localizer.Format("#MechJeb_LandingGuidance_Status5"); //"Braking"
                 }
                 else
@@ -78,8 +78,8 @@ namespace MuMech
                     double speedError = desiredSpeed - controlledSpeed;
                     double desiredAccel = speedError / SPEED_CORRECTION_TIME_CONSTANT + (desiredSpeedAfterDt - desiredSpeed) / VesselState.deltaT;
                     if (maxAccel - minAccel > 0)
-                        Core.Thrust.TargetThrottle  = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.01F, 1.0F);
-                    else Core.Thrust.TargetThrottle = 0.01F;
+                        Core.Thrust.TargetThrottle  = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), Core.Landing.MinAllowedThrottle(), 1.0F);
+                    else Core.Thrust.TargetThrottle = Core.Landing.MinAllowedThrottle();
                     Status = Localizer.Format("#MechJeb_LandingGuidance_Status6",
                         desiredSpeed >= double.MaxValue ? "∞" : Math.Abs(desiredSpeed).ToString("F1")); //"Braking: target speed = " +  + " m/s"
                 }

--- a/MechJeb2/LandingAutopilot/DecelerationBurn.cs
+++ b/MechJeb2/LandingAutopilot/DecelerationBurn.cs
@@ -74,7 +74,7 @@ namespace MuMech
                     double desiredAccel = speedError / SPEED_CORRECTION_TIME_CONSTANT + (desiredSpeedAfterDt - desiredSpeed) / VesselState.deltaT;
                     if (maxAccel - minAccel > 0)
                         Core.Thrust.TargetThrottle  = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.0F, 1.0F);
-                    else Core.Thrust.TargetThrottle = 0;
+                    else Core.Thrust.TargetThrottle = 0.01F;
                     Status = Localizer.Format("#MechJeb_LandingGuidance_Status6",
                         desiredSpeed >= double.MaxValue ? "∞" : Math.Abs(desiredSpeed).ToString("F1")); //"Braking: target speed = " +  + " m/s"
                 }

--- a/MechJeb2/LandingAutopilot/DecelerationBurn.cs
+++ b/MechJeb2/LandingAutopilot/DecelerationBurn.cs
@@ -56,7 +56,7 @@ namespace MuMech
                 if (Vector3d.Dot(VesselState.surfaceVelocity, VesselState.up) > 0
                     || Vector3d.Dot(VesselState.forward, desiredThrustVector) < 0.75)
                 {
-                    Core.Thrust.TargetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0.01F;
                     Status                     = Localizer.Format("#MechJeb_LandingGuidance_Status5"); //"Braking"
                 }
                 else
@@ -73,7 +73,7 @@ namespace MuMech
                     double speedError = desiredSpeed - controlledSpeed;
                     double desiredAccel = speedError / SPEED_CORRECTION_TIME_CONSTANT + (desiredSpeedAfterDt - desiredSpeed) / VesselState.deltaT;
                     if (maxAccel - minAccel > 0)
-                        Core.Thrust.TargetThrottle  = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.0F, 1.0F);
+                        Core.Thrust.TargetThrottle  = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.01F, 1.0F);
                     else Core.Thrust.TargetThrottle = 0.01F;
                     Status = Localizer.Format("#MechJeb_LandingGuidance_Status6",
                         desiredSpeed >= double.MaxValue ? "∞" : Math.Abs(desiredSpeed).ToString("F1")); //"Braking: target speed = " +  + " m/s"

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -53,7 +53,7 @@ namespace MuMech
                     Core.Thrust.TransKillH  = true;
                     Core.Thrust.TransSpdAct = 0;
                 }
-                else if (minalt > 200)
+                else if (minalt > 300)
                 {
                     if (VesselState.surfaceVelocity.magnitude > 5 && Vector3d.Angle(VesselState.surfaceVelocity, VesselState.up) < 80)
                     {

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -90,7 +90,7 @@ namespace MuMech
                 }
                 else
                 {
-                    // last 200 meters:
+                    // last 300 meters:
                     Core.Thrust.TransSpdAct = -Mathf.Lerp(0,
                         (float)Math.Sqrt((VesselState.limitedMaxThrustAccel - VesselState.localg) * 2 * 200) * 0.90F, (float)minalt / 200);
 
@@ -111,8 +111,10 @@ namespace MuMech
                         //Follow min thrust limiter
                         if (Core.Thrust.TransSpdAct < VesselState.speedVertical && !_finalThrottleUpTriggered)
                         {
+                            // if we're not facing approximately retrograde, turn to point retrograde and follow min thrust limiter:
+                            Core.Attitude.attitudeTo(Vector3d.back, AttitudeReference.SURFACE_VELOCITY, null);
                             Core.Thrust.Tmode = MechJebModuleThrustController.TMode.DIRECT;
-                            Core.Thrust.TransSpdAct = 100*Core.Landing.MinAllowedThrottle();
+                            Core.Thrust.TransSpdAct = 100 * Core.Landing.MinAllowedThrottle();
                         }
                         else
                         {

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using KSP.Localization;
 using UnityEngine;
 
@@ -16,7 +16,8 @@ namespace MuMech
 
             public override AutopilotStep OnFixedUpdate()
             {
-                double minalt = Math.Min(VesselState.altitudeBottom, Math.Min(VesselState.altitudeASL, VesselState.altitudeTrue));
+                return this;
+                /*double minalt = Math.Min(VesselState.altitudeBottom, Math.Min(VesselState.altitudeASL, VesselState.altitudeTrue));
 
                 if (!Core.Node.Autowarp || _aggressivePolicy == null) return this;
 
@@ -29,7 +30,7 @@ namespace MuMech
                 else
                     Core.Warp.MinimumWarp(true);
 
-                return this;
+                return this;*/
             }
 
             public override AutopilotStep Drive(FlightCtrlState s)

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -106,6 +106,13 @@ namespace MuMech
                         // kill horizontal velocity
                         Core.Thrust.Tmode      = MechJebModuleThrustController.TMode.KEEP_VERTICAL;
                         Core.Thrust.TransKillH = true;
+
+                        //Prevent full engine shutdown
+                        if (Core.Thrust.TransSpdAct < VesselState.speedVertical)
+                        {
+                            Core.Thrust.Tmode = MechJebModuleThrustController.TMode.DIRECT;
+                            Core.Thrust.TransSpdAct = 1f;
+                        }
                     }
                     else
                     {
@@ -117,9 +124,6 @@ namespace MuMech
                         Core.Thrust.TransSpdAct *= -1;
                     }
                 }
-
-                if (Core.Thrust.TargetThrottle < 0.01F)
-                    Core.Thrust.TargetThrottle = 0.01F;
 
                 Status = Localizer.Format("#MechJeb_LandingGuidance_Status9",
                     VesselState.altitudeBottom.ToString("F0")); //"Final descent: " +  + "m above terrain"

--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -118,6 +118,9 @@ namespace MuMech
                     }
                 }
 
+                if (Core.Thrust.TargetThrottle < 0.01F)
+                    Core.Thrust.TargetThrottle = 0.01F;
+
                 Status = Localizer.Format("#MechJeb_LandingGuidance_Status9",
                     VesselState.altitudeBottom.ToString("F0")); //"Final descent: " +  + "m above terrain"
 

--- a/MechJeb2/LandingAutopilot/KillHorizontalVelocity.cs
+++ b/MechJeb2/LandingAutopilot/KillHorizontalVelocity.cs
@@ -20,7 +20,7 @@ namespace MuMech
                 Vector3d horizontalPointingDirection = Vector3d.Exclude(VesselState.up, VesselState.forward).normalized;
                 if (Vector3d.Dot(horizontalPointingDirection, VesselState.surfaceVelocity) > 0)
                 {
-                    Core.Thrust.TargetThrottle = 0.01F;
+                    Core.Thrust.TargetThrottle = Core.Landing.MinAllowedThrottle();
                     Core.Attitude.attitudeTo(Vector3.up, AttitudeReference.SURFACE_NORTH, Core.Landing);
                     return new FinalDescent(Core);
                 }
@@ -35,11 +35,11 @@ namespace MuMech
                 double maxAccel = -VesselState.localg + Vector3d.Dot(VesselState.forward, VesselState.up) * VesselState.maxThrustAccel;
                 if (maxAccel - minAccel > 0)
                 {
-                    Core.Thrust.TargetThrottle = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.01F, 1.0F);
+                    Core.Thrust.TargetThrottle = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), Core.Landing.MinAllowedThrottle(), 1.0F);
                 }
                 else
                 {
-                    Core.Thrust.TargetThrottle = 0.01F;
+                    Core.Thrust.TargetThrottle = Core.Landing.MinAllowedThrottle();
                 }
 
                 //angle up and slightly away from vertical:

--- a/MechJeb2/LandingAutopilot/KillHorizontalVelocity.cs
+++ b/MechJeb2/LandingAutopilot/KillHorizontalVelocity.cs
@@ -1,4 +1,4 @@
-using KSP.Localization;
+﻿using KSP.Localization;
 using UnityEngine;
 
 namespace MuMech
@@ -20,7 +20,7 @@ namespace MuMech
                 Vector3d horizontalPointingDirection = Vector3d.Exclude(VesselState.up, VesselState.forward).normalized;
                 if (Vector3d.Dot(horizontalPointingDirection, VesselState.surfaceVelocity) > 0)
                 {
-                    Core.Thrust.TargetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0.01F;
                     Core.Attitude.attitudeTo(Vector3.up, AttitudeReference.SURFACE_NORTH, Core.Landing);
                     return new FinalDescent(Core);
                 }
@@ -35,11 +35,11 @@ namespace MuMech
                 double maxAccel = -VesselState.localg + Vector3d.Dot(VesselState.forward, VesselState.up) * VesselState.maxThrustAccel;
                 if (maxAccel - minAccel > 0)
                 {
-                    Core.Thrust.TargetThrottle = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.0F, 1.0F);
+                    Core.Thrust.TargetThrottle = Mathf.Clamp((float)((desiredAccel - minAccel) / (maxAccel - minAccel)), 0.01F, 1.0F);
                 }
                 else
                 {
-                    Core.Thrust.TargetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0.01F;
                 }
 
                 //angle up and slightly away from vertical:

--- a/MechJeb2/LandingAutopilot/LowDeorbitBurn.cs
+++ b/MechJeb2/LandingAutopilot/LowDeorbitBurn.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using KSP.Localization;
 using UnityEngine;
 
@@ -27,6 +27,10 @@ namespace MuMech
                 if (_deorbitBurnTriggered && Core.Attitude.attitudeAngleFromTarget() < 5)
                 {
                     Core.Thrust.TargetThrottle = Mathf.Clamp01((float)_lowDeorbitBurnMaxThrottle);
+                }
+                else if (_deorbitBurnTriggered && Core.Attitude.attitudeAngleFromTarget() < 10)
+                {
+                    Core.Thrust.TargetThrottle = 0.01F;
                 }
                 else
                 {

--- a/MechJeb2/LandingAutopilot/LowDeorbitBurn.cs
+++ b/MechJeb2/LandingAutopilot/LowDeorbitBurn.cs
@@ -66,7 +66,7 @@ namespace MuMech
                     "#MechJeb_LandingGuidance_Status12"); //"Moving to low deorbit burn point"
 
                 //Warp toward deorbit burn if it hasn't been triggerd yet:
-                if (!_deorbitBurnTriggered && Core.Node.Autowarp && rangeToTarget > 2 * triggerDistance)
+                if (!_deorbitBurnTriggered && Core.Node.Autowarp && rangeToTarget > 2 * triggerDistance && Core.vessel.angularVelocity.magnitude < 0.001)
                     Core.Warp.WarpRegularAtRate((float)(Orbit.period / 6));
                 if (rangeToTarget < triggerDistance && !MuUtils.PhysicsRunning()) Core.Warp.MinimumWarp();
 

--- a/MechJeb2/LandingAutopilot/LowDeorbitBurn.cs
+++ b/MechJeb2/LandingAutopilot/LowDeorbitBurn.cs
@@ -28,9 +28,9 @@ namespace MuMech
                 {
                     Core.Thrust.TargetThrottle = Mathf.Clamp01((float)_lowDeorbitBurnMaxThrottle);
                 }
-                else if (_deorbitBurnTriggered && Core.Attitude.attitudeAngleFromTarget() < 10)
+                else if (_deorbitBurnTriggered && Core.Attitude.attitudeAngleFromTarget() < 10 && Core.Landing.MinAllowedThrottle() > 0)
                 {
-                    Core.Thrust.TargetThrottle = 0.01F;
+                    Core.Thrust.TargetThrottle = Core.Landing.MinAllowedThrottle();
                 }
                 else
                 {

--- a/MechJeb2/LandingAutopilot/PlaneChange.cs
+++ b/MechJeb2/LandingAutopilot/PlaneChange.cs
@@ -39,9 +39,9 @@ namespace MuMech
                 {
                     Core.Thrust.TargetThrottle = Mathf.Clamp01((float)(_planeChangeDVLeft / (2 * Core.VesselState.maxThrustAccel)));
                 }
-                else if (_planeChangeTriggered && Core.Attitude.attitudeAngleFromTarget() < 10)
+                else if (_planeChangeTriggered && Core.Attitude.attitudeAngleFromTarget() < 10 && Core.Landing.MinAllowedThrottle() > 0)
                 {
-                    Core.Thrust.TargetThrottle = 0.01F;
+                    Core.Thrust.TargetThrottle = Core.Landing.MinAllowedThrottle();
                 }
                 else
                 {

--- a/MechJeb2/LandingAutopilot/PlaneChange.cs
+++ b/MechJeb2/LandingAutopilot/PlaneChange.cs
@@ -81,7 +81,8 @@ namespace MuMech
 
                     if (_planeChangeDVLeft < 0.1F)
                     {
-                        return new LowDeorbitBurn(Core);
+                        Core.Thrust.TargetThrottle = 0;
+                        return new LowDeorbitBurn(Core); //DecelerationBurn(Core); would by cool to immediately proceed to DecelerationBurn instead, can't figure out how to convince trajectory predicted to do so with Pe>0, must be done in ReentrySimulation.cs somewhere.
                     }
                 }
                 else

--- a/MechJeb2/LandingAutopilot/PlaneChange.cs
+++ b/MechJeb2/LandingAutopilot/PlaneChange.cs
@@ -1,4 +1,4 @@
-using KSP.Localization;
+﻿using KSP.Localization;
 using UnityEngine;
 
 // FIXME: use a maneuver node
@@ -35,13 +35,17 @@ namespace MuMech
 
             public override AutopilotStep Drive(FlightCtrlState s)
             {
-                if (_planeChangeTriggered && Core.Attitude.attitudeAngleFromTarget() < 2)
+                if (_planeChangeTriggered && Core.Attitude.attitudeAngleFromTarget() < 2 )
                 {
                     Core.Thrust.TargetThrottle = Mathf.Clamp01((float)(_planeChangeDVLeft / (2 * Core.VesselState.maxThrustAccel)));
                 }
+                else if (_planeChangeTriggered && Core.Attitude.attitudeAngleFromTarget() < 10)
+                {
+                    Core.Thrust.TargetThrottle = 0.01F;
+                }
                 else
                 {
-                    Core.Thrust.TargetThrottle = 0;
+                    Core.Thrust.TargetThrottle = 0F;
                 }
 
                 return this;

--- a/MechJeb2/MechJebModuleLandingAutopilot.cs
+++ b/MechJeb2/MechJebModuleLandingAutopilot.cs
@@ -524,6 +524,18 @@ namespace MuMech
 
         public double MaxAllowedSpeed() => DescentSpeedPolicy.MaxAllowedSpeed(VesselState.CoM - MainBody.position, VesselState.surfaceVelocity);
 
+        public float MinAllowedThrottle()
+        {
+            if (Core.Thrust.LimiterMinThrottle)
+            {
+                return (float)Core.Thrust.MinThrottle;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
         public double MaxAllowedSpeedAfterDt(double dt) =>
             DescentSpeedPolicy.MaxAllowedSpeed(VesselState.CoM + VesselState.orbitalVelocity * dt - MainBody.position,
                 VesselState.surfaceVelocity + dt * VesselState.gravityForce);

--- a/MechJeb2/MechJebModuleLandingAutopilot.cs
+++ b/MechJeb2/MechJebModuleLandingAutopilot.cs
@@ -1,4 +1,4 @@
-extern alias JetBrainsAnnotations;
+﻿extern alias JetBrainsAnnotations;
 using System;
 using KSP.Localization;
 using ModuleWheels;
@@ -426,8 +426,8 @@ namespace MuMech
         {
             //if the atmosphere is thin, the deceleration burn should end
             //500 meters above the landing site to allow for a controlled final descent
-            //MechJebCore.print("DecelerationEndAltitude Vacum " + (500 + LandingAltitude).ToString("F2"));
-            if (!UseAtmosphereToBrake()) return 500 + _landingAltitude;
+            //MechJebCore.print("DecelerationEndAltitude Vacum " + (200 + LandingAltitude).ToString("F2"));
+            if (!UseAtmosphereToBrake()) return 200 + _landingAltitude;
 
             // if the atmosphere is thick, deceleration (meaning freefall through the atmosphere)
             // should end a safe height above the landing site in order to allow braking from terminal velocity

--- a/MechJeb2/MechJebModuleLandingGuidance.cs
+++ b/MechJeb2/MechJebModuleLandingGuidance.cs
@@ -151,6 +151,7 @@ namespace MuMech
                 Core.Landing.RCSAdjustment =
                     GUILayout.Toggle(Core.Landing.RCSAdjustment,
                         Localizer.Format("#MechJeb_LandingGuidance_checkbox4")); //Use RCS for small adjustment
+                Core.Thrust.LimiterMinThrottleInfoItem(); //Toggle to prevent full engine shutdowns
 
                 if (Core.Landing.Enabled)
                 {


### PR DESCRIPTION
Currently, landing guidance loves wasting ignitions on limited ignition engines. It also doesn't wait for a craft to stop rotating before entering timewarp.

This PR adds a mode to limit the minimum throttle to prevent a full engine shutdown whilst the landing autopilot is performing burns. It will now only ignite three times in all cases I've tested.

If you turn off the minimum throttle limit, the old throttling behaviour is restored.

This PR also 
1. Makes MechJeb wait for the craft's rotation to settle before warping.
2. Moves the braking end altitude to 200 meters. 500 meters was excessive (open to reverting this based on a good argument).
3. Removes the warp between the horizontal velocity kill and final descent, which always resulted in the craft crashing, and isn't necessary for a few hundred meter final descent.