### PR TITLE
Add RequestActiveThrottle() API to ThrustController

### DIFF
--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -288,6 +288,17 @@ namespace MuMech
             SetFlightGlobals(0);
         }
 
+        public void RequestActiveThrottle(float target, bool enforceMinimum = true, bool allowZero = false)
+        {
+            if (enforceMinimum && LimiterMinThrottle)
+                if (allowZero && target == 0)
+                    TargetThrottle = 0;
+                else
+                    TargetThrottle = Mathf.Max(target, (float)MinThrottle);
+            else
+                TargetThrottle = target;
+        }
+
         private void SetFlightGlobals(double throttle)
         {
             if (FlightGlobals.ActiveVessel != null && Vessel == FlightGlobals.ActiveVessel)


### PR DESCRIPTION
This is intended to be used by consumers when they want to have a "burn" segment which can throttle down, but for RO/RF the throttle must be kept over the minimum throttle at all times to not waste an ignition.

The exiting min throttle setting only applies to the throttle limiters, which limit max throttle (limiting how much the throttle limiters can limit the throttle).  This API sets a min limit on the requested throttle.

If the minimum throttle is set to zero, or if `allowZero` is set to true then an explicit request of zero will cut the throttle (e.g. for stock).  It would generally be better to call `ThrustOff()` explicitly though rather than to use `RequestActiveThrottle(0, allowZero: true)`.

At some point the codebase should probably have all uses of `TargetThrottle = 0` changed to `ThrustOff()` and then all remaining uses of `TargetThrottle = x` changed to `RequestActiveThrottle(x, enforceMinimum: false)`.  Then the latter could be tweaked as RO/RF bugs are found.