### PR TITLE
PSG computes trajectories with atmospheric drag now

### DIFF
--- a/MechJeb2/MechJebModulePSGGlueBall.cs
+++ b/MechJeb2/MechJebModulePSGGlueBall.cs
@@ -8,9 +8,11 @@ extern alias JetBrainsAnnotations;
 using System;
 using System.Threading.Tasks;
 using MechJebLib.FuelFlowSimulation;
+using MechJebLib.Primitives;
 using MechJebLib.PSG;
 using UnityEngine;
 using static MechJebLib.Utils.Statics;
+using static System.Math;
 
 #nullable enable
 
@@ -200,6 +202,22 @@ namespace MuMech
                   , MainBody.gravParameter, MainBody.Radius)
                 .SetTarget(peR, apR, attR, Deg2Rad(inclination), Deg2Rad(lan), 0, fpa, attachAltFlag, lanflag, false);
 
+            if (MainBody.atmosphere)
+            {
+                // This very crudely fits an exponential between "sea" level and 15% of the way to space to find rho0 and h0
+                double r1 = MainBody.atmosphereDepth * 0.15;
+
+                double rho0 = MainBody.atmDensityASL;
+                double rho1 = MainBody.GetDensity(MainBody.GetPressure(r1), MainBody.GetTemperature(r1));
+
+                double h0   = r1 / Log(rho0 / rho1);
+                double cd   = 0.5;
+                double aRef = 2 * TAU;
+                V3     w    = 2 * PI / MainBody.rotationPeriod * V3.northpole;
+
+                ascentBuilder.AerodynamicConstants(cd, aRef, rho0, h0, w);
+            }
+
             if (Core.Guidance.Solution != null)
                 ascentBuilder.OldSolution(Core.Guidance.Solution);
 
@@ -237,8 +255,8 @@ namespace MuMech
 
                         if (Core.Guidance.IsCoasting())
                         {
-                            maxt = Math.Max(maxt - (VesselState.time - Core.Guidance.StartCoast), 0);
-                            mint = Math.Max(mint - (VesselState.time - Core.Guidance.StartCoast), 0);
+                            maxt = Max(maxt - (VesselState.time - Core.Guidance.StartCoast), 0);
+                            mint = Max(mint - (VesselState.time - Core.Guidance.StartCoast), 0);
                         }
 
                         bool unguidedCoast = IsUnguided(kspStage);

--- a/MechJebLib/PSG/AscentBuilder.cs
+++ b/MechJebLib/PSG/AscentBuilder.cs
@@ -23,9 +23,8 @@ namespace MechJebLib.PSG
             private double    _t0            { get; set; }
             private double    _mu            { get; set; }
             private double    _rbody         { get; set; } = 1.0;
-            private double    _rho0          { get; set; } = 0;
-            private double    _h0            { get; set; } = 0;
-            private double    _cdAref        { get; set; } = 0;
+            private double    _h0            { get; set; }
+            private double    _rho0CdAref    { get; set; }
             private V3        _w             { get; set; } = V3.zero;
             private double    _apR           { get; set; }
             private double    _peR           { get; set; }
@@ -73,12 +72,11 @@ namespace MechJebLib.PSG
                 return this;
             }
 
-            public AscentBuilder AerodynamicConstants(double cdAref, double rho0, double h0, V3 w)
+            public AscentBuilder AerodynamicConstants(double cd, double aRef, double rho0, double h0, V3 w)
             {
-                _rho0   = rho0;
-                _h0     = h0;
-                _cdAref = cdAref;
-                _w      = w;
+                _h0         = h0;
+                _rho0CdAref = cd * aRef * rho0;
+                _w          = w;
                 return this;
             }
 
@@ -148,7 +146,7 @@ namespace MechJebLib.PSG
                     }
                 }
 
-                var problem = new Problem(_r0, _v0, _u0, m0, _t0, _mu, _rbody, _rho0, _h0, _cdAref, _w, terminal);
+                var problem = new Problem(_r0, _v0, _u0, m0, _t0, _mu, _rbody, _h0, _rho0CdAref, _w, terminal);
 
                 var normalizedPhases = new PhaseCollection();
 

--- a/MechJebLib/PSG/AscentProblem.cs
+++ b/MechJebLib/PSG/AscentProblem.cs
@@ -280,17 +280,16 @@ namespace MechJebLib.PSG
                     BtIdx = thisPhase.BtIdx()
                 };
 
-                double rho0   = _optimizer._problem.Rho0;
-                double cdAref = _optimizer._problem.CdAref;
-                double rBody  = _optimizer._problem.RBody;
-                double h0     = _optimizer._problem.H0;
-                V3 w          = _optimizer._problem.W;
+                double rho0CdAref = _optimizer._problem.Rho0CdAref;
+                double rBody      = _optimizer._problem.RBody;
+                double h0         = _optimizer._problem.H0;
+                V3     w          = _optimizer._problem.W;
 
                 DualV3 VDot(ref HermiteSimpsonDualPoint d)
                 {
                     DualV3 vr   = d.V - DualV3.Cross(w, d.R);
-                    Dual   rho  = rho0 * Dual.Exp(-(d.R.magnitude - rBody) / h0);
-                    DualV3 drag = 0.5 * cdAref * rho * vr.sqrMagnitude * vr.normalized;
+                    var    rho  = Dual.Exp(-(d.R.magnitude - rBody) / h0);
+                    DualV3 drag = 0.5 * rho0CdAref * rho * vr.sqrMagnitude * vr.normalized;
                     Dual   r3   = d.R.sqrMagnitude * d.R.magnitude;
                     return -d.R / r3 + thrust / d.M * d.U - drag / d.M;
                 }
@@ -301,7 +300,7 @@ namespace MechJebLib.PSG
                     return -d.R / r3 + thrust / d.M * d.U;
                 }
 
-                if (h0 > 0 && rho0 > 0 && cdAref > 0)
+                if (h0 > 0 && rho0CdAref > 0)
                     ci = ApplyHermiteSimpsonDynamics(f, j, ci, VDot, point, indexes, _optimizer.N);
                 else
                     ci = ApplyHermiteSimpsonDynamics(f, j, ci, VDotVacuum, point, indexes, _optimizer.N);

--- a/MechJebLib/PSG/Problem.cs
+++ b/MechJebLib/PSG/Problem.cs
@@ -19,26 +19,24 @@ namespace MechJebLib.PSG
         public readonly V3        U0;
         public readonly double    Mu;
         public readonly double    RBody;
-        public readonly double    Rho0;
-        public readonly double    CdAref;
+        public readonly double    Rho0CdAref;
         public readonly double    H0;
         public readonly V3        W;
 
-        public Problem(V3 r0, V3 v0, V3 u0, double m0, double t0, double mu, double rbody, double rho0, double h0, double cdAref, V3 w, ITerminal terminal)
+        public Problem(V3 r0, V3 v0, V3 u0, double m0, double t0, double mu, double rbody, double h0, double rho0CdAref, V3 w, ITerminal terminal)
         {
-            Scale    = Scale.Create(mu, r0.magnitude, m0);
-            Mu       = mu;
-            R0       = r0 / Scale.LengthScale;
-            V0       = v0 / Scale.VelocityScale;
-            M0       = m0 / Scale.MassScale;
-            U0       = u0;
-            RBody    = rbody / Scale.LengthScale;
-            Rho0     = rho0 / Scale.DensityScale;
-            H0       = h0 / Scale.LengthScale;
-            CdAref   = cdAref / Scale.AreaScale;
-            Terminal = terminal.Rescale(Scale);
-            T0       = t0;
-            W        = w * Scale.TimeScale;
+            Scale      = Scale.Create(mu, r0.magnitude, m0);
+            Mu         = mu;
+            R0         = r0 / Scale.LengthScale;
+            V0         = v0 / Scale.VelocityScale;
+            M0         = m0 / Scale.MassScale;
+            U0         = u0;
+            RBody      = rbody / Scale.LengthScale;
+            H0         = h0 / Scale.LengthScale;
+            Rho0CdAref = rho0CdAref / Scale.MassScale * Scale.LengthScale;
+            Terminal   = terminal.Rescale(Scale);
+            T0         = t0;
+            W          = w * Scale.TimeScale;
         }
     }
 }

--- a/MechJebLib/PSG/Terminal/FlightPathAngle3Energy.cs
+++ b/MechJebLib/PSG/Terminal/FlightPathAngle3Energy.cs
@@ -6,7 +6,6 @@
 using MechJebLib.Primitives;
 using static MechJebLib.Utils.Statics;
 using static System.Math;
-using static MechJebLib.Utils.Statics;
 using static MechJebLib.Utils.AutoDiff;
 
 namespace MechJebLib.PSG.Terminal
@@ -35,10 +34,10 @@ namespace MechJebLib.PSG.Terminal
         {
             double gammaT = _gammaT;
             double rT     = _rT;
-            double incT = _incT;
+            double incT   = _incT;
 
-            var    rf     = V3.CopyFromIndices(x, ri);
-            var    vf     = V3.CopyFromIndices(x, vi);
+            var rf = V3.CopyFromIndices(x, ri);
+            var vf = V3.CopyFromIndices(x, vi);
 
             ci = ApplyScalarConstraintV3(f, j, ci, FlightPathAngleConstraint, new[] { rf, vf }, new[] { ri, vi });
             ci = ApplyScalarConstraintV3(f, j, ci, RadiusConstraint, new[] { rf }, new[] { ri });

--- a/MechJebLibTest/PSGTests/AscentTests/RealRocketTests.cs
+++ b/MechJebLibTest/PSGTests/AscentTests/RealRocketTests.cs
@@ -43,7 +43,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
             double ApR = Astro.ApoapsisFromKeplerian(smaT, eccT);
 
             Ascent ascent = Ascent.Builder()
-                .AerodynamicConstants(cd * aref, rho0, h0, w)
+                .AerodynamicConstants(cd, aref, rho0, h0, w)
                 .AddStageUsingFinalMassAndThrust(301454.000000, 171863.885057, 4854100.000000, 75.200000, 4, 4)
                 .AddStageUsingFinalMassAndThrust(158183.885057, 79623.770115, 2968600.000000, 75.200000, 3, 3)
                 .AddStageUsingFinalMassAndThrust(72783.770115, 32294.000000, 1083100.000000, 110.600000, 2, 2)


### PR DESCRIPTION
- Constants are currently fixed to a delta3 model and haven't been pushed up into the API
- Cd is fixed to 0.5
- Aref is fixed to 4*pi m^3

Test on one of my rockets cut the dv discrepancy down to 100m/s between the pad prediction and actually reaching orbit.