### PR TITLE
PSG: fix some CoastDuring bugs

### DIFF
--- a/MechJeb2/MechJebModulePSGGlueBall.cs
+++ b/MechJeb2/MechJebModulePSGGlueBall.cs
@@ -240,8 +240,6 @@ namespace MuMech
                 if (kspStage < _ascentSettings.LastStage)
                     break;
 
-                Debug.Log($"{Core.StageStats.VacStats[mjPhase].Thrust} {Core.StageStats.VacStats[mjPhase].MinThrust}/{Core.StageStats.VacStats[mjPhase].MaxThrust}");
-
                 bool massContinuity = false;
 
                 if (!hasCoast)
@@ -295,7 +293,7 @@ namespace MuMech
 
         private bool IsCurrentCoastAfterStage(int kspStage)
         {
-            if (kspStage == Vessel.currentStage && Core.Guidance.IsCoasting() && !CoastingBefore())
+            if (kspStage == Vessel.currentStage && Core.Guidance.IsCoasting() && CoastingAfter())
                 return true;
 
             return false;

--- a/MechJebLib/PSG/AscentBuilder.cs
+++ b/MechJebLib/PSG/AscentBuilder.cs
@@ -70,6 +70,7 @@ namespace MechJebLib.PSG
 
             public AscentBuilder AerodynamicConstants(double cd, double aRef, double rho0, double qAlphaMax, double qMax, double h0, V3 w)
             {
+                DebugPrint($"AerodynamicConstants({cd},  {aRef}, {rho0}, {qAlphaMax}, {qMax}, {h0}, new V3({w}))");
                 _h0               = h0;
                 _rho0CdAref       = cd * aRef * rho0;
                 _rho0QAlphaMaxInv = qAlphaMax > 0 ? rho0 / qAlphaMax : 0;
@@ -81,7 +82,7 @@ namespace MechJebLib.PSG
             public AscentBuilder AddCoast(double m0, double mint, double maxt, int kspStage, int mjPhase, bool unguided = false, bool massContinuity = false)
             {
                 var sb = new StringBuilder();
-                sb.Append($"[MechJebLib.AscentBuilder] AddOptimizedCoast({m0}, {mint}, {maxt}, {kspStage}, {mjPhase}");
+                sb.Append($"[MechJebLib.AscentBuilder] AddCoast({m0}, {mint}, {maxt}, {kspStage}, {mjPhase}");
                 if (unguided)
                     sb.Append(", unguided: true");
                 if (massContinuity)
@@ -102,7 +103,7 @@ namespace MechJebLib.PSG
                 Check.PositiveFinite(mu);
                 Check.PositiveFinite(rbody);
 
-                DebugPrint($"[MechJebLib.AscentBuilder] Initial({r0}, {v0}, {u0}, {t0}, {mu}, {rbody})");
+                DebugPrint($"[MechJebLib.AscentBuilder] Initial(new V3({r0}), new V3({v0}), new V3({u0}), {t0}, {mu}, {rbody})");
                 _r0    = r0;
                 _v0    = v0;
                 _u0    = u0.normalized;
@@ -178,7 +179,7 @@ namespace MechJebLib.PSG
                 double fpa, bool attachAltFlag, bool lanflag, bool argpflag)
             {
                 DebugPrint(
-                    $"[MechJebLib.AscentBuilder] SetTarget({peR}, {apR}, {attR}, {inclination}, {lan}, {fpa}, {(attachAltFlag ? "true" : "false")}, {(lanflag ? "true" : "false")})");
+                    $"[MechJebLib.AscentBuilder] SetTarget({peR}, {apR}, {attR}, {inclination}, {lan}, {fpa}, {argp}, {(attachAltFlag ? "true" : "false")}, {(lanflag ? "true" : "false")}, {(argpflag ? "true" : "false")})");
                 _peR           = peR;
                 _apR           = apR;
                 _attR          = attR;

--- a/MechJebLib/PSG/AscentGuesser.cs
+++ b/MechJebLib/PSG/AscentGuesser.cs
@@ -88,7 +88,7 @@ namespace MechJebLib.PSG
         {
             if (p + 2 > phases.Count - 1) // need three phases in a row
                 return false;
-            if (!phases[p + 1].MassContinuity || !phases[p + 2].MassContinuity) // need 2 mass continuity stages
+            if (!phases[p + 2].MassContinuity) // next burn should be mass continuity stage
                 return false;
             if (phases[p].Coast || !phases[p + 1].Coast || phases[p + 2].Coast) // need burn-coast-burn
                 return false;

--- a/MechJebLib/PSG/AscentProblem.cs
+++ b/MechJebLib/PSG/AscentProblem.cs
@@ -240,9 +240,6 @@ namespace MechJebLib.PSG
                 alglib.sparseappendelement(j, nextBurnPhase.BtIdx(), a / Sqrt(u) - 1);
             }
 
-            // relaxed bilinear constraint on burn times (needs inequality constraint)
-            //f[ci++] = a * b;  //where a <= 1e-6 && b <= 1e-6 -- constraint should be 1/2 of the SFB epsilon value
-
             return ci;
         }
 

--- a/MechJebLib/PSG/Optimizer.cs
+++ b/MechJebLib/PSG/Optimizer.cs
@@ -336,7 +336,7 @@ namespace MechJebLib.PSG
                 int        idx       = thisPhase.BtIdx();
 
                 bndl[idx] = Phases[p].MinT;
-                bndu[idx] = Phases[p].MaxT;
+                bndu[idx] = Phases[p].MaxT / Phases[p].MinThrottle;
 
                 /*
                 if (Phases[p].Coast)

--- a/MechJebLib/PSG/Phase.cs
+++ b/MechJebLib/PSG/Phase.cs
@@ -84,7 +84,7 @@ namespace MechJebLib.PSG
             Check.PositiveFinite(thrust);
             Check.PositiveFinite(mf);
             Check.PositiveFinite(isp);
-            Check.PositiveFinite(minThrottle);
+            Check.NonNegativeFinite(minThrottle);
 
             double mdot = thrust / (isp * G0);
             double bt   = (m0 - mf) / mdot;

--- a/MechJebLibTest/MechJebLibTest.csproj
+++ b/MechJebLibTest/MechJebLibTest.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Primitives\V3Tests\VectorMathOperationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PSGTests\AscentTests\BuggyTests.cs" />
+    <Compile Include="PSGTests\AscentTests\KerbinTests.cs" />
     <Compile Include="PSGTests\AscentTests\RealRocketTests.cs" />
     <Compile Include="PSGTests\AscentTests\TheStandardTests.cs" />
     <Compile Include="PSGTests\AscentTests\Titan2Tests.cs" />

--- a/MechJebLibTest/PSGTests/AscentTests/KerbinTests.cs
+++ b/MechJebLibTest/PSGTests/AscentTests/KerbinTests.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using MechJebLib.Primitives;
+using MechJebLib.PSG;
+using MechJebLib.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MechJebLibTest.PSGTests.AscentTests
+{
+    public class KerbinTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public KerbinTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        void MainSailTinCanVacuum()
+        {
+            double t0 = 82132.7494998545;
+
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
+
+            Ascent ascent = Ascent.Builder()
+                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0)
+                .AddCoast(79699.9986022711, 0, 450, 0, 0)
+                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0, massContinuity:true)
+                .Initial(new V3(365592.912061998, -475862.737003702, -1017.92554628857), new V3(138.749920001822, 106.593409136045, 5.05460467277035E-06), new V3(0.608250428397881, -0.793743408918215, -0.00172494351863861), t0, 3531600000000, 600000)
+                .SetTarget(700000, 700000, 700000, 0, 0, 0, 0, false, false, false)
+                .Build();
+
+            ascent.Run();
+
+            Optimizer      psg      = ascent.GetOptimizer() ?? throw new Exception("null optimizer");
+            using Solution solution = psg.Solution ?? throw new Exception("null solution");
+
+            psg.PrimalFeasibility.ShouldBeZero(1e-5);
+            solution.Tgo(t0).ShouldEqual(1050.4212938233472, 1e-3);
+            solution.Vgo(t0).ShouldEqual(2429, 1e-3);
+
+            (V3 rf, V3 vf) = solution.TerminalStateVectors();
+        }
+
+        [Fact]
+        void MainSailTinCanAtmo()
+        {
+            double t0 = 82132.7494998545;
+
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
+
+            Ascent ascent = Ascent.Builder()
+                .AerodynamicConstants(0.5,  19.6, 1.22497705725583, 4000, 0, 6797.80562531277, new V3(0, 0, 0.000291570900559802))
+                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0)
+                .AddCoast(79699.9986022711, 0, 450, 0, 0)
+                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0, massContinuity:true)
+                .Initial(new V3(365592.912061998, -475862.737003702, -1017.92554628857), new V3(138.749920001822, 106.593409136045, 5.05460467277035E-06), new V3(0.608250428397881, -0.793743408918215, -0.00172494351863861), t0, 3531600000000, 600000)
+                .SetTarget(700000, 700000, 700000, 0, 0, 0, 0, false, false, false)
+                .Build();
+
+            ascent.Run();
+
+            Optimizer      psg      = ascent.GetOptimizer() ?? throw new Exception("null optimizer");
+            using Solution solution = psg.Solution ?? throw new Exception("null solution");
+
+            psg.PrimalFeasibility.ShouldBeZero(1e-5);
+            solution.Tgo(t0).ShouldEqual(303.81036578362705, 1e-3);
+            solution.Vgo(t0).ShouldEqual(3541.2477099301864, 1e-3);
+
+            (V3 rf, V3 vf) = solution.TerminalStateVectors();
+        }
+    }
+}


### PR DESCRIPTION
Also add some tests for a simple rocket on Kerbin

- relax MaxT box constraint by MinThrottle
- fix IsCurrentCoastAfterStage() logic
- fix MassContinuity-related bug in AscentGuesser
- improve some debug logging
- remove stray logging in the glueball