### PR TITLE
For hotstaging, sum stages with the same number

### DIFF
--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -432,10 +432,23 @@ namespace MuMech
         private double LastNonZeroDVStageBurnTime()
         {
             _stats.RequestUpdate();
-            for (int mjPhase = _vacStats.Count - 1; mjPhase >= 0; mjPhase--)
+            int kspStage = -1;
+            int mjPhase;
+            double dt = 0f;
+
+            // Find the last MJ phase and corresponding KSP stage with non-zero burn time
+            for (mjPhase = _vacStats.Count - 1; mjPhase >= 0; mjPhase--)
                 if (_vacStats[mjPhase].DeltaTime > 0)
-                    return _vacStats[mjPhase].DeltaTime;
-            return 0;
+                {
+                    kspStage = _vacStats[mjPhase].KSPStage;
+                    break;
+                }
+
+            // Sum the burn time of all MJ phases with the same KSP stage number
+            for (; mjPhase >= 0 && _vacStats[mjPhase].KSPStage == kspStage; mjPhase--)
+                dt += _vacStats[mjPhase].DeltaTime;
+
+            return dt;
         }
 
         // allModuleEngines => IsEngine() && !IsSepratron()


### PR DESCRIPTION
If a stage has ullage motors that light at the same time as the main engine, then hotstaging the _next_ stage does not work properly. Since both the ullage motors and the "regular" engine have the same KSP stage number, hotstaging starts when the ullage motors have less than `HotStagingLeadTime` seconds left to burn, even if the main engine burn time is much longer.

With this change, all burn times with the same KSP stage are added up to calculate the `LastNonZeroDVStageBurnTime`.