### PR TITLE
Hoverslam: add RF-compatible pulse width modulation

### DIFF
--- a/Localization/en-us.cfg
+++ b/Localization/en-us.cfg
@@ -1073,6 +1073,7 @@ Localization
         #MechJeb_HoverslamVerticalAltitude = Vertical phase altitude
         #MechJeb_HoverslamVerticalAuthority = Vertical phase authority
         #MechJeb_HoverslamTouchdownSpeed = Touchdown speed
+        #MechJeb_HoverslamPWMTimeWidth = PWM time width
         #MechJeb_HoverslamIgnitionLead = Ignition lead
         #MechJeb_HoverslamSimRecalcInterval = Simulation recalc interval
         #MechJeb_HoverslamAutoWarp = Hoverslam auto-warp

--- a/MechJeb2.sln.DotSettings
+++ b/MechJeb2.sln.DotSettings
@@ -37,6 +37,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PID/@EntryIndexedValue">PID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PSG/@EntryIndexedValue">PSG</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PVG/@EntryIndexedValue">PVG</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PWM/@EntryIndexedValue">PWM</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RC/@EntryIndexedValue">RC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RCS/@EntryIndexedValue">RCS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RH/@EntryIndexedValue">RH</s:String>

--- a/MechJeb2/MechJebModuleCustomInfoWindow.cs
+++ b/MechJeb2/MechJebModuleCustomInfoWindow.cs
@@ -1300,6 +1300,7 @@ Toggle:HoverslamSimulation.MapLandingPrediction
 Editable:HoverslamSimulation.VerticalAltitude
 Editable:HoverslamSimulation.VerticalAuthority
 Editable:HoverslamAutopilot.TouchdownSpeed
+Editable:HoverslamAutopilot.PWMTimeWidth
 Editable:HoverslamAutopilot.IgnitionLead
 Editable:HoverslamSimulation.SimRecalcInterval
 Toggle:HoverslamAutopilot.AutoWarp

--- a/MechJeb2/MechJebModuleHoverslamAutopilot.cs
+++ b/MechJeb2/MechJebModuleHoverslamAutopilot.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using MechJebLib.Control;
 using UnityEngine;
 using static MechJebLib.Utils.Statics;
 
@@ -37,6 +38,11 @@ namespace MuMech
 
         [ValueInfoItem("#MechJeb_HoverslamState", InfoItem.Category.Hoverslam)] //Hoverslam state
         public string HoverslamState => !Enabled ? "Disabled" : _state.ToString();
+
+        private const double DEFAULT_MIN_ON_TIME = 0.50;
+        [EditableInfoItem("#MechJeb_HoverslamPWMTimeWidth", InfoItem.Category.Hoverslam, width = 50, rightLabel = "s", expandWidth = true)]
+        [Persistent(pass = (int)(Pass.GLOBAL | Pass.TYPE))] //PWM time width
+        public readonly EditableDouble PWMTimeWidth = new EditableDouble(DEFAULT_MIN_ON_TIME);
 
         protected override void OnModuleEnabled()
         {
@@ -163,7 +169,13 @@ namespace MuMech
 
         private void TickBurn() => Core.Attitude.attitudeTo(-_adjV, AttitudeReference.INERTIAL, this);
 
-        private void OnEnterFinalDescent() => Core.Attitude.attitudeTo(Vector3d.back, AttitudeReference.SURFACE_VELOCITY, this);
+        private void OnEnterFinalDescent()
+        {
+            _pwm.Reset();
+            Core.Attitude.attitudeTo(Vector3d.back, AttitudeReference.SURFACE_VELOCITY, this);
+        }
+
+        private readonly DeltaSigmaThrottleModulator _pwm = new DeltaSigmaThrottleModulator(0.02, DEFAULT_MIN_ON_TIME);
 
         private void TickFinalDescent()
         {
@@ -175,10 +187,11 @@ namespace MuMech
             double h  = VesselState.altitudeBottom;
             double vf = TouchdownSpeed;
 
-            double accel    = g + 0.5 * (v2 - vf * vf) / h;
-            double throttle = (accel - VesselState.minThrustAccel) / (VesselState.maxThrustAccel - VesselState.minThrustAccel);
+            double accel = g + 0.5 * (v2 - vf * vf) / h;
 
-            Core.Thrust.TargetThrottle = (float)Clamp(throttle, 0.0001, 1.0);
+            _pwm.MinOnTime = PWMTimeWidth;
+            _pwm.MinOffTime = TimeWarp.fixedDeltaTime;
+            Core.Thrust.TargetThrottle = _pwm.ThrottleCommand(accel, VesselState.minThrustAccel, VesselState.maxThrustAccel, TimeWarp.fixedDeltaTime);
         }
 
         private void OnEnterFinished()

--- a/MechJebLib/Control/DeltaSigmaThrottleModulator.cs
+++ b/MechJebLib/Control/DeltaSigmaThrottleModulator.cs
@@ -1,0 +1,103 @@
+﻿using static System.Math;
+
+namespace MechJebLib.Control
+{
+    public class DeltaSigmaThrottleModulator
+    {
+        public double MinOnTime;
+        public double MinOffTime;
+
+        private double _accumulator; // impulse debt in m/s (positive = owed)
+        private bool   _outputOn;
+        private double _stateTimer;
+
+        // Smallest non-zero throttle we'll emit in the continuous regime.
+        // RealFuels (with allowZero) treats throttle == 0 as "engine off",
+        // so we never want to return exactly zero when the engine should
+        // be running at minimum.
+        private const double ENGINE_ON_EPSILON = 1e-4;
+
+        public DeltaSigmaThrottleModulator(double minOffTime, double minOnTime)
+        {
+            MinOffTime = minOffTime;
+            MinOnTime = minOnTime;
+        }
+
+        public void Reset()
+        {
+            _accumulator = 0.0;
+            _outputOn = false;
+            _stateTimer = 0.0;
+        }
+
+        /// <summary>
+        ///     Translates a commanded acceleration (m/s²) into a RealFuels-style
+        ///     throttle command (fraction of available control authority).
+        ///     0 = engine off; (0, 1] = engine on, mapping linearly between
+        ///     minThrustAccel and maxThrustAccel.
+        ///     Above minThrustAccel, returns the continuous throttle directly.
+        ///     Below minThrustAccel, delta-sigma modulates between full-off (0)
+        ///     and full-on (1) so the time-integrated acceleration tracks the
+        ///     commanded profile.
+        /// </summary>
+        public float ThrottleCommand(double commandedAccel,
+                                     double minThrustAccel,
+                                     double maxThrustAccel,
+                                     double dt)
+        {
+            // Hard rails.
+            if (commandedAccel <= 0.0)
+            {
+                Reset();
+                return 0.0f;
+            }
+
+            if (commandedAccel >= maxThrustAccel)
+            {
+                Reset();
+                _outputOn = true;
+                return 1.0f;
+            }
+
+            // Continuous regime: the engine can throttle to deliver
+            // commandedAccel without pulsing.
+            if (commandedAccel >= minThrustAccel)
+            {
+                Reset();
+                double t = (commandedAccel - minThrustAccel)
+                    / (maxThrustAccel - minThrustAccel);
+                return (float)Max(ENGINE_ON_EPSILON, t);
+            }
+
+            // PWM regime: pulse between 0 (engine off) and 1 (engine at
+            // maxThrustAccel). The integrator carries impulse debt in m/s.
+            double delivered = _outputOn ? maxThrustAccel : 0.0;
+            _accumulator += (commandedAccel - delivered) * dt;
+            _stateTimer += dt;
+
+            // Anti-windup: bound to one max-dwell of impulse debt.
+            double clamp = maxThrustAccel * Max(MinOnTime, MinOffTime);
+            if (_accumulator > clamp) _accumulator = clamp;
+            if (_accumulator < -clamp) _accumulator = -clamp;
+
+            if (_outputOn)
+            {
+                if (_accumulator < 0.0 && _stateTimer >= MinOnTime)
+                {
+                    _outputOn = false;
+                    _stateTimer = 0.0;
+                }
+            }
+            else
+            {
+                if (_accumulator > 0.0 && _stateTimer >= MinOffTime)
+                {
+                    _outputOn = true;
+                    _stateTimer = 0.0;
+                }
+            }
+
+            return _outputOn ? 1.0f : 0.0f;
+        }
+    }
+}

--- a/MechJebLib/MechJebLib.csproj
+++ b/MechJebLib/MechJebLib.csproj
@@ -62,6 +62,7 @@
         <Compile Include="Control\MultiVariableInterpolator.cs"/>
         <Compile Include="Control\PIDLoop.cs"/>
         <Compile Include="Control\PIDLoop2.cs"/>
+        <Compile Include="Control\DeltaSigmaThrottleModulator.cs" />
         <Compile Include="FuelFlowSimulation\DecouplingAnalyzer.cs"/>
         <Compile Include="FuelFlowSimulation\FuelFlowSimulation.cs"/>
         <Compile Include="FuelFlowSimulation\FuelStats.cs"/>


### PR DESCRIPTION
This integrates the requested acceleration in the vertical descent and applies a PWM to the throttle with a configurable minimum pulse width.

It doesn't know about limited ignitions and it will shift to PWM below minThrottle on any engine and start to waste ignitions. (but you really shouldn't have limited ignition engines that you need lower than your minThrottle to land -- either deep throttle and keep your authority somewhere in the middle of the band, or have lots or infinite ignitions).