### PR TITLE
Hoverslam: force the user out of non-phys warp

### DIFF
--- a/MechJeb2/MechJebModuleHoverslamAutopilot.cs
+++ b/MechJeb2/MechJebModuleHoverslamAutopilot.cs
@@ -139,7 +139,11 @@ namespace MuMech
             Core.Thrust.ThrustOff();
         }
 
-        private void TickAligning() { }
+        private void TickAligning()
+        {
+            if (!MuUtils.PhysicsRunning() && VesselState.time + TimeWarp.fixedDeltaTime > Core.Hoverslam.IgnitionUT)
+                Core.Warp.MinimumWarp(true);
+        }
 
         private void OnEnterCoast()
         {
@@ -151,6 +155,8 @@ namespace MuMech
         {
             if (AutoWarp)
                 Core.Warp.WarpToUT(Core.Hoverslam.IgnitionUT);
+            else if (!MuUtils.PhysicsRunning() && VesselState.time + TimeWarp.fixedDeltaTime > Core.Hoverslam.IgnitionUT)
+                Core.Warp.MinimumWarp(true);
         }
 
         private void OnEnterBurn() => Core.Thrust.TargetThrottle = 1.0f;


### PR DESCRIPTION
When in Align or Warp set the warp rate to 1x hard when in non-physwarp at the last instant before the next fixed update will be too late.