### PR TITLE
Fix NRE in editor

### DIFF
--- a/MechJeb2/MechJebModuleAscentSettings.cs
+++ b/MechJeb2/MechJebModuleAscentSettings.cs
@@ -323,8 +323,6 @@ namespace MuMech
             DesiredOrbitAltitude.Val = 145000;
             DesiredAttachAlt.Val     = 145000;
 
-            DesiredInclination.Val = Math.Round(Vessel.mainBody.GetLatitude(Vessel.CoMD), 3);
-
             Core.Guidance.UllageLeadTime.Val = 20;
 
             Core.Settings.rssMode = true;


### PR DESCRIPTION
Don't set the latitude based on the vessel during first "boot up" of RO settings since we may be in the editor, which will NRE and that doesn't make sense anyway.