### PR TITLE
Fix inverse rotation maneuver bugs

### DIFF
--- a/MechJeb2.sln.DotSettings
+++ b/MechJeb2.sln.DotSettings
@@ -27,6 +27,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=KSP/@EntryIndexedValue">KSP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LAN/@EntryIndexedValue">LAN</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LD/@EntryIndexedValue">LD</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LH/@EntryIndexedValue">LH</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LQR/@EntryIndexedValue">LQR</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MET/@EntryIndexedValue">MET</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MJ/@EntryIndexedValue">MJ</s:String>
@@ -37,6 +38,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PVG/@EntryIndexedValue">PVG</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RC/@EntryIndexedValue">RC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RCS/@EntryIndexedValue">RCS</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RH/@EntryIndexedValue">RH</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RHS/@EntryIndexedValue">RHS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RK/@EntryIndexedValue">RK</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RO/@EntryIndexedValue">RO</s:String>

--- a/MechJeb2/OrbitExtensions.cs
+++ b/MechJeb2/OrbitExtensions.cs
@@ -71,7 +71,10 @@ namespace MuMech
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static (V3 pos, V3 vel) RightHandedStateVectorsAtUT(this Orbit o, double ut)
         {
-            o.GetOrbitalStateVectorsAtUT(ut, out Vector3d pos, out Vector3d vel);
+            // GetOrbitalStateVectorsAtUT() uses a crazy future-rotation-at-UT to rotate vectors, so carefully avoid it.
+            o.GetOrbitalStateVectorsAtTrueAnomaly(o.TrueAnomalyAtT(o.getObtAtUT(ut)), ut, false, out Vector3d pos, out Vector3d vel);
+            pos = Planetarium.Zup.WorldToLocal(pos);
+            vel = Planetarium.Zup.WorldToLocal(vel);
             return (pos.ToV3(), vel.ToV3());
         }
 


### PR DESCRIPTION
GetOrbitalStateVectorsAtUT() is particularly whack in the way that it applies the inverse rotation constructed at a future time via using Planetarium.ZupAtT().  That means that for the most part it is only useful for constructing values which can only be compared to other vectors constructed at the same time.  This bug only occurs when the vessel is below the inverse rotation threshold, though, so most of the time works fine when there's no rotation being applied.

The changes to RightHandedStateVectorsAtUT mean that we apply our own rotation in the current frames rotation to get RH rotating vectors.  This is consistent with the old API, but should probably be retired and everything migrated to RH non-rotating vectors now that I can see how to get them out of the API correctly.

This may also fix other bugs in consumers of the underlying maneuvers class (e.g. rendezvous autopilot, ascent autopilot in stock, etc).

closes #2102
closes #2077