### PR TITLE
More cherry picks to master

### DIFF
--- a/.idea/.idea.MechJeb2/.idea/.name
+++ b/.idea/.idea.MechJeb2/.idea/.name
@@ -1,0 +1,1 @@
+MechJeb2

--- a/MechJeb2.sln.DotSettings
+++ b/MechJeb2.sln.DotSettings
@@ -24,6 +24,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=KSP/@EntryIndexedValue">KSP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LAN/@EntryIndexedValue">LAN</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LD/@EntryIndexedValue">LD</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LH/@EntryIndexedValue">LH</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LQR/@EntryIndexedValue">LQR</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MET/@EntryIndexedValue">MET</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MJ/@EntryIndexedValue">MJ</s:String>
@@ -32,6 +33,8 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PVG/@EntryIndexedValue">PVG</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RC/@EntryIndexedValue">RC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RCS/@EntryIndexedValue">RCS</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RH/@EntryIndexedValue">RH</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RHS/@EntryIndexedValue">RHS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RK/@EntryIndexedValue">RK</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RO/@EntryIndexedValue">RO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SI/@EntryIndexedValue">SI</s:String>

--- a/MechJeb2/Maneuver/TransferCalculator.cs
+++ b/MechJeb2/Maneuver/TransferCalculator.cs
@@ -351,11 +351,11 @@ namespace MuMech
             Debug.Log("maneuver guess dV: " + maneuver.dV);
             Debug.Log("maneuver guess UT: " + maneuver.UT);
             Debug.Log("arrival guess UT: " + utArrival);
-            _initialOrbit.GetOrbitalStateVectorsAtUT(maneuver.UT, out Vector3d r1, out Vector3d v1);
+            _initialOrbit.FixedGetOrbitalStateVectorsAtUT(maneuver.UT, out Vector3d r1, out Vector3d v1);
             Debug.Log($"initial orbit at {maneuver.UT} x = {r1}; v = {v1}");
-            _initialOrbit.referenceBody.orbit.GetOrbitalStateVectorsAtUT(maneuver.UT, out Vector3d r2, out Vector3d v2);
+            _initialOrbit.referenceBody.orbit.FixedGetOrbitalStateVectorsAtUT(maneuver.UT, out Vector3d r2, out Vector3d v2);
             Debug.Log($"source at {maneuver.UT} x = {r2}; v = {v2}");
-            _targetBody.orbit.GetOrbitalStateVectorsAtUT(utArrival, out Vector3d r3, out Vector3d v3);
+            _targetBody.orbit.FixedGetOrbitalStateVectorsAtUT(utArrival, out Vector3d r3, out Vector3d v3);
             Debug.Log($"source at {utArrival} x = {r3}; v = {v3}");
 
             _impulseScale = maneuver.dV.magnitude;

--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -787,7 +787,7 @@ namespace MuMech
                 LoadComputerModules();
 
                 var global = new ConfigNode("MechJebGlobalSettings");
-                if (File.Exists<MechJebCore>("mechjeb_settings_global.cfg"))
+                if (MuUtils.FileExistsCreateDirectory(MuUtils.GetCfgPath("mechjeb_settings_global.cfg")))
                 {
                     try
                     {
@@ -809,7 +809,7 @@ namespace MuMech
                     vessel != null
                         ? string.Join("_", vessel.vesselName.Split(Path.GetInvalidFileNameChars()))
                         : ""; // Strip illegal char from the filename
-                if (vessel != null && File.Exists<MechJebCore>("mechjeb_settings_type_" + vesselName + ".cfg"))
+                if (vessel != null && MuUtils.FileExistsCreateDirectory(MuUtils.GetCfgPath("mechjeb_settings_type_" + vesselName + ".cfg")))
                 {
                     try
                     {

--- a/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
@@ -268,9 +268,11 @@ namespace MuMech
                 // TWR launches from equatorial launch sites -- should probably be made optional (or clip it if the correction is too large).
                 Vector3d inclinationCorrection =
                     OrbitalManeuverCalculator.DeltaVToChangeInclination(Orbit, ut, AscentSettings.DesiredInclination);
-                Vector3d smaCorrection = OrbitalManeuverCalculator.DeltaVForSemiMajorAxis(Orbit.PerturbedOrbit(ut, inclinationCorrection), ut,
-                    AscentSettings.DesiredOrbitAltitude + MainBody.Radius);
-                Vector3d dV = inclinationCorrection + smaCorrection;
+                // Circularize on the perturbed orbit rather than fixing the SMA to the desired altitude.  This
+                // avoids errors that creep in when the orbit at this point is inaccurate while still circularizing.
+                Vector3d circularizeCorrection =
+                    OrbitalManeuverCalculator.DeltaVToCircularize(Orbit.PerturbedOrbit(ut, inclinationCorrection), ut);
+                Vector3d dV = inclinationCorrection + circularizeCorrection;
                 Vessel.PlaceManeuverNode(Orbit, dV, ut);
                 _placedCircularizeNode = true;
 

--- a/MechJeb2/MechJebModuleAscentMenu.cs
+++ b/MechJeb2/MechJebModuleAscentMenu.cs
@@ -49,18 +49,11 @@ namespace MuMech
 
         private bool _launchingWithAnyPlaneControl => _launchingToPlane || _launchingToRendezvous || _launchingToMatchLan || _launchingToLan;
 
-        private MechJebModuleAscentBaseAutopilot   _autopilot      => Core.Ascent;
-        private MechJebModuleAscentSettings        _ascentSettings => Core.AscentSettings;
-        private MechJebModuleAscentClassicPathMenu _classicPathMenu;
-        private MechJebModuleAscentPVGSettingsMenu _pvgSettingsMenu;
-        private MechJebModuleAscentSettingsMenu    _settingsMenu;
-
-        public override void OnStart(PartModule.StartState state)
-        {
-            _pvgSettingsMenu = Core.GetComputerModule<MechJebModuleAscentPVGSettingsMenu>();
-            _settingsMenu    = Core.GetComputerModule<MechJebModuleAscentSettingsMenu>();
-            _classicPathMenu = Core.GetComputerModule<MechJebModuleAscentClassicPathMenu>();
-        }
+        private MechJebModuleAscentBaseAutopilot   _autopilot       => Core.Ascent;
+        private MechJebModuleAscentSettings        _ascentSettings  => Core.AscentSettings;
+        private MechJebModuleAscentClassicPathMenu _classicPathMenu => Core.GetComputerModule<MechJebModuleAscentClassicPathMenu>();
+        private MechJebModuleAscentPVGSettingsMenu _pvgSettingsMenu => Core.GetComputerModule<MechJebModuleAscentPVGSettingsMenu>();
+        private MechJebModuleAscentSettingsMenu    _settingsMenu    => Core.GetComputerModule<MechJebModuleAscentSettingsMenu>();
 
         [UsedImplicitly]
         [Persistent(pass = (int)Pass.GLOBAL)]

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -300,7 +300,7 @@ namespace MuMech
 
         private void SetAttitude()
         {
-            Core.Attitude.attitudeTo(_worldDirection, AttitudeReference.INERTIAL, this, killRollRotation:KillRollRotation);
+            Core.Attitude.attitudeTo(_worldDirection, AttitudeReference.INERTIAL_COT, this, killRollRotation:KillRollRotation);
         }
 
         private bool ShouldTerminatePrincipia()

--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -684,7 +684,7 @@ namespace MuMech
             //      payload fairing now (fixing payload fairings causing stacks to not decouple).
             // if a user requires an interstage fairing that is alone in a stage with no stack decoupler, engine, or
             // anything else in the stage (for cinematics?) then the user MUST use proc fairings.
-            return _partsInStage.Slinq().All(p => (p.IsDecoupler() || p.HasModule<ModuleProceduralFairing>()) && !p.IsLaunchClamp() && p.children.Count == 0);
+            return _partsInStage.Slinq().All(p => ((p.IsDecoupler() && p.children.Count == 0) || p.HasModule<ModuleProceduralFairing>() ) && !p.IsLaunchClamp());
         }
     }
 }

--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -684,7 +684,7 @@ namespace MuMech
             //      payload fairing now (fixing payload fairings causing stacks to not decouple).
             // if a user requires an interstage fairing that is alone in a stage with no stack decoupler, engine, or
             // anything else in the stage (for cinematics?) then the user MUST use proc fairings.
-            return _partsInStage.Slinq().All(p => p.IsDecoupler() && !p.IsLaunchClamp() && p.children.Count == 0);
+            return _partsInStage.Slinq().All(p => (p.IsDecoupler() || p.HasModule<ModuleProceduralFairing>()) && !p.IsLaunchClamp() && p.children.Count == 0);
         }
     }
 }

--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -149,7 +149,7 @@ namespace MuMech
         public void LimitThrottleInfoItem()
         {
             GUIStyle s = Limiter == LimitMode.THROTTLE ? MaxThrottle > 0d ? GuiUtils.GreenToggle : GuiUtils.RedToggle : null;
-            GuiUtils.ToggledTextBox(ref LimitThrottle, CachedLocalizer.Instance.MechJebAscentCheckbox17, MaxAcceleration, "%", s,
+            GuiUtils.ToggledTextBox(ref LimitThrottle, CachedLocalizer.Instance.MechJebAscentCheckbox17, MaxThrottle, "%", s,
                 30); //"Limit throttle to"
         }
 

--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -366,7 +366,7 @@ namespace MuMech
             if (!FlightGlobals.ready) return; // bodies not loaded yet
 
             var wps = new ConfigNode("Routes");
-            if (File.Exists<MechJebCore>("mechjeb_routes.cfg"))
+            if (MuUtils.FileExistsCreateDirectory(MuUtils.GetCfgPath("mechjeb_routes.cfg")))
             {
                 try
                 {

--- a/MechJeb2/MuUtils.cs
+++ b/MechJeb2/MuUtils.cs
@@ -11,6 +11,15 @@ namespace MuMech
 
         public static string GetCfgPath(string file) => Path.Combine(_cfgPath, file);
 
+        // Duplicates the KSP.IO.File.Exist style API where it creates the directory if it doesn't exist
+        public static bool FileExistsCreateDirectory(string path)
+        {
+            string directoryName = Path.GetDirectoryName(path);
+            if (directoryName != null && !Directory.Exists(directoryName))
+                Directory.CreateDirectory(directoryName);
+            return File.Exists(path);
+        }
+
         public static string PadPositive(double x, string format = "F3")
         {
             string s = x.ToString(format);

--- a/MechJeb2/OrbitExtensions.cs
+++ b/MechJeb2/OrbitExtensions.cs
@@ -78,6 +78,14 @@ namespace MuMech
             return (pos.ToV3(), vel.ToV3());
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void FixedGetOrbitalStateVectorsAtUT(this Orbit o, double ut, out Vector3d pos, out Vector3d vel)
+        {
+            o.GetOrbitalStateVectorsAtTrueAnomaly(o.TrueAnomalyAtT(o.getObtAtUT(ut)), ut, false, out pos, out vel);
+            pos = Planetarium.Zup.WorldToLocal(pos);
+            vel = Planetarium.Zup.WorldToLocal(vel);
+        }
+
         //normalized vector perpendicular to the orbital plane
         //convention: as you look down along the orbit normal, the satellite revolves counterclockwise
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/MechJeb2/OrbitExtensions.cs
+++ b/MechJeb2/OrbitExtensions.cs
@@ -123,51 +123,6 @@ namespace MuMech
         public static Orbit PerturbedOrbit(this Orbit o, double ut, Vector3d dV) =>
             MuUtils.OrbitFromStateVectors(o.WorldPositionAtUT(ut), o.WorldOrbitalVelocityAtUT(ut) + dV, o.referenceBody, ut);
 
-        // returns a new orbit that is identical to the current one (although the epoch will change)
-        // (i tried many different APIs in the orbit class, but the GetOrbitalStateVectors/UpdateFromStateVectors route was the only one that worked)
-        public static Orbit Clone(this Orbit o, double ut = double.NegativeInfinity)
-        {
-            // hack up a dynamic default value to the current time
-            if (double.IsNegativeInfinity(ut))
-                ut = Planetarium.GetUniversalTime();
-
-            var newOrbit = new Orbit();
-            o.GetOrbitalStateVectorsAtUT(ut, out Vector3d pos, out Vector3d vel);
-            newOrbit.UpdateFromStateVectors(pos, vel, o.referenceBody, ut);
-
-            return newOrbit;
-        }
-
-        // calculate the next patch, which makes patchEndTransition be valid
-        //
-        public static Orbit CalculateNextOrbit(this Orbit o, double ut = double.NegativeInfinity)
-        {
-            var solverParameters = new PatchedConics.SolverParameters();
-
-            // hack up a dynamic default value to the current time
-            if (double.IsNegativeInfinity(ut))
-                ut = Planetarium.GetUniversalTime();
-
-            o.StartUT = ut;
-            o.EndUT   = o.eccentricity >= 1.0 ? o.period : ut + o.period;
-            var nextOrbit = new Orbit();
-            PatchedConics.CalculatePatch(o, nextOrbit, ut, solverParameters, null);
-
-            return nextOrbit;
-        }
-
-        // This does not allocate a new orbit object and the caller should call new Orbit if/when required
-        public static void MutatedOrbit(this Orbit o, double periodOffset = double.NegativeInfinity)
-        {
-            double ut = Planetarium.GetUniversalTime();
-
-            if (!periodOffset.IsFinite())
-                return;
-
-            o.GetOrbitalStateVectorsAtUT(ut + o.period * periodOffset, out Vector3d pos, out Vector3d vel);
-            o.UpdateFromStateVectors(pos, vel, o.referenceBody, ut);
-        }
-
         // circular orbital speed at this instant
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double CircularOrbitSpeed(this Orbit o) => Astro.CircularVelocity(o.referenceBody.gravParameter, o.radius);

--- a/MechJeb2/OrbitExtensions.cs
+++ b/MechJeb2/OrbitExtensions.cs
@@ -71,7 +71,10 @@ namespace MuMech
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static (V3 pos, V3 vel) RightHandedStateVectorsAtUT(this Orbit o, double ut)
         {
-            o.GetOrbitalStateVectorsAtUT(ut, out Vector3d pos, out Vector3d vel);
+            // GetOrbitalStateVectorsAtUT() uses a crazy future-rotation-at-UT to rotate vectors, so carefully avoid it.
+            o.GetOrbitalStateVectorsAtTrueAnomaly(o.TrueAnomalyAtT(o.getObtAtUT(ut)), ut, false, out Vector3d pos, out Vector3d vel);
+            pos = Planetarium.Zup.WorldToLocal(pos);
+            vel = Planetarium.Zup.WorldToLocal(vel);
             return (pos.ToV3(), vel.ToV3());
         }
 

--- a/MechJeb2/Properties/AssemblyInfo.cs
+++ b/MechJeb2/Properties/AssemblyInfo.cs
@@ -23,18 +23,9 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a903d9fe-4604-47b8-b9d9-95728538f769")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.5.1.0")] // We should not change it anymore. It break mods that links MJ ( cf http://support.microsoft.com/kb/556041 )
-[assembly: AssemblyFileVersion("2.15.2.0")] // this one we can change all we want
+// We use a 2.[Major].[Minor/Patch].0 naming convention
+[assembly: AssemblyVersion("2.15.0.0")] // This should be bumped for major versions/breaking changes when the 2nd number changes
+[assembly: AssemblyFileVersion("2.15.3.0")] // this one is bumped every single time for both minor/patch
 [assembly: AssemblyInformationalVersion("")] // Displayed in the window title if not empty (used to display dev #)
 
-[assembly: KSPAssembly("MechJeb2", 2, 5)]
+[assembly: KSPAssembly("MechJeb2", 2, 15, 3)] // this one is bumped every single time for both minor/patch

--- a/MechJeb2/RCSSolver.cs
+++ b/MechJeb2/RCSSolver.cs
@@ -110,7 +110,7 @@ namespace MuMech
 
             int count = thrusters.Count;
 
-            if (count == 0) return null;
+            if (count == 0) return new double[fullCount]; // array of zeros
 
             // We want to minimize torque (3 values), translation error (3 values),
             // and any thrust that's wasted due to not being toward 'direction' (1
@@ -157,20 +157,18 @@ namespace MuMech
 
                 if (waste < _wasteThreshold) waste = 0;
 
-                _a[0, tIdx] = torqueErr.x * _factorTorque;
-                _a[1, tIdx] = torqueErr.y * _factorTorque;
-                _a[2, tIdx] = torqueErr.z * _factorTorque;
-                _a[3, tIdx] = transErr.x * _factorTranslate;
-                _a[4, tIdx] = transErr.y * _factorTranslate;
-                _a[5, tIdx] = transErr.z * _factorTranslate;
-                _a[6, tIdx] = waste * _factorWaste;
-                _a[7, tIdx] = 0.001;
+                _a[(int)Params.TORQUE_X, tIdx] = torqueErr.x * _factorTorque;
+                _a[(int)Params.TORQUE_Y, tIdx] = torqueErr.y * _factorTorque;
+                _a[(int)Params.TORQUE_Z, tIdx] = torqueErr.z * _factorTorque;
+                _a[(int)Params.TRANS_X, tIdx] = transErr.x * _factorTranslate;
+                _a[(int)Params.TRANS_Y, tIdx] = transErr.y * _factorTranslate;
+                _a[(int)Params.TRANS_Z, tIdx] = transErr.z * _factorTranslate;
+                _a[(int)Params.WASTE, tIdx] = waste * _factorWaste;
+                _a[(int)Params.FUDGE, tIdx] = 0.001;
                 x[tIdx]     = 1;
                 bndl[tIdx]  = 0;
                 bndu[tIdx]  = 1;
             }
-
-            alglib.minbleicreport rep;
 
             const double EPSG = 0.01;
             const double EPSF = 0;
@@ -182,7 +180,7 @@ namespace MuMech
             alglib.minbleicsetbc(state, bndl, bndu);
             alglib.minbleicsetcond(state, EPSG, EPSF, EPSX, MAXITS);
             alglib.minbleicoptimize(state, cost_func, null, null);
-            alglib.minbleicresults(state, out double[] throttles, out rep);
+            alglib.minbleicresults(state, out double[] throttles, out alglib.minbleicreport _);
 
             double m = throttles.Max();
 
@@ -405,11 +403,8 @@ namespace MuMech
 
         public void ResetThrusterForces()
         {
-            for (int i = 0; i < _thrusters.Count; i++)
-            {
-                RCSSolver.Thruster t = _thrusters[i];
+            foreach (RCSSolver.Thruster t in _thrusters)
                 t.RestoreOriginalForce();
-            }
         }
 
         private static Vector3 WorldToVessel(Vessel vessel, Vector3 pos) =>
@@ -437,9 +432,9 @@ namespace MuMech
 
             // Make sure all thrusters are still enabled, because if they're not,
             // our calculations will be wrong.
-            for (int i = 0; i < _thrusters.Count; i++)
+            foreach (RCSSolver.Thruster t in _thrusters)
             {
-                if (!_thrusters[i].PartModule.isEnabled)
+                if (!t.PartModule.isEnabled)
                 {
                     changed = true;
                     break;
@@ -448,9 +443,8 @@ namespace MuMech
 
             // Likewise, make sure any previously-disabled RCS modules are still
             // disabled.
-            for (int i = 0; i < _lastDisabled.Count; i++)
+            foreach (ModuleRCS pm in _lastDisabled)
             {
-                ModuleRCS pm = _lastDisabled[i];
                 if (pm.isEnabled)
                 {
                     changed = true;
@@ -473,7 +467,7 @@ namespace MuMech
                 //
                 // Using a few actual KSP ships, I burned RCS fuel (or moved fuel
                 // from one tank to another) to see how far the CoM could shift
-                // before the the rotation error on translation became annoying.
+                // before the rotation error on translation became annoying.
                 // I came up with roughly:
                 //
                 //      d         moi
@@ -519,9 +513,8 @@ namespace MuMech
 
             // Rebuild the list of thrusters.
             var ts = new List<RCSSolver.Thruster>();
-            for (int index = 0; index < vessel.parts.Count; index++)
+            foreach (Part p in vessel.parts)
             {
-                Part p = vessel.parts[index];
                 foreach (ModuleRCS pm in p.Modules.OfType<ModuleRCS>())
                 {
                     if (!pm.isEnabled)
@@ -537,7 +530,7 @@ namespace MuMech
                         // requires some assumptions about how the game's RCS code will
                         // drive the individual thrusters (which we can't control).
 
-                        var thrustDirs = new Vector3[pm.thrusterTransforms.Count];
+                        var thrustDirs   = new Vector3[pm.thrusterTransforms.Count];
                         var rotationQuat = Quaternion.Inverse(vessel.GetTransform().rotation);
                         for (int i = 0; i < pm.thrusterTransforms.Count; i++)
                         {


### PR DESCRIPTION
Yet more bug stomping.

- fixes bad inverse rotation maneuver bug
- fixes some NREs
- prevents broken KSP installs from tanking MJ
- fix the staging controller for stock fairings
- fix node executor aligning to COT for e.g shuttle maneuvers
- fix class ascent circularization
- fix limit throttle/accel linkage
- fix NRE in rcs solver