### PR TITLE
Transfer planner: GetOrbitalStateVectorsAtUT fix

### DIFF
--- a/MechJeb2/Maneuver/TransferCalculator.cs
+++ b/MechJeb2/Maneuver/TransferCalculator.cs
@@ -351,11 +351,11 @@ namespace MuMech
             Debug.Log("maneuver guess dV: " + maneuver.dV);
             Debug.Log("maneuver guess UT: " + maneuver.UT);
             Debug.Log("arrival guess UT: " + utArrival);
-            _initialOrbit.GetOrbitalStateVectorsAtUT(maneuver.UT, out Vector3d r1, out Vector3d v1);
+            _initialOrbit.FixedGetOrbitalStateVectorsAtUT(maneuver.UT, out Vector3d r1, out Vector3d v1);
             Debug.Log($"initial orbit at {maneuver.UT} x = {r1}; v = {v1}");
-            _initialOrbit.referenceBody.orbit.GetOrbitalStateVectorsAtUT(maneuver.UT, out Vector3d r2, out Vector3d v2);
+            _initialOrbit.referenceBody.orbit.FixedGetOrbitalStateVectorsAtUT(maneuver.UT, out Vector3d r2, out Vector3d v2);
             Debug.Log($"source at {maneuver.UT} x = {r2}; v = {v2}");
-            _targetBody.orbit.GetOrbitalStateVectorsAtUT(utArrival, out Vector3d r3, out Vector3d v3);
+            _targetBody.orbit.FixedGetOrbitalStateVectorsAtUT(utArrival, out Vector3d r3, out Vector3d v3);
             Debug.Log($"source at {utArrival} x = {r3}; v = {v3}");
 
             _impulseScale = maneuver.dV.magnitude;

--- a/MechJeb2/OrbitExtensions.cs
+++ b/MechJeb2/OrbitExtensions.cs
@@ -78,6 +78,14 @@ namespace MuMech
             return (pos.ToV3(), vel.ToV3());
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void FixedGetOrbitalStateVectorsAtUT(this Orbit o, double ut, out Vector3d pos, out Vector3d vel)
+        {
+            o.GetOrbitalStateVectorsAtTrueAnomaly(o.TrueAnomalyAtT(o.getObtAtUT(ut)), ut, false, out pos, out vel);
+            pos = Planetarium.Zup.WorldToLocal(pos);
+            vel = Planetarium.Zup.WorldToLocal(vel);
+        }
+
         //normalized vector perpendicular to the orbital plane
         //convention: as you look down along the orbit normal, the satellite revolves counterclockwise
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This fixes a (now) obvious bug in the transfer planner in the use of GetOrbitalStateVectorsAtUT(), although it seems to only affect debug log output.