### PR TITLE
Change the logic for speed control when in final descent below 300m with more than 5 m/s horizontal velocity

### DIFF
--- a/MechJeb2/LandingAutopilot/FinalDescent.cs
+++ b/MechJeb2/LandingAutopilot/FinalDescent.cs
@@ -115,12 +115,11 @@ namespace MuMech
                     else
                     {
                         // if we're falling at a significant angle from vertical, our vertical speed might be
-                        // quite small but we might still need to decelerate. Control the total speed instead
+                        // quite small but we might still need to decelerate. Reduce the horizontal speed
                         // by thrusting directly retrograde
                         Core.Thrust.Tmode = MechJebModuleThrustController.TMode.OFF;
                         Core.Attitude.attitudeTo(Vector3d.back, AttitudeReference.SURFACE_VELOCITY, null);
-                        float desiredThrust = desiredSpeed < VesselState.speedSurface ? 1.0f : 0.0f;
-                        Core.Thrust.RequestActiveThrottle(desiredThrust);
+                        Core.Thrust.RequestActiveThrottle(1.0f);
                     }
                 }
 


### PR DESCRIPTION
Currently, when in final descent with too much horizontal velocity, the throttle misbehaves.
This change will actually keep the engines on correctly instead of spamming them so hard they produce no thrust.