### PR TITLE
One more fix to the PVG settings window

### DIFF
--- a/MechJeb2/MechJebModuleAscentPVGSettingsMenu.cs
+++ b/MechJeb2/MechJebModuleAscentPVGSettingsMenu.cs
@@ -47,7 +47,7 @@ namespace MuMech
 
             List<FuelStats> vacStats = Core.StageStats.VacStats;
 
-            if (vacStats.Count > 0 && _ascentSettings.LastStage < vacStats[vacStats.Count - 1].KSPStage)
+            if (vacStats.Count > 0 && _ascentSettings.LastStage <= vacStats[vacStats.Count - 1].KSPStage)
             {
                 GUILayout.BeginVertical(GUI.skin.box);
 


### PR DESCRIPTION
I noticed when flying a rocket with PVG, that during the final stage's burn the stage stats in the PVG settings window disappeared. When the 'last stage' is equal to the bottom-most stage in the Δv stats window, it should be shown.