### PR TITLE
Fix Classic Ascent with sliders fully left

### DIFF
--- a/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
@@ -357,6 +357,7 @@ namespace MuMech
             else
                 Core.Attitude.attitudeTo(desiredThrustVector, AttitudeReference.INERTIAL_COT, this);
 
+            Core.Attitude.SetActuationControl(true, true, true);
             Core.Attitude.SetAxisControl(true, true, AscentSettings.ForceRoll);
         }
 


### PR DESCRIPTION
It sometimes takes a few ticks before the base game updates the vessel's situation. This means that `VerticalHeadingTo` will disable the actuation controls during this time.

If the vessel switches from `VERTICAL_ASCENT` to `GRAVITY_TURN` before the situation changes, the actuation controls never get re-enabled (`VerticalHeadingTo` never gets called while, according to the game, the vessel has lifted off). This can happen if the pitch start velocity is very small, for example if the auto-turn velocity slider is all the way to the left.

This change makes sure that the actuation controls also get enabled properly while in the `GRAVITY_TURN` phase of flight, by enabling the actuation controls at the same time as the axis controls in the `AttitudeTo` method.

Fixes the root cause of the problem in #2025.