### PR TITLE
Maneuver executor fixes

### DIFF
--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -332,7 +332,9 @@ namespace MuMech
 
         private bool Aligned() => AngleFromDirection() < Deg2Rad(1);
 
-        private bool AlignedAndSettled() => Aligned() && Core.vessel.angularVelocity.magnitude < 0.001;
+        private bool AlignedAndSettled() =>
+            Aligned()
+            && Vector3.Scale(Core.vessel.angularVelocity, new Vector3(1f, 0f, 1f)).magnitude < 0.001;
 
         // This returns the angle to the node (in radians), note that you probably don't want to use this outside of
         // stock checks for maneuver termination, and probably never in principia (see SafeCurrentPrincipiaNode()).


### PR DESCRIPTION
- Ignore roll rate when checking if the orientation has settled down (fixes #1981).
- Allow physics timewarp while rotating towards a maneuver node.