### PR TITLE
Remove quotation marks from body names in LandingSites.cfg

### DIFF
--- a/LandingSites.cfg
+++ b/LandingSites.cfg
@@ -10,14 +10,14 @@ Site
 name = KSC Pad
 latitude = -0.09694444
 longitude = -74.5575
-// body = "Kerbin" // if not set defaults to the starting world (Kerbin, Earth for RSS)
+// body = Kerbin // if not set defaults to the starting world (Kerbin, Earth for RSS)
 }
 Site
 {
 name = VAB
 latitude = -0.09694444
 longitude = -74.617
-// body = "Kerbin" // if not set defaults to the starting world (Kerbin, Earth for RSS)
+// body = Kerbin // if not set defaults to the starting world (Kerbin, Earth for RSS)
 }
 Site
 {
@@ -88,7 +88,7 @@ Runways
 Runway
 {
 name = KSC Runway 09
-body = "Kerbin"
+body = Kerbin
 touchdown = 100.0
 start
 {
@@ -106,7 +106,7 @@ altitude = 69
 Runway
 {
 name = KSC Runway 27
-body = "Kerbin" // if not set defaults to the starting world (Kerbin, Earth for RSS)
+body = Kerbin // if not set defaults to the starting world (Kerbin, Earth for RSS)
 touchdown = 100.0 // distance in meters from start point
 start
 {
@@ -124,7 +124,7 @@ altitude = 69
 Runway
 {
 name = Island Runway 09
-body = "Kerbin"
+body = Kerbin
 touchdown = 25.0
 start
 {
@@ -142,7 +142,7 @@ altitude = 132
 Runway
 {
 name = Island Runway 27
-body = "Kerbin"
+body = Kerbin
 touchdown = 25.0
 end
 {


### PR DESCRIPTION
The quotation marks around the body name is a syntax error that is masked by the fact that KSC and Island runways are hard-coded in `MechJebModuleSpaceplaneAutopilot.cs`.

I found out while adding extra runways from Kerbin Side, using these default ones as a examples.

The module silently skips runways with syntax errors, which made debugging this take a bit longer than it should have.