### PR TITLE
Add larger increments and smooth control to SmartASS

### DIFF
--- a/MechJeb2/MechJebModuleSmartASS.cs
+++ b/MechJeb2/MechJebModuleSmartASS.cs
@@ -163,6 +163,8 @@ namespace MuMech
         private Quaternion targetAttitude = Quaternion.identity;
         private AttitudeReference targetReference = AttitudeReference.ORBIT;
 
+        private static readonly double LARGE_INCREMENT = 10.0;
+
         // Current attitude/direction (for smooth interpolation)
         private Vector3d curDirection = Vector3d.zero;
         private Quaternion curAttitude = Quaternion.identity;
@@ -321,7 +323,7 @@ namespace MuMech
 
                             if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
                             {
-                                srfHdg -= 10;
+                                srfHdg -= LARGE_INCREMENT;
                                 changed = true;
                             }
 
@@ -339,7 +341,7 @@ namespace MuMech
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
-                                srfHdg += 10;
+                                srfHdg += LARGE_INCREMENT;
                                 changed = true;
                             }
 
@@ -362,7 +364,7 @@ namespace MuMech
 
                             if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
                             {
-                                srfPit -= 10;
+                                srfPit -= LARGE_INCREMENT;
                                 changed = true;
                             }
 
@@ -380,7 +382,7 @@ namespace MuMech
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
-                                srfPit += 10;
+                                srfPit += LARGE_INCREMENT;
                                 changed = true;
                             }
 
@@ -403,7 +405,7 @@ namespace MuMech
 
                             if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
                             {
-                                srfRol -= 10;
+                                srfRol -= LARGE_INCREMENT;
                                 changed = true;
                             }
 
@@ -422,7 +424,7 @@ namespace MuMech
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
-                                srfRol += 10;
+                                srfRol += LARGE_INCREMENT;
                                 changed = true;
                             }
 
@@ -464,7 +466,7 @@ namespace MuMech
 
                             if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
                             {
-                                srfVelRol -= 10;
+                                srfVelRol -= LARGE_INCREMENT;
                                 changed = true;
                             }
 
@@ -482,7 +484,7 @@ namespace MuMech
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
-                                srfVelRol += 10;
+                                srfVelRol += LARGE_INCREMENT;
                                 changed = true;
                             }
 
@@ -504,7 +506,7 @@ namespace MuMech
                             GuiUtils.SimpleTextBox("PIT", srfVelPit, "°", 37);
                             if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
                             {
-                                srfVelPit -= 10;
+                                srfVelPit -= LARGE_INCREMENT;
                                 changed = true;
                             }
 
@@ -522,7 +524,7 @@ namespace MuMech
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
-                                srfVelPit += 10;
+                                srfVelPit += LARGE_INCREMENT;
                                 changed = true;
                             }
 
@@ -545,7 +547,7 @@ namespace MuMech
 
                             if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
                             {
-                                srfVelYaw -= 10;
+                                srfVelYaw -= LARGE_INCREMENT;
                                 changed = true;
                             }
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
@@ -563,7 +565,7 @@ namespace MuMech
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
-                                srfVelYaw += 10;
+                                srfVelYaw += LARGE_INCREMENT;
                                 changed = true;
                             }
 

--- a/MechJeb2/MechJebModuleSmartASS.cs
+++ b/MechJeb2/MechJebModuleSmartASS.cs
@@ -152,7 +152,20 @@ namespace MuMech
 
         [Persistent(pass = (int)Pass.GLOBAL)]
         public bool autoDisableSmartASS = true;
+        [Persistent(pass = (int)Pass.LOCAL)]
+        public bool smoothControl = false;
 
+        [Persistent(pass = (int)Pass.LOCAL)]
+        public EditableDouble degreesPerSecond = new EditableDouble(10);
+
+        // Target attitude/direction (what we want to achieve)
+        private Vector3d targetDirection = Vector3d.zero;
+        private Quaternion targetAttitude = Quaternion.identity;
+        private AttitudeReference targetReference = AttitudeReference.ORBIT;
+
+        // Current attitude/direction (for smooth interpolation)
+        private Vector3d curDirection = Vector3d.zero;
+        private Quaternion curAttitude = Quaternion.identity;
         [GeneralInfoItem("#MechJeb_DisableSmartACSAutomatically", InfoItem.Category.Misc)] //Disable SmartACS automatically
         public void AutoDisableSmartASS() =>
             autoDisableSmartASS = GUILayout.Toggle(autoDisableSmartASS,
@@ -211,6 +224,7 @@ namespace MuMech
 
         protected override void WindowGUI(int windowID)
         {
+            bool hasSmoothControl = false;  // Local variable for current frame
             if (btNormal == null)
             {
                 btNormal                    = new GUIStyle(GUI.skin.button);
@@ -310,34 +324,34 @@ namespace MuMech
                                 srfHdg -= 10;
                                 changed = true;
                             }
-                            
+
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
-                                srfHdg  -= val;
-                                changed =  true;
+                                srfHdg -= val;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
-                                srfHdg  += val;
-                                changed =  true;
+                                srfHdg += val;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
-                                srfHdg  += 10;
-                                changed =  true;
+                                srfHdg += 10;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
                             {
-                                srfHdg  = 0;
+                                srfHdg = 0;
                                 changed = true;
                             }
 
                             if (GUILayout.Button("90", GUILayout.Width(35)))
                             {
-                                srfHdg  = 90;
+                                srfHdg = 90;
                                 changed = true;
                             }
 
@@ -345,40 +359,40 @@ namespace MuMech
                             GUILayout.BeginHorizontal();
                             forcePitch = GUILayout.Toggle(forcePitch, "", GUILayout.ExpandWidth(false));
                             GuiUtils.SimpleTextBox("PIT", srfPit, "°", 37);
-                            
+
                             if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
                             {
                                 srfPit -= 10;
                                 changed = true;
                             }
-                            
+
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
-                                srfPit  -= val;
-                                changed =  true;
+                                srfPit -= val;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
-                                srfPit  += val;
-                                changed =  true;
+                                srfPit += val;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
-                                srfPit  += 10;
-                                changed =  true;
+                                srfPit += 10;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
                             {
-                                srfPit  = 0;
+                                srfPit = 0;
                                 changed = true;
                             }
 
                             if (GUILayout.Button("90", GUILayout.Width(35)))
                             {
-                                srfPit  = 90;
+                                srfPit = 90;
                                 changed = true;
                             }
 
@@ -392,39 +406,42 @@ namespace MuMech
                                 srfRol -= 10;
                                 changed = true;
                             }
-                            
+
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
-                                srfRol  -= val;
-                                changed =  true;
+                                srfRol -= val;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
-                                srfRol  += val;
-                                changed =  true;
+                                srfRol += val;
+                                changed = true;
                             }
 
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
-                                srfRol  += 10;
-                                changed =  true;
+                                srfRol += 10;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
                             {
-                                srfRol  = 0;
+                                srfRol = 0;
                                 changed = true;
                             }
 
                             if (GUILayout.Button("180", GUILayout.Width(35)))
                             {
-                                srfRol  = 180;
+                                srfRol = 180;
                                 changed = true;
                             }
 
                             GUILayout.EndHorizontal();
+
+                            DisplaySmoothControlUI(ref hasSmoothControl);
+
                             if (GUILayout.Button(Localizer.Format("#MechJeb_SmartASS_button58")))
                             {
                                 // "EXECUTE"
@@ -450,35 +467,35 @@ namespace MuMech
                                 srfVelRol -= 10;
                                 changed = true;
                             }
-                            
+
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelRol -= val;
-                                changed   =  true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelRol += val;
-                                changed   =  true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelRol += 10;
-                                changed   =  true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelRol = -VesselState.vesselRoll.Value;
-                                changed   = true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelRol = 0;
-                                changed   = true;
+                                changed = true;
                             }
 
                             GUILayout.EndHorizontal();
@@ -488,81 +505,84 @@ namespace MuMech
                             if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelPit -= 10;
-                                changed   =  true;
+                                changed = true;
                             }
-                            
+
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelPit -= val;
-                                changed   =  true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelPit += val;
-                                changed   =  true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelPit += 10;
-                                changed   =  true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelPit = VesselState.AoA.Value;
-                                changed   = true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelPit = 0;
-                                changed   = true;
+                                changed = true;
                             }
 
                             GUILayout.EndHorizontal();
                             GUILayout.BeginHorizontal();
                             forceYaw = GUILayout.Toggle(forceYaw, "", GUILayout.ExpandWidth(false));
                             GuiUtils.SimpleTextBox("YAW", srfVelYaw, "°", 37);
-                            
+
                             if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelYaw -= 10;
-                                changed   =  true;
+                                changed = true;
                             }
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelYaw -= val;
-                                changed   =  true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelYaw += val;
-                                changed   =  true;
+                                changed = true;
                             }
 
 
                             if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelYaw += 10;
-                                changed   =  true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelYaw = -VesselState.AoS.Value;
-                                changed   = true;
+                                changed = true;
                             }
 
                             if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelYaw = 0;
-                                changed   = true;
+                                changed = true;
                             }
 
                             GUILayout.EndHorizontal();
+
+                            DisplaySmoothControlUI(ref hasSmoothControl);
+
                             if (GUILayout.Button(Localizer.Format("#MechJeb_SmartASS_button58"))) //"EXECUTE"
                             {
                                 Engage();
@@ -572,6 +592,7 @@ namespace MuMech
                             {
                                 Engage(false);
                             }
+
 
                             Core.Attitude.SetAxisControl(forcePitch, forceYaw, forceRol);
                         }
@@ -618,11 +639,26 @@ namespace MuMech
                     case Mode.AUTO:
                         break;
                 }
+                
+                // Disable smooth control for modes that don't have it
+                if (!hasSmoothControl)
+                {
+                    smoothControl = false;
+                }
 
                 GUILayout.EndVertical();
             }
 
             base.WindowGUI(windowID);
+        }
+
+        private void DisplaySmoothControlUI(ref bool hasSmoothControl)
+        {
+            GUILayout.BeginHorizontal();
+            hasSmoothControl = true;
+            smoothControl = GUILayout.Toggle(smoothControl, "Smooth Control:", GUILayout.ExpandWidth(false));
+            GuiUtils.SimpleTextBox("", degreesPerSecond, "°/s", 40);
+            GUILayout.EndHorizontal();
         }
 
         public void Engage(bool resetPID = true)
@@ -736,12 +772,98 @@ namespace MuMech
                 direction = Vector3d.zero;
             }
 
-            if (direction != Vector3d.zero)
-                Core.Attitude.attitudeTo(direction, reference, this);
+            // Store target values
+            targetDirection = direction;
+            targetAttitude = attitude;
+            targetReference = reference;
+
+            // If smooth control is enabled, initialize current values with actual vessel orientation
+            if (smoothControl)
+            {
+                // Get the reference rotation for the current mode
+                QuaternionD refRotation = Core.Attitude.attitudeGetReferenceRotation(reference);
+                QuaternionD vesselRotation = QuaternionD.LookRotation(Part.vessel.GetTransform().up, -Part.vessel.GetTransform().forward);
+                
+                // Get the vessel's current attitude in the reference frame
+                QuaternionD vesselAttitudeInRef = QuaternionD.Inverse(refRotation) * vesselRotation;
+
+                if (direction != Vector3d.zero)
+                {
+                    // For direction-based targets, the vessel's current direction is forward in its reference frame
+                    curDirection = Vector3d.forward;
+                    curAttitude = Quaternion.identity;
+                }
+                else
+                {
+                    // For attitude-based targets, use the actual vessel attitude in this reference frame
+                    curDirection = Vector3d.zero;
+                    curAttitude = (Quaternion)vesselAttitudeInRef;
+                }
+
+                // Call attitudeTo with current values, smooth transition will take over in OnFixedUpdate
+                if (curDirection != Vector3d.zero)
+                    Core.Attitude.attitudeTo(curDirection, targetReference, this);
+                else
+                    Core.Attitude.attitudeTo(curAttitude, targetReference, this);
+            }
             else
-                Core.Attitude.attitudeTo(attitude, reference, this);
+            {
+                // Without smooth control, apply attitude immediately
+                if (direction != Vector3d.zero)
+                    Core.Attitude.attitudeTo(direction, reference, this);
+                else
+                    Core.Attitude.attitudeTo(attitude, reference, this);
+            }
 
             if (resetPID) { Core.Attitude.Controller.Reset(); }
+        }
+
+        public override void OnFixedUpdate()
+        {
+            base.OnFixedUpdate();
+
+            if (!smoothControl || target == Target.OFF || !Core.Attitude.Users.Contains(this)) {
+                // Just make sure that if we randomly turn on smooth control, it won't cause weird behavior
+                // by jumping to some random attitude because the current values are out of date
+                curDirection = targetDirection;
+                curAttitude = targetAttitude;
+            } 
+            // Handle smooth transitions if enabled and SmartASS is still controlling
+            else
+            {
+                float degreesThisFrame = (float)degreesPerSecond * Time.fixedDeltaTime;
+
+                if (targetDirection != Vector3d.zero && curDirection != Vector3d.zero)
+                {
+                    // Smooth interpolation of direction vectors
+                    float angularDistance = (float)Vector3d.Angle(curDirection, targetDirection);
+                    if (degreesThisFrame < angularDistance && angularDistance > 0.01f)
+                    {
+                        float stepSize = Mathf.Clamp01(degreesThisFrame / angularDistance);
+                        curDirection = Vector3d.Slerp(curDirection, targetDirection, stepSize);
+                    }
+                    else
+                    {
+                        curDirection = targetDirection;
+                    }
+                    Core.Attitude.attitudeTo(curDirection, targetReference, this);
+                }
+                else
+                {
+                    // Smooth interpolation of quaternions
+                    float angularDistance = Quaternion.Angle(curAttitude, targetAttitude);
+                    if (degreesThisFrame < angularDistance && angularDistance > 0.01f)
+                    {
+                        float stepSize = Mathf.Clamp01(degreesThisFrame / angularDistance);
+                        curAttitude = Quaternion.Slerp(curAttitude, targetAttitude, stepSize);
+                    }
+                    else
+                    {
+                        curAttitude = targetAttitude;
+                    }
+                    Core.Attitude.attitudeTo(curAttitude, targetReference, this);
+                }
+            }
         }
 
         protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(180), GUILayout.Height(100) };

--- a/MechJeb2/MechJebModuleSmartASS.cs
+++ b/MechJeb2/MechJebModuleSmartASS.cs
@@ -304,6 +304,13 @@ namespace MuMech
                             GUILayout.BeginHorizontal();
                             forceYaw = GUILayout.Toggle(forceYaw, "", GUILayout.ExpandWidth(false));
                             GuiUtils.SimpleTextBox("HDG", srfHdg, "°", 37);
+
+                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            {
+                                srfHdg -= 10;
+                                changed = true;
+                            }
+                            
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
                                 srfHdg  -= val;
@@ -313,6 +320,12 @@ namespace MuMech
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
                                 srfHdg  += val;
+                                changed =  true;
+                            }
+
+                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            {
+                                srfHdg  += 10;
                                 changed =  true;
                             }
 
@@ -332,6 +345,13 @@ namespace MuMech
                             GUILayout.BeginHorizontal();
                             forcePitch = GUILayout.Toggle(forcePitch, "", GUILayout.ExpandWidth(false));
                             GuiUtils.SimpleTextBox("PIT", srfPit, "°", 37);
+                            
+                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            {
+                                srfPit -= 10;
+                                changed = true;
+                            }
+                            
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
                                 srfPit  -= val;
@@ -341,6 +361,12 @@ namespace MuMech
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
                                 srfPit  += val;
+                                changed =  true;
+                            }
+
+                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            {
+                                srfPit  += 10;
                                 changed =  true;
                             }
 
@@ -360,6 +386,13 @@ namespace MuMech
                             GUILayout.BeginHorizontal();
                             forceRol = GUILayout.Toggle(forceRol, "", GUILayout.ExpandWidth(false));
                             GuiUtils.SimpleTextBox("ROL", srfRol, "°", 37);
+
+                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            {
+                                srfRol -= 10;
+                                changed = true;
+                            }
+                            
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
                                 srfRol  -= val;
@@ -369,6 +402,13 @@ namespace MuMech
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
                                 srfRol  += val;
+                                changed =  true;
+                            }
+
+
+                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            {
+                                srfRol  += 10;
                                 changed =  true;
                             }
 
@@ -404,6 +444,13 @@ namespace MuMech
                             GUILayout.BeginHorizontal();
                             forceRol = GUILayout.Toggle(forceRol, "", GUILayout.ExpandWidth(false));
                             GuiUtils.SimpleTextBox("ROL", srfVelRol, "°", 37);
+
+                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            {
+                                srfVelRol -= 10;
+                                changed = true;
+                            }
+                            
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelRol -= val;
@@ -413,6 +460,12 @@ namespace MuMech
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelRol += val;
+                                changed   =  true;
+                            }
+
+                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            {
+                                srfVelRol += 10;
                                 changed   =  true;
                             }
 
@@ -432,6 +485,12 @@ namespace MuMech
                             GUILayout.BeginHorizontal();
                             forcePitch = GUILayout.Toggle(forcePitch, "", GUILayout.ExpandWidth(false));
                             GuiUtils.SimpleTextBox("PIT", srfVelPit, "°", 37);
+                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            {
+                                srfVelPit -= 10;
+                                changed   =  true;
+                            }
+                            
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelPit -= val;
@@ -441,6 +500,12 @@ namespace MuMech
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelPit += val;
+                                changed   =  true;
+                            }
+
+                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            {
+                                srfVelPit += 10;
                                 changed   =  true;
                             }
 
@@ -460,6 +525,12 @@ namespace MuMech
                             GUILayout.BeginHorizontal();
                             forceYaw = GUILayout.Toggle(forceYaw, "", GUILayout.ExpandWidth(false));
                             GuiUtils.SimpleTextBox("YAW", srfVelYaw, "°", 37);
+                            
+                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            {
+                                srfVelYaw -= 10;
+                                changed   =  true;
+                            }
                             if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelYaw -= val;
@@ -469,6 +540,13 @@ namespace MuMech
                             if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
                             {
                                 srfVelYaw += val;
+                                changed   =  true;
+                            }
+
+
+                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            {
+                                srfVelYaw += 10;
                                 changed   =  true;
                             }
 


### PR DESCRIPTION
I had both of these features on my wishlist to better control lifting body reentries (Shuttle-style), specifically during the decent control phase using banking.

- Larger increments for attitude adjustments: allow controlling the bank angle without typing in numbers or spamming the - and + buttons. I chose 10deg, but maybe we want to use 5deg? I felt like making it configurable would be a bit overkill
- Add a "smooth control" flag to Surface relative modes, with a degree per second value. If enabled, any changes to the three axes will result in a slow linear transition from the current attitude to the target attitude. I have had too many ships spin out of control because I changed the roll value too quickly while going mach-foo at a 40 degree pitch. I set the default to 10 degrees, which gives a nice smooth transition if enabled.

Now, I would love someone to test this before it gets merged, I did already but don't feel too confident.