### PR TITLE
fix two strings missing in en and fr localization

### DIFF
--- a/Localization/en-us.cfg
+++ b/Localization/en-us.cfg
@@ -1194,6 +1194,8 @@ Localization
         #MechJeb_RelativeInclination = Relative inclination
         #MechJeb_TimeToAN = Time to AN
         #MechJeb_TimeToDN = Time to DN
+        #MechJeb_TimeToEquatorialAN = Time to eq. AN
+        #MechJeb_TimeToEquatorialDN = Time to eq. DN
         #MechJeb_CircularOrbitSpeed = Circular orbit speed
         #MechJeb_StageDv_vac = Stage ΔV (vac)
         #MechJeb_StageDV_atmo = Stage ΔV (atmo)

--- a/Localization/fr-fr.cfg
+++ b/Localization/fr-fr.cfg
@@ -1196,6 +1196,8 @@ Localization
         #MechJeb_RelativeInclination = Inclinaison relative
         #MechJeb_TimeToAN = Temps avant NA
         #MechJeb_TimeToDN = Temps avant ND
+        #MechJeb_TimeToEquatorialAN = Temps avant NA éq.
+        #MechJeb_TimeToEquatorialDN = Temps avant ND éq.
         #MechJeb_CircularOrbitSpeed = Vitesse d'orbite circulaire
         #MechJeb_StageDv_vac = ΔV de l'étage (vide)
         #MechJeb_StageDV_atmo = ΔV de l'étage (atmo)


### PR DESCRIPTION
The two strings `#MechJeb_TimeToEquatorialAN` and `#MechJeb_TimeToEquatorialDN` were missing in _en_ and _fr_ (but already present in the other ones).
Note: Used AI to translate to _fr_.
