### PR TITLE
Prevent Reflection errors from other mods tanking MJ

### DIFF
--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -785,7 +785,7 @@ namespace MuMech
                 LoadComputerModules();
 
                 var global = new ConfigNode("MechJebGlobalSettings");
-                if (File.Exists<MechJebCore>("mechjeb_settings_global.cfg"))
+                if (MuUtils.FileExistsCreateDirectory(MuUtils.GetCfgPath("mechjeb_settings_global.cfg")))
                 {
                     try
                     {
@@ -807,7 +807,7 @@ namespace MuMech
                     vessel != null
                         ? string.Join("_", vessel.vesselName.Split(Path.GetInvalidFileNameChars()))
                         : ""; // Strip illegal char from the filename
-                if (vessel != null && File.Exists<MechJebCore>("mechjeb_settings_type_" + vesselName + ".cfg"))
+                if (vessel != null && MuUtils.FileExistsCreateDirectory(MuUtils.GetCfgPath("mechjeb_settings_type_" + vesselName + ".cfg")))
                 {
                     try
                     {

--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -366,7 +366,7 @@ namespace MuMech
             if (!FlightGlobals.ready) return; // bodies not loaded yet
 
             var wps = new ConfigNode("Routes");
-            if (File.Exists<MechJebCore>("mechjeb_routes.cfg"))
+            if (MuUtils.FileExistsCreateDirectory(MuUtils.GetCfgPath("mechjeb_routes.cfg")))
             {
                 try
                 {

--- a/MechJeb2/MuUtils.cs
+++ b/MechJeb2/MuUtils.cs
@@ -11,6 +11,15 @@ namespace MuMech
 
         public static string GetCfgPath(string file) => Path.Combine(_cfgPath, file);
 
+        // Duplicates the KSP.IO.File.Exist style API where it creates the directory if it doesn't exist
+        public static bool FileExistsCreateDirectory(string path)
+        {
+            string directoryName = Path.GetDirectoryName(path);
+            if (directoryName != null && !Directory.Exists(directoryName))
+                Directory.CreateDirectory(directoryName);
+            return File.Exists(path);
+        }
+
         public static string PadPositive(double x, string format = "F3")
         {
             string s = x.ToString(format);


### PR DESCRIPTION
Avoids using the KSP.IO.File.Exist<T>() API that walks the loaded assemblies and throws, looking for the path to the assembly with the type T.

The MuUtils helper replicates the side effect of this API of creating the directory.

Since we construct the path afterwards anyway to load the file the only reason I can see for the reflection-driven-API is for that side-effect, and to cause weird bugs if someone ever moves the DLL location around and makes the two APIs start to disagree.