### PR TITLE
Add Cd and Aref boxes to PSG settings

### DIFF
--- a/MechJeb2.sln.DotSettings
+++ b/MechJeb2.sln.DotSettings
@@ -16,6 +16,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FFS/@EntryIndexedValue">FFS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FORE/@EntryIndexedValue">FORE</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FPA/@EntryIndexedValue">FPA</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GTO/@EntryIndexedValue">GTO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HS/@EntryIndexedValue">HS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IPM/@EntryIndexedValue">IPM</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IPVG/@EntryIndexedValue">IPVG</s:String>

--- a/MechJeb2/MechJebModuleAscentPSGSettingsMenu.cs
+++ b/MechJeb2/MechJebModuleAscentPSGSettingsMenu.cs
@@ -114,6 +114,10 @@ namespace MuMech
             GUILayout.EndVertical();
 
             GUILayout.BeginVertical(GUI.skin.box);
+            GUILayout.BeginHorizontal();
+            GuiUtils.SimpleTextBox("Cd:", _ascentSettings.Cd, "", 40);
+            GuiUtils.SimpleTextBox("Aref:", _ascentSettings.Aref, "m²", 40);
+            GUILayout.EndHorizontal();
             GuiUtils.SimpleTextBox(CachedLocalizer.Instance.MechJebAscentLabel13, _ascentSettings.PitchStartVelocity, "m/s",
                 40);                                                                                                     //Booster Pitch start:
             GuiUtils.SimpleTextBox(CachedLocalizer.Instance.MechJebAscentLabel14, _ascentSettings.PitchRate, "°/s", 40); //Booster Pitch rate:

--- a/MechJeb2/MechJebModuleAscentSettings.cs
+++ b/MechJeb2/MechJebModuleAscentSettings.cs
@@ -237,6 +237,12 @@ namespace MuMech
 
         public bool OptimizeStageFlag;
 
+        [Persistent(pass = (int)(Pass.TYPE | Pass.GLOBAL))]
+        public readonly EditableDouble Cd = new EditableDouble(0.5);
+
+        [Persistent(pass = (int)(Pass.TYPE | Pass.GLOBAL))]
+        public readonly EditableDouble Aref = new EditableDouble(0.0);
+
         /*
          * some non-persisted values
          */

--- a/MechJeb2/MechJebModulePSGGlueBall.cs
+++ b/MechJeb2/MechJebModulePSGGlueBall.cs
@@ -211,8 +211,8 @@ namespace MuMech
                 double rho1 = MainBody.GetDensity(MainBody.GetPressure(r1), MainBody.GetTemperature(r1));
 
                 double h0   = r1 / Log(rho0 / rho1);
-                double cd   = 0.5;
-                double aRef = 2 * TAU;
+                double cd   = _ascentSettings.Cd;
+                double aRef = _ascentSettings.Aref;
                 V3     w    = 2 * PI / MainBody.rotationPeriod * V3.northpole;
 
                 ascentBuilder.AerodynamicConstants(cd, aRef, rho0, h0, w);

--- a/MechJebLib/PSG/AscentBuilder.cs
+++ b/MechJebLib/PSG/AscentBuilder.cs
@@ -72,6 +72,17 @@ namespace MechJebLib.PSG
                 return this;
             }
 
+            public AscentBuilder AddStageUsingFinalMassThrustAndIsp(double m0, double mf, double thrust, double isp, int kspStage,
+                int mjPhase, bool unguided = false, bool allowShutdown = true, bool massContinuity = false)
+            {
+                DebugPrint(
+                    $"[MechJebLib.AscentBuilder] AddStageUsingThrust({m0}, {mf}, {thrust}, {isp}, {kspStage}, {mjPhase}, {(unguided ? "true" : "false")}, {(allowShutdown ? "true" : "false")})");
+
+                _phases.Add(Phase.NewStageUsingFinalMassThrustAndIsp(m0, mf, thrust, isp, kspStage, mjPhase, unguided, allowShutdown, massContinuity));
+
+                return this;
+            }
+
             public AscentBuilder AerodynamicConstants(double cd, double aRef, double rho0, double h0, V3 w)
             {
                 _h0         = h0;

--- a/MechJebLib/PSG/Phase.cs
+++ b/MechJebLib/PSG/Phase.cs
@@ -146,6 +146,25 @@ namespace MechJebLib.PSG
             return phase;
         }
 
+        public static Phase NewStageUsingFinalMassThrustAndIsp(double m0, double mf, double thrust, double isp, int kspStage, int mjPhase,
+            bool unguided = false, bool allowShutdown = true, bool massContinuity = false)
+        {
+            Check.PositiveFinite(m0);
+            Check.PositiveFinite(thrust);
+            Check.PositiveFinite(mf);
+            Check.PositiveFinite(isp);
+
+            double mdot = thrust / (isp * G0);
+            double bt   = (m0 - mf) / mdot;
+
+            Check.PositiveFinite(mdot);
+            Check.PositiveFinite(isp);
+
+            var phase = new Phase(m0, thrust, isp, mf, bt, kspStage, mjPhase) { AllowShutdown = allowShutdown, Unguided = unguided, MassContinuity = massContinuity };
+
+            return phase;
+        }
+
         public static Phase NewCoast(double m0, double mint, double maxt, int kspStage, int mjPhase, bool unguided = false, bool massContinuity = false)
         {
             var phase = new Phase(m0, 0, double.PositiveInfinity, m0, mint, kspStage, mjPhase) { mint = mint, maxt = maxt, Unguided = unguided, MassContinuity = massContinuity };

--- a/MechJebLibTest/PSGTests/AscentTests/RealRocketTests.cs
+++ b/MechJebLibTest/PSGTests/AscentTests/RealRocketTests.cs
@@ -88,5 +88,85 @@ namespace MechJebLibTest.PSGTests.AscentTests
             lanf.ShouldEqual(lanT, 1e-2);
             argpf.ShouldEqual(argpT, 1e-2);
         }
+
+        [Fact]
+        public void Falcon9GTO()
+        {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
+            var    r0    = new V3(5605222.973039, 0.000000, 3043387.760956);
+            var    v0    = new V3(0.000000, 408.739353, 0.000000);
+            double t0    = 0;
+            double rbody = 6378145;
+            double smaT  = 24361140;
+            double eccT  = 0.7308;
+            double incT  = Deg2Rad(28.5);
+            double lanT  = Deg2Rad(269.8);
+            double argpT = Deg2Rad(130.5);
+            double mu    = 3.986012e14;
+            double aref  = Powi(3.7 / 2, 2) * PI;
+            double cd    = 0.5;
+            double rho0  = 1.225;
+            double h0    = 7200;
+            V3     w     = 7.29211585e-5 * V3.northpole;
+
+            double PeR = Astro.PeriapsisFromKeplerian(smaT, eccT);
+            double ApR = Astro.ApoapsisFromKeplerian(smaT, eccT);
+
+            double firstStageDry  = 22200;
+            double firstStageWet  = 433100;
+            double firstIsp       = 310;
+            double firstThrust    = 7607000;
+            double secondStageDry = 4000;
+            double secondStageWet = 111500;
+            double secondIsp      = 348;
+            double secondThrust   = 934000;
+            double payload        = 8300;
+
+            Ascent ascent = Ascent.Builder()
+                .AerodynamicConstants(cd, aref, rho0, h0, w)
+                .AddStageUsingFinalMassThrustAndIsp(payload+secondStageWet+firstStageWet, payload+secondStageWet+firstStageDry, firstThrust, firstIsp, 2, 2, allowShutdown:false)
+                .AddStageUsingFinalMassThrustAndIsp(payload+secondStageWet, payload+secondStageDry, secondThrust, secondIsp, 1, 1)
+                .AddCoast(payload+secondStageWet, 0, 1200, 1, 1, massContinuity: true)
+                .AddStageUsingFinalMassThrustAndIsp(payload+secondStageWet, payload+secondStageDry, secondThrust, secondIsp, 1, 1, massContinuity: true)
+                .Initial(r0, v0, r0.normalized, t0, mu, rbody)
+                .SetTarget(PeR, ApR, PeR, incT, lanT, argpT, 0, false, true, true)
+                .Build();
+
+            ascent.Run();
+
+            Optimizer      psg      = ascent.GetOptimizer() ?? throw new Exception("null optimizer");
+            using Solution solution = psg.Solution ?? throw new Exception("null solution");
+
+            (V3 rf, V3 vf) = solution.TerminalStateVectors();
+
+            (double smaf, double eccf, double incf, double lanf, double argpf, double nuf, _) =
+                Astro.KeplerianFromStateVectors(mu, rf, vf);
+
+            solution.R(0).ShouldEqual(r0, 1e-9);
+            solution.V(0).ShouldEqual(v0, 1e-9);
+            solution.M(0).ShouldEqual(payload+secondStageWet+firstStageWet, 1e-9);
+
+            //solution.Tgo(solution.T0, 0).ShouldEqual(75.200000, 1e-3);
+            //solution.Tgo(solution.T0, 1).ShouldEqual(75.200000, 1e-3);
+            solution.Tgo(solution.T0, 2).ShouldEqual(110.600000, 1e-3);
+            //solution.Tgo(solution.T0, 3).ShouldBePositive();
+
+            psg.PrimalFeasibility.ShouldBeZero(1e-5);
+            solution.Tgo(0).ShouldEqual(924.139, 1e-3);
+            //solution.Vgo(0).ShouldEqual(8518.1366714811684, 1e-3);
+
+            //solution.U(0).normalized.ShouldEqual(new V3(0.69734975209707417, 0.6074944955387559, 0.38033374967291772), 1e-2);
+
+            double aprf = Astro.ApoapsisFromKeplerian(smaf, eccf);
+            double perf = Astro.PeriapsisFromKeplerian(smaf, eccf);
+
+            smaf.ShouldEqual(smaT, 1e-5);
+            eccf.ShouldEqual(eccT, 1e-5);
+            perf.ShouldEqual(PeR, 1e-5);
+            aprf.ShouldEqual(ApR, 1e-5);
+            incf.ShouldEqual(incT, 1e-5);
+            lanf.ShouldEqual(lanT, 1e-2);
+            argpf.ShouldEqual(argpT, 1e-2);
+        }
     }
 }


### PR DESCRIPTION
Aref is set to zero initially so aero will be turned off unless you "turn it on" by putting the correct value in for the rocket.

I believe the only way to find the correct values for these is going to be FAR analysis?

But figuring it out by hand based on the diameter of the rocket and assuming 0.5 for Cd should work reasonably well.