### PR TITLE
Fix node executor to align COT to the node direction

### DIFF
--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -300,7 +300,7 @@ namespace MuMech
 
         private void SetAttitude()
         {
-            Core.Attitude.attitudeTo(_worldDirection, AttitudeReference.INERTIAL, this, killRollRotation:KillRollRotation);
+            Core.Attitude.attitudeTo(_worldDirection, AttitudeReference.INERTIAL_COT, this, killRollRotation:KillRollRotation);
         }
 
         private bool ShouldTerminatePrincipia()


### PR DESCRIPTION
Should help fix e.g. shuttles work with the node executor