### PR TITLE
Fix not being able to launch southwards

### DIFF
--- a/MechJebLib/PSG/Terminal/FlightPathAngle3Energy.cs
+++ b/MechJebLib/PSG/Terminal/FlightPathAngle3Energy.cs
@@ -21,7 +21,7 @@ namespace MechJebLib.PSG.Terminal
             NumConstraints = 3;
             _gammaT        = gammaT;
             _rT            = rT;
-            _incT          = Abs(ClampPi(incT));
+            _incT          = incT;
         }
 
         public ITerminal Rescale(Scale scale)  => new FlightPathAngle3Energy(_gammaT, _rT / scale.LengthScale, _incT);

--- a/MechJebLib/PSG/Terminal/FlightPathAngle4.cs
+++ b/MechJebLib/PSG/Terminal/FlightPathAngle4.cs
@@ -29,7 +29,7 @@ namespace MechJebLib.PSG.Terminal
             _gammaT        = gammaT;
             _rT            = rT;
             _vT            = vT;
-            _incT          = Abs(ClampPi(incT));
+            _incT          = incT;
         }
 
         public ITerminal Rescale(Scale scale)  => new FlightPathAngle4(_gammaT, _rT / scale.LengthScale, _vT / scale.VelocityScale, _incT);

--- a/MechJebLib/PSG/Terminal/FlightPathAngle4Energy.cs
+++ b/MechJebLib/PSG/Terminal/FlightPathAngle4Energy.cs
@@ -24,7 +24,7 @@ namespace MechJebLib.PSG.Terminal
         {
             NumConstraints = 4;
             _rT            = rT;
-            _incT          = Abs(ClampPi(incT));
+            _incT          = incT;
             _lanT          = lanT;
             _gammaT        = gammaT;
             _iHT           = Astro.HunitFromKeplerian(_incT, _lanT);

--- a/MechJebLib/PSG/Terminal/FlightPathAngle5.cs
+++ b/MechJebLib/PSG/Terminal/FlightPathAngle5.cs
@@ -28,7 +28,7 @@ namespace MechJebLib.PSG.Terminal
             _rT            = rT;
             _vT            = vT;
             _lanT          = Clamp2Pi(lanT);
-            _incT          = Abs(ClampPi(incT));
+            _incT          = incT;
 
             _hT = Astro.HvecFromFlightPathAngle(_rT, _vT, _gammaT, _incT, _lanT);
         }

--- a/MechJebLib/PSG/Terminal/Kepler3.cs
+++ b/MechJebLib/PSG/Terminal/Kepler3.cs
@@ -24,7 +24,7 @@ namespace MechJebLib.PSG.Terminal
             NumConstraints = 3;
             _smaT          = smaT;
             _eccT          = eccT;
-            _incT          = Abs(ClampPi(incT));
+            _incT          = incT;
             _hTm           = Astro.HmagFromKeplerian(1.0, _smaT, _eccT);
             _energyT       = -1.0 / (2.0 * _smaT);
         }

--- a/MechJebLib/PSG/Terminal/Kepler4.cs
+++ b/MechJebLib/PSG/Terminal/Kepler4.cs
@@ -24,7 +24,7 @@ namespace MechJebLib.PSG.Terminal
             NumConstraints = 4;
             _smaT          = smaT;
             _eccT          = eccT;
-            _incT          = Abs(ClampPi(incT));
+            _incT          = incT;
             _lanT          = lanT;
             _hT            = Astro.HvecFromKeplerian(1.0, _smaT, _eccT, _incT, _lanT);
         }

--- a/MechJebLib/PSG/Terminal/Kepler5.cs
+++ b/MechJebLib/PSG/Terminal/Kepler5.cs
@@ -26,7 +26,7 @@ namespace MechJebLib.PSG.Terminal
             NumConstraints = 6;
             _smaT          = smaT;
             _eccT          = eccT;
-            _incT          = Abs(ClampPi(incT));
+            _incT          = incT;
             _lanT          = lanT;
             _argpT         = argpT;
 


### PR DESCRIPTION
The inclination in the constraint was `Abs()`'d, which prevented the direction vector from being optimized for the negative Z direction. Neither the `Abs()` nor the `ClampPi()` is necessary for the inclination parameter, because the sine functions already do that inherently, so this parameter sanitation was simply removed.

**ALSO**

The `ClampPi` function is actually bugged, as it internally uses `Clamp2Pi`, which clamps from 0 to 6.28. Thus `ClampPI`, even though its description states "Returns the equivalent value in radians between -pi and pi.", is actually only returning values between 0 and 3.14. I'm not sure if I should open this as an issue or anything like that, because I don't really care about it and I haven't noticed any bugs caused by this, but it should probably be changed.