### PR TITLE
Make BetterController obey control rate limits

### DIFF
--- a/MechJeb2/AttitudeControllers/BetterController.cs
+++ b/MechJeb2/AttitudeControllers/BetterController.cs
@@ -277,7 +277,8 @@ namespace MuMech.AttitudeControllers
                     {
                         _posPID[i].Reset();
                         // v = - sqrt(2 * F * x / m) is target stopping velocity based on distance
-                        _targetOmega[i] = Sqrt(2 * _maxAlpha[i] * (Abs(_error[i]) - effLD)) * Sign(_error[i]);
+                        double v = Sqrt(2 * _maxAlpha[i] * (Abs(_error[i]) - effLD)) * Sign(_error[i]);
+                        _targetOmega[i] = Clamp(v, -maxOmega, maxOmega);
                     }
 
                     if (UseControlRange && _distance * Mathf.Rad2Deg > RollControlRange)


### PR DESCRIPTION
Before, it only used the max stopping time and minimum flip time when in the PID-controlled range; now, it obeys these limits also in the angular-distance-based control region.