### PR TITLE
Eliminate UI ExpandWidth allocs

### DIFF
--- a/MechJeb2/AttitudeControllers/BetterController.cs
+++ b/MechJeb2/AttitudeControllers/BetterController.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using JetBrainsAnnotations::JetBrains.Annotations;
 using KSP.Localization;
 using MechJebLib.Control;
@@ -345,14 +345,14 @@ namespace MuMech.AttitudeControllers
         public override void GUI()
         {
             GUILayout.BeginHorizontal();
-            UseStoppingTime = GUILayout.Toggle(UseStoppingTime, "Maximum Stopping Time", GUILayout.ExpandWidth(false));
+            UseStoppingTime = GUILayout.Toggle(UseStoppingTime, "Maximum Stopping Time", GuiUtils.LayoutNoExpandWidth);
             MaxStoppingTime.Text =
-                GUILayout.TextField(MaxStoppingTime.Text, GUILayout.ExpandWidth(true), GUILayout.Width(60));
+                GUILayout.TextField(MaxStoppingTime.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(60));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            UseFlipTime      = GUILayout.Toggle(UseFlipTime, "Minimum Flip Time", GUILayout.ExpandWidth(false));
-            MinFlipTime.Text = GUILayout.TextField(MinFlipTime.Text, GUILayout.ExpandWidth(true), GUILayout.Width(60));
+            UseFlipTime      = GUILayout.Toggle(UseFlipTime, "Minimum Flip Time", GuiUtils.LayoutNoExpandWidth);
+            MinFlipTime.Text = GUILayout.TextField(MinFlipTime.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(60));
             GUILayout.EndHorizontal();
 
             if (!UseStoppingTime)
@@ -360,9 +360,9 @@ namespace MuMech.AttitudeControllers
 
             GUILayout.BeginHorizontal();
             UseControlRange = GUILayout.Toggle(UseControlRange, Localizer.Format("#MechJeb_HybridController_checkbox2"),
-                GUILayout.ExpandWidth(false)); //"RollControlRange"
+                GuiUtils.LayoutNoExpandWidth); //"RollControlRange"
             RollControlRange.Text =
-                GUILayout.TextField(RollControlRange.Text, GUILayout.ExpandWidth(true), GUILayout.Width(60));
+                GUILayout.TextField(RollControlRange.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(60));
             GUILayout.EndHorizontal();
 
             const int COL1_WIDTH = 100;
@@ -370,109 +370,109 @@ namespace MuMech.AttitudeControllers
             const int COL3_WIDTH = 50;
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            GUILayout.Label("Velocity", GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            GUILayout.Label("Position", GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            GUILayout.Label("Velocity", GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            GUILayout.Label("Position", GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Kp", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            VelKp.Text = GUILayout.TextField(VelKp.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            PosKp.Text = GUILayout.TextField(PosKp.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("Kp", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            VelKp.Text = GUILayout.TextField(VelKp.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            PosKp.Text = GUILayout.TextField(PosKp.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Ti", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            VelTi.Text = GUILayout.TextField(VelTi.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            PosTi.Text = GUILayout.TextField(PosTi.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("Ti", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            VelTi.Text = GUILayout.TextField(VelTi.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            PosTi.Text = GUILayout.TextField(PosTi.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Td", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            VelTd.Text = GUILayout.TextField(VelTd.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            PosTd.Text = GUILayout.TextField(PosTd.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("Td", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            VelTd.Text = GUILayout.TextField(VelTd.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            PosTd.Text = GUILayout.TextField(PosTd.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("N", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            VelN.Text = GUILayout.TextField(VelN.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            PosN.Text = GUILayout.TextField(PosN.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("N", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            VelN.Text = GUILayout.TextField(VelN.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            PosN.Text = GUILayout.TextField(PosN.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("B", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            VelB.Text = GUILayout.TextField(VelB.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            PosB.Text = GUILayout.TextField(PosB.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("B", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            VelB.Text = GUILayout.TextField(VelB.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            PosB.Text = GUILayout.TextField(PosB.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("C", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            VelC.Text = GUILayout.TextField(VelC.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            PosC.Text = GUILayout.TextField(PosC.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("C", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            VelC.Text = GUILayout.TextField(VelC.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            PosC.Text = GUILayout.TextField(PosC.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Deadband", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            VelDeadband.Text = GUILayout.TextField(VelDeadband.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            PosDeadband.Text = GUILayout.TextField(PosDeadband.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("Deadband", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            VelDeadband.Text = GUILayout.TextField(VelDeadband.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            PosDeadband.Text = GUILayout.TextField(PosDeadband.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("SmoothIn", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            VelSmoothIn.Text = GUILayout.TextField(VelSmoothIn.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            PosSmoothIn.Text = GUILayout.TextField(PosSmoothIn.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("SmoothIn", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            VelSmoothIn.Text = GUILayout.TextField(VelSmoothIn.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            PosSmoothIn.Text = GUILayout.TextField(PosSmoothIn.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("SmoothOut", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            VelSmoothOut.Text = GUILayout.TextField(VelSmoothOut.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            PosSmoothOut.Text = GUILayout.TextField(PosSmoothOut.Text, GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("SmoothOut", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            VelSmoothOut.Text = GUILayout.TextField(VelSmoothOut.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            PosSmoothOut.Text = GUILayout.TextField(PosSmoothOut.Text, GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("", GUILayout.ExpandWidth(true), GUILayout.Width(COL1_WIDTH));
-            VelClegg = GUILayout.Toggle(VelClegg, Localizer.Format("Clegg"), GUILayout.ExpandWidth(false), GUILayout.Width(COL2_WIDTH));
-            PosClegg = GUILayout.Toggle(PosClegg, Localizer.Format("Clegg"), GUILayout.ExpandWidth(false), GUILayout.Width(COL3_WIDTH));
+            GUILayout.Label("", GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(COL1_WIDTH));
+            VelClegg = GUILayout.Toggle(VelClegg, Localizer.Format("Clegg"), GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL2_WIDTH));
+            PosClegg = GUILayout.Toggle(PosClegg, Localizer.Format("Clegg"), GuiUtils.LayoutNoExpandWidth, GuiUtils.LayoutWidth(COL3_WIDTH));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Pos PTerm", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_posPID[0].PTerm, _posPID[1].PTerm, _posPID[2].PTerm)), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Pos PTerm", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_posPID[0].PTerm, _posPID[1].PTerm, _posPID[2].PTerm)), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Pos ITerm", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_posPID[0].ITerm, _posPID[1].ITerm, _posPID[2].ITerm)), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Pos ITerm", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_posPID[0].ITerm, _posPID[1].ITerm, _posPID[2].ITerm)), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Pos DTerm", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_posPID[0].DTerm, _posPID[1].DTerm, _posPID[2].DTerm)), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Pos DTerm", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_posPID[0].DTerm, _posPID[1].DTerm, _posPID[2].DTerm)), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Vel PTerm", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_velPID[0].PTerm, _velPID[1].PTerm, _velPID[2].PTerm)), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Vel PTerm", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_velPID[0].PTerm, _velPID[1].PTerm, _velPID[2].PTerm)), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Vel ITerm", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_velPID[0].ITerm, _velPID[1].ITerm, _velPID[2].ITerm)), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Vel ITerm", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_velPID[0].ITerm, _velPID[1].ITerm, _velPID[2].ITerm)), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Vel DTerm", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_velPID[0].DTerm, _velPID[1].DTerm, _velPID[2].DTerm)), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Vel DTerm", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrintSci(new Vector3d(_velPID[0].DTerm, _velPID[1].DTerm, _velPID[2].DTerm)), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Smooth Torque", GUILayout.ExpandWidth(false));
-            SmoothTorque.Text = GUILayout.TextField(SmoothTorque.Text, GUILayout.ExpandWidth(true), GUILayout.Width(50));
+            GUILayout.Label("Smooth Torque", GuiUtils.LayoutNoExpandWidth);
+            SmoothTorque.Text = GUILayout.TextField(SmoothTorque.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(50));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Soften", GUILayout.ExpandWidth(false));
-            Soften.Text = GUILayout.TextField(Soften.Text, GUILayout.ExpandWidth(true), GUILayout.Width(50));
+            GUILayout.Label("Soften", GuiUtils.LayoutNoExpandWidth);
+            Soften.Text = GUILayout.TextField(Soften.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(50));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
@@ -481,66 +481,66 @@ namespace MuMech.AttitudeControllers
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Current", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_current), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Current", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_current), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Desired", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_desired), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Desired", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_desired), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Error", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_error), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Error", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_error), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("TargetOmega", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_targetOmega), GUILayout.ExpandWidth(false));
+            GUILayout.Label("TargetOmega", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_targetOmega), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Omega", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_vessel.angularVelocityD), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Omega", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_vessel.angularVelocityD), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label2"),
-                GUILayout.ExpandWidth(true)); //"Actuation"
-            GUILayout.Label(MuUtils.PrettyPrint(_actuation), GUILayout.ExpandWidth(false));
+                GuiUtils.LayoutExpandWidth); //"Actuation"
+            GUILayout.Label(MuUtils.PrettyPrint(_actuation), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label4"),
-                GUILayout.ExpandWidth(true)); //"TargetTorque"
-            GUILayout.Label(MuUtils.PrettyPrint(_targetTorque), GUILayout.ExpandWidth(false));
+                GuiUtils.LayoutExpandWidth); //"TargetTorque"
+            GUILayout.Label(MuUtils.PrettyPrint(_targetTorque), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label5"),
-                GUILayout.ExpandWidth(true)); //"ControlTorque"
-            GUILayout.Label(MuUtils.PrettyPrint(_controlTorque), GUILayout.ExpandWidth(false));
+                GuiUtils.LayoutExpandWidth); //"ControlTorque"
+            GUILayout.Label(MuUtils.PrettyPrint(_controlTorque), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("TargetAlpha", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_targetAlpha), GUILayout.ExpandWidth(false));
+            GUILayout.Label("TargetAlpha", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_targetAlpha), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("MaxAlpha", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_maxAlpha), GUILayout.ExpandWidth(false));
+            GUILayout.Label("MaxAlpha", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_maxAlpha), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("MOI", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_vessel.MOI), GUILayout.ExpandWidth(false));
+            GUILayout.Label("MOI", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_vessel.MOI), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Response Speed", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(Ac.VesselState.torqueResponseSpeed), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Response Speed", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(Ac.VesselState.torqueResponseSpeed), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
         }
     }

--- a/MechJeb2/AttitudeControllers/HybridController.cs
+++ b/MechJeb2/AttitudeControllers/HybridController.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using JetBrainsAnnotations::JetBrains.Annotations;
 using KSP.Localization;
@@ -150,14 +150,14 @@ namespace MuMech.AttitudeControllers
             UseInertia = GUILayout.Toggle(UseInertia, Localizer.Format("#MechJeb_HybridController_checkbox1")); //"useInertia"
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label1"), GUILayout.ExpandWidth(false)); //"MaxStoppingTime"
-            MaxStoppingTime.Text = GUILayout.TextField(MaxStoppingTime.Text, GUILayout.ExpandWidth(true), GUILayout.Width(60));
+            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label1"), GuiUtils.LayoutNoExpandWidth); //"MaxStoppingTime"
+            MaxStoppingTime.Text = GUILayout.TextField(MaxStoppingTime.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(60));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             UseControlRange = GUILayout.Toggle(UseControlRange, Localizer.Format("#MechJeb_HybridController_checkbox2"),
-                GUILayout.ExpandWidth(false)); //"RollControlRange"
-            RollControlRange.Text = GUILayout.TextField(RollControlRange.Text, GUILayout.ExpandWidth(true), GUILayout.Width(60));
+                GuiUtils.LayoutNoExpandWidth); //"RollControlRange"
+            RollControlRange.Text = GUILayout.TextField(RollControlRange.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(60));
             GUILayout.EndHorizontal();
 
             // Not used yet
@@ -172,38 +172,38 @@ namespace MuMech.AttitudeControllers
             //}
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label2"), GUILayout.ExpandWidth(true)); //"Actuation"
-            GUILayout.Label(MuUtils.PrettyPrint(_actuation), GUILayout.ExpandWidth(false));
+            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label2"), GuiUtils.LayoutExpandWidth); //"Actuation"
+            GUILayout.Label(MuUtils.PrettyPrint(_actuation), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label3"), GUILayout.ExpandWidth(true)); //"phiVector"
-            GUILayout.Label(MuUtils.PrettyPrint(_phiVector), GUILayout.ExpandWidth(false));
+            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label3"), GuiUtils.LayoutExpandWidth); //"phiVector"
+            GUILayout.Label(MuUtils.PrettyPrint(_phiVector), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Omega", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_omega), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Omega", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_omega), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("MaxOmega", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_maxOmega), GUILayout.ExpandWidth(false));
+            GUILayout.Label("MaxOmega", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_maxOmega), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label4"), GUILayout.ExpandWidth(true)); //"TargetTorque"
-            GUILayout.Label(MuUtils.PrettyPrint(_targetTorque), GUILayout.ExpandWidth(false));
+            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label4"), GuiUtils.LayoutExpandWidth); //"TargetTorque"
+            GUILayout.Label(MuUtils.PrettyPrint(_targetTorque), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label5"), GUILayout.ExpandWidth(true)); //"ControlTorque"
-            GUILayout.Label(MuUtils.PrettyPrint(_controlTorque), GUILayout.ExpandWidth(false));
+            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label5"), GuiUtils.LayoutExpandWidth); //"ControlTorque"
+            GUILayout.Label(MuUtils.PrettyPrint(_controlTorque), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label6"), GUILayout.ExpandWidth(true)); //"Inertia"
-            GUILayout.Label("|" + Ac.inertia.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(Ac.inertia), GUILayout.ExpandWidth(false));
+            GUILayout.Label(Localizer.Format("#MechJeb_HybridController_label6"), GuiUtils.LayoutExpandWidth); //"Inertia"
+            GUILayout.Label("|" + Ac.inertia.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(Ac.inertia), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
         }
     }

--- a/MechJeb2/AttitudeControllers/KosAttitudeController.cs
+++ b/MechJeb2/AttitudeControllers/KosAttitudeController.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using JetBrainsAnnotations::JetBrains.Annotations;
 using UnityEngine;
@@ -162,35 +162,35 @@ namespace MuMech.AttitudeControllers
         public override void GUI()
         {
             GUILayout.BeginHorizontal();
-            GUILayout.Label("MaxStoppingTime", GUILayout.ExpandWidth(false));
-            MaxStoppingTime.Text = GUILayout.TextField(MaxStoppingTime.Text, GUILayout.ExpandWidth(true), GUILayout.Width(40));
+            GUILayout.Label("MaxStoppingTime", GuiUtils.LayoutNoExpandWidth);
+            MaxStoppingTime.Text = GUILayout.TextField(MaxStoppingTime.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(40));
             GUILayout.EndHorizontal();
 
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("RollControlRange", GUILayout.ExpandWidth(false));
-            RollControlRange.Text = GUILayout.TextField(RollControlRange.Text, GUILayout.ExpandWidth(true), GUILayout.Width(40));
+            GUILayout.Label("RollControlRange", GuiUtils.LayoutNoExpandWidth);
+            RollControlRange.Text = GUILayout.TextField(RollControlRange.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(40));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Actuation", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_actuation), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Actuation", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_actuation), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("phiVector", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_phiVector), GUILayout.ExpandWidth(false));
+            GUILayout.Label("phiVector", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_phiVector), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("TargetTorque", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_targetTorque), GUILayout.ExpandWidth(false));
+            GUILayout.Label("TargetTorque", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_targetTorque), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("ControlTorque", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_controlTorque), GUILayout.ExpandWidth(false));
+            GUILayout.Label("ControlTorque", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_controlTorque), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
         }
     }

--- a/MechJeb2/AttitudeControllers/LQRController.cs
+++ b/MechJeb2/AttitudeControllers/LQRController.cs
@@ -1,4 +1,4 @@
-﻿using JetBrains.Annotations;
+using JetBrains.Annotations;
 using MechJebLib.Control;
 using UnityEngine;
 using static System.Math;
@@ -103,53 +103,53 @@ namespace MuMech.AttitudeControllers
         public override void GUI()
         {
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Smooth Torque", GUILayout.ExpandWidth(false));
-            SmoothTorque.Text = GUILayout.TextField(SmoothTorque.Text, GUILayout.ExpandWidth(true), GUILayout.Width(50));
+            GUILayout.Label("Smooth Torque", GuiUtils.LayoutNoExpandWidth);
+            SmoothTorque.Text = GUILayout.TextField(SmoothTorque.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(50));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Position", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_current), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Position", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_current), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Desired", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_desired), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Desired", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_desired), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Error", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_error), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Error", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_error), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Velocity", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_velocity), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Velocity", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_velocity), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Mass", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_mass), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Mass", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_mass), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Actuation", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_actuation), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Actuation", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_actuation), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("MOI", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_vessel.MOI), GUILayout.ExpandWidth(false));
+            GUILayout.Label("MOI", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_vessel.MOI), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Control Torque", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_controlTorque), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Control Torque", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_controlTorque), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Applied Torque", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(_targetTorque), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Applied Torque", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(_targetTorque), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
         }
     }

--- a/MechJeb2/AttitudeControllers/MJAttitudeController.cs
+++ b/MechJeb2/AttitudeControllers/MJAttitudeController.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using JetBrainsAnnotations::JetBrains.Annotations;
 using KSP.Localization;
@@ -248,13 +248,13 @@ namespace MuMech.AttitudeControllers
                 GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label1")); //"Larger ship do better with a larger Tf"
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label2"), GUILayout.ExpandWidth(true));  //"Tf (s)"
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label3"), GUILayout.ExpandWidth(false)); //"P"
-                _uiTfX.Text = GUILayout.TextField(_uiTfX.Text, GUILayout.ExpandWidth(true), GUILayout.Width(40));
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label4"), GUILayout.ExpandWidth(false)); //"Y"
-                _uiTfY.Text = GUILayout.TextField(_uiTfY.Text, GUILayout.ExpandWidth(true), GUILayout.Width(40));
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label5"), GUILayout.ExpandWidth(false)); //"R"
-                _uiTfZ.Text = GUILayout.TextField(_uiTfZ.Text, GUILayout.ExpandWidth(true), GUILayout.Width(40));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label2"), GuiUtils.LayoutExpandWidth);  //"Tf (s)"
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label3"), GuiUtils.LayoutNoExpandWidth); //"P"
+                _uiTfX.Text = GUILayout.TextField(_uiTfX.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(40));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label4"), GuiUtils.LayoutNoExpandWidth); //"Y"
+                _uiTfY.Text = GUILayout.TextField(_uiTfY.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(40));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label5"), GuiUtils.LayoutNoExpandWidth); //"R"
+                _uiTfZ.Text = GUILayout.TextField(_uiTfZ.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(40));
                 GUILayout.EndHorizontal();
 
                 _uiTfX = Math.Max(0.01, _uiTfX);
@@ -264,12 +264,12 @@ namespace MuMech.AttitudeControllers
             else
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label6"), GUILayout.ExpandWidth(true)); //"Tf"
-                GUILayout.Label(MuUtils.PrettyPrint(_tfV), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label6"), GuiUtils.LayoutExpandWidth); //"Tf"
+                GUILayout.Label(MuUtils.PrettyPrint(_tfV), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label7"), GUILayout.ExpandWidth(true)); //"Tf range"
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label7"), GuiUtils.LayoutExpandWidth); //"Tf range"
                 GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_AttitudeController_label8"), _uiTfMin, "", 50);     //"min"
                 _uiTfMin = Math.Max(_uiTfMin, 0.01);
                 GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_AttitudeController_label9"), _uiTfMax, "", 50); //"max"
@@ -312,49 +312,49 @@ namespace MuMech.AttitudeControllers
             //if (showInfos)
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label12"), GUILayout.ExpandWidth(true)); //"Kp"
-                GUILayout.Label(MuUtils.PrettyPrint(_pid.Kp), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label12"), GuiUtils.LayoutExpandWidth); //"Kp"
+                GUILayout.Label(MuUtils.PrettyPrint(_pid.Kp), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label13"), GUILayout.ExpandWidth(true)); //"Ki"
-                GUILayout.Label(MuUtils.PrettyPrint(_pid.Ki), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label13"), GuiUtils.LayoutExpandWidth); //"Ki"
+                GUILayout.Label(MuUtils.PrettyPrint(_pid.Ki), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label14"), GUILayout.ExpandWidth(true)); //"Kd"
-                GUILayout.Label(MuUtils.PrettyPrint(_pid.Kd), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label14"), GuiUtils.LayoutExpandWidth); //"Kd"
+                GUILayout.Label(MuUtils.PrettyPrint(_pid.Kd), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label15"), GUILayout.ExpandWidth(true)); //"Error"
-                GUILayout.Label(MuUtils.PrettyPrint(_error * Mathf.Rad2Deg), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label15"), GuiUtils.LayoutExpandWidth); //"Error"
+                GUILayout.Label(MuUtils.PrettyPrint(_error * Mathf.Rad2Deg), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label16"), GUILayout.ExpandWidth(true)); //"prop. action."
-                GUILayout.Label(MuUtils.PrettyPrint(_pid.PropAct), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label16"), GuiUtils.LayoutExpandWidth); //"prop. action."
+                GUILayout.Label(MuUtils.PrettyPrint(_pid.PropAct), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label17"), GUILayout.ExpandWidth(true)); //"deriv. action"
-                GUILayout.Label(MuUtils.PrettyPrint(_pid.DerivativeAct), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label17"), GuiUtils.LayoutExpandWidth); //"deriv. action"
+                GUILayout.Label(MuUtils.PrettyPrint(_pid.DerivativeAct), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label18"), GUILayout.ExpandWidth(true)); //"integral action."
-                GUILayout.Label(MuUtils.PrettyPrint(_pid.INTAccum), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label18"), GuiUtils.LayoutExpandWidth); //"integral action."
+                GUILayout.Label(MuUtils.PrettyPrint(_pid.INTAccum), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label19"), GUILayout.ExpandWidth(true)); //"PID Action"
-                GUILayout.Label(MuUtils.PrettyPrint(_pidAction), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label19"), GuiUtils.LayoutExpandWidth); //"PID Action"
+                GUILayout.Label(MuUtils.PrettyPrint(_pidAction), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label20"), GUILayout.ExpandWidth(true)); //"Inertia"
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeController_label20"), GuiUtils.LayoutExpandWidth); //"Inertia"
                 GUILayout.Label("|" + Ac.inertia.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(Ac.inertia),
-                    GUILayout.ExpandWidth(false));
+                    GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
             }
 

--- a/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
+++ b/MechJeb2/Maneuver/OperationAdvancedTransfer.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using System.Collections.Generic;
 using JetBrainsAnnotations::JetBrains.Annotations;
@@ -235,7 +235,7 @@ namespace MuMech
                         fontStyle = GuiUtils.Skin.label.fontStyle,
                         normal    = { textColor = GuiUtils.Skin.label.normal.textColor }
                     };
-                GUILayout.Box(Localizer.Format("#MechJeb_adv_computing") + worker.Progress + "%", progressStyle, GUILayout.Width(windowWidth),
+                GUILayout.Box(Localizer.Format("#MechJeb_adv_computing") + worker.Progress + "%", progressStyle, GuiUtils.LayoutWidth(windowWidth),
                     GUILayout.Height(porkchop_Height)); //"Computing:"
             }
 

--- a/MechJeb2/Maneuver/OperationResonantOrbit.cs
+++ b/MechJeb2/Maneuver/OperationResonantOrbit.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System.Collections.Generic;
 using JetBrainsAnnotations::JetBrains.Annotations;
 using KSP.Localization;
@@ -28,10 +28,10 @@ namespace MuMech
             GUILayout.Label(Localizer.Format("#MechJeb_resonant_label1",
                 ResonanceNumerator.Val + "/" + ResonanceDenominator.Val)); //"Change your orbital period to <<1>> of your current orbital period"
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_resonant_label2"), GUILayout.ExpandWidth(true)); //New orbital period ratio :
-            ResonanceNumerator.Text = GUILayout.TextField(ResonanceNumerator.Text, GUILayout.Width(30));
-            GUILayout.Label("/", GUILayout.ExpandWidth(false));
-            ResonanceDenominator.Text = GUILayout.TextField(ResonanceDenominator.Text, GUILayout.Width(30));
+            GUILayout.Label(Localizer.Format("#MechJeb_resonant_label2"), GuiUtils.LayoutExpandWidth); //New orbital period ratio :
+            ResonanceNumerator.Text = GUILayout.TextField(ResonanceNumerator.Text, GuiUtils.LayoutWidth(30));
+            GUILayout.Label("/", GuiUtils.LayoutNoExpandWidth);
+            ResonanceDenominator.Text = GUILayout.TextField(ResonanceDenominator.Text, GuiUtils.LayoutWidth(30));
             GUILayout.EndHorizontal();
             _timeSelector.DoChooseTimeGUI();
         }

--- a/MechJeb2/Maneuver/PlotArea.cs
+++ b/MechJeb2/Maneuver/PlotArea.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 
 namespace MuMech
@@ -68,7 +68,7 @@ namespace MuMech
 
         public void DoGUI()
         {
-            GUILayout.Box(_texture, GUIStyle.none, GUILayout.Width(_texture.width), GUILayout.Height(_texture.height));
+            GUILayout.Box(_texture, GUIStyle.none, GuiUtils.LayoutWidth(_texture.width), GUILayout.Height(_texture.height));
             if (Event.current.type == EventType.Repaint)
             {
                 HoveredPoint = null;

--- a/MechJeb2/MechJebModuleAscentClassicPathMenu.cs
+++ b/MechJeb2/MechJebModuleAscentClassicPathMenu.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using KSP.Localization;
 using UnityEngine;
@@ -27,7 +27,7 @@ namespace MuMech
             _path           = Core.GetComputerModule<MechJebModuleAscentClassicAutopilot>();
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(300), GUILayout.Height(100) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(300), GUILayout.Height(100) };
 
         protected override void WindowGUI(int windowID)
         {
@@ -44,16 +44,16 @@ namespace MuMech
             double oldTurnShapeExponent = _ascentSettings.TurnShapeExponent;
 
             _ascentSettings.AutoPath = GUILayout.Toggle(_ascentSettings.AutoPath, Localizer.Format("#MechJeb_AscentPathEd_auto"),
-                GUILayout.ExpandWidth(false)); //"Automatic Altitude Turn"
+                GuiUtils.LayoutNoExpandWidth); //"Automatic Altitude Turn"
             if (_ascentSettings.AutoPath)
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AscentPathEd_label1"), GUILayout.Width(60)); //"Altitude: "
+                GUILayout.Label(Localizer.Format("#MechJeb_AscentPathEd_label1"), GuiUtils.LayoutWidth(60)); //"Altitude: "
                 // 1 to 200 / 200 = 0.5% to 105%, without this mess would the slider cause lots of garbage floats like 0.9999864
                 _ascentSettings.AutoTurnPerc = Mathf.Floor(GUILayout.HorizontalSlider(_ascentSettings.AutoTurnPerc * 200f, 1f, 210.5f)) / 200f;
                 GUILayout.EndHorizontal();
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AscentPathEd_label2"), GUILayout.Width(60)); //"Velocity: "
+                GUILayout.Label(Localizer.Format("#MechJeb_AscentPathEd_label2"), GuiUtils.LayoutWidth(60)); //"Velocity: "
                 _ascentSettings.AutoTurnSpdFactor = Mathf.Floor(GUILayout.HorizontalSlider(_ascentSettings.AutoTurnSpdFactor * 2f, 8f, 160f)) / 2f;
                 GUILayout.EndHorizontal();
             }
@@ -61,15 +61,15 @@ namespace MuMech
             if (_ascentSettings.AutoPath)
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AscentPathEd_label3"), GUILayout.ExpandWidth(false)); //"Turn start when Altitude is "
-                GUILayout.Label(_ascentSettings.AutoTurnStartAltitude.ToSI(2) + "m ", GUILayout.ExpandWidth(false));
-                GUILayout.Label(Localizer.Format("#MechJeb_AscentPathEd_label4"), GUILayout.ExpandWidth(false));      //"or Velocity reach "
-                GUILayout.Label(_ascentSettings.AutoTurnStartVelocity.ToSI(3) + "m/s", GUILayout.ExpandWidth(false)); //
+                GUILayout.Label(Localizer.Format("#MechJeb_AscentPathEd_label3"), GuiUtils.LayoutNoExpandWidth); //"Turn start when Altitude is "
+                GUILayout.Label(_ascentSettings.AutoTurnStartAltitude.ToSI(2) + "m ", GuiUtils.LayoutNoExpandWidth);
+                GUILayout.Label(Localizer.Format("#MechJeb_AscentPathEd_label4"), GuiUtils.LayoutNoExpandWidth);      //"or Velocity reach "
+                GUILayout.Label(_ascentSettings.AutoTurnStartVelocity.ToSI(3) + "m/s", GuiUtils.LayoutNoExpandWidth); //
                 GUILayout.EndHorizontal();
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(Localizer.Format("#MechJeb_AscentPathEd_label5")); //"Turn end altitude: "
                 GUILayout.Label(_ascentSettings.AutoTurnEndAltitude.ToSI(2) + "m", GuiUtils.MiddleRightLabel,
-                    GUILayout.ExpandWidth(true));
+                    GuiUtils.LayoutExpandWidth);
                 GUILayout.EndHorizontal();
             }
             else

--- a/MechJeb2/MechJebModuleAscentMenu.cs
+++ b/MechJeb2/MechJebModuleAscentMenu.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using JetBrainsAnnotations::JetBrains.Annotations;
 using KSP.Localization;
@@ -484,7 +484,7 @@ namespace MuMech
             return $"burn: {kspStage} {solution.Tgo(t, psgPhase):F1}s {solution.DV(t, psgPhase):F1}m/s ({excessDV:F1}m/s)";
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(275), GUILayout.Height(30) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(275), GUILayout.Height(30) };
 
         public override string GetName() => CachedLocalizer.Instance.MechJebAscentTitle; //"Ascent Guidance"
 

--- a/MechJeb2/MechJebModuleAscentPSGSettingsMenu.cs
+++ b/MechJeb2/MechJebModuleAscentPSGSettingsMenu.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System.Collections.Generic;
 using MechJebLib.FuelFlowSimulation;
 using UnityEngine;
@@ -18,7 +18,7 @@ namespace MuMech
         private static GUIStyle _btNormal;
         private static GUIStyle _btActive;
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(300), GUILayout.Height(100) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(300), GUILayout.Height(100) };
 
         private void SetupButtonStyles()
         {

--- a/MechJeb2/MechJebModuleAscentSettingsMenu.cs
+++ b/MechJeb2/MechJebModuleAscentSettingsMenu.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using UnityEngine;
 using UnityEngine.Profiling;
 
@@ -122,7 +122,7 @@ namespace MuMech
             base.WindowGUI(windowID);
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(275), GUILayout.Height(30) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(275), GUILayout.Height(30) };
 
         public override string GetName() => "Ascent Settings";
 

--- a/MechJeb2/MechJebModuleAttitudeAdjustment.cs
+++ b/MechJeb2/MechJebModuleAttitudeAdjustment.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using KSP.Localization;
 using UnityEngine;
 
@@ -60,52 +60,52 @@ namespace MuMech
             if (showInfos)
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label1"), GUILayout.ExpandWidth(true)); //Axis Control
-                GUILayout.Label(MuUtils.PrettyPrint(Core.Attitude.AxisControl, "F0"), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label1"), GuiUtils.LayoutExpandWidth); //Axis Control
+                GUILayout.Label(MuUtils.PrettyPrint(Core.Attitude.AxisControl, "F0"), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label2"), GUILayout.ExpandWidth(true)); //Torque
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label2"), GuiUtils.LayoutExpandWidth); //Torque
                 GUILayout.Label("|" + Core.Attitude.torque.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(Core.Attitude.torque),
-                    GUILayout.ExpandWidth(false));
+                    GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label3"), GUILayout.ExpandWidth(true)); //torqueReactionSpeed
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label3"), GuiUtils.LayoutExpandWidth); //torqueReactionSpeed
                 GUILayout.Label(
                     "|" + VesselState.torqueReactionSpeed.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(VesselState.torqueReactionSpeed),
-                    GUILayout.ExpandWidth(false));
+                    GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 var ratio = Vector3d.Scale(VesselState.MoI, Core.Attitude.torque.InvertNoNaN());
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label4"), GUILayout.ExpandWidth(true)); //MOI / torque
-                GUILayout.Label("|" + ratio.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(ratio), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label4"), GuiUtils.LayoutExpandWidth); //MOI / torque
+                GUILayout.Label("|" + ratio.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(ratio), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label5"), GUILayout.ExpandWidth(true)); //MOI
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label5"), GuiUtils.LayoutExpandWidth); //MOI
                 GUILayout.Label("|" + VesselState.MoI.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(VesselState.MoI),
-                    GUILayout.ExpandWidth(false));
+                    GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label6"), GUILayout.ExpandWidth(true)); //Angular Velocity
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label6"), GuiUtils.LayoutExpandWidth); //Angular Velocity
                 GUILayout.Label("|" + Vessel.angularVelocity.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(Vessel.angularVelocity),
-                    GUILayout.ExpandWidth(false));
+                    GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label7"), GUILayout.ExpandWidth(true)); //"Angular M"
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label7"), GuiUtils.LayoutExpandWidth); //"Angular M"
                 GUILayout.Label(
                     "|" + VesselState.angularMomentum.magnitude.ToString("F3") + "| " + MuUtils.PrettyPrint(VesselState.angularMomentum),
-                    GUILayout.ExpandWidth(false));
+                    GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label8"), GUILayout.ExpandWidth(true)); //fixedDeltaTime
-                GUILayout.Label(TimeWarp.fixedDeltaTime.ToString("F3"), GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label8"), GuiUtils.LayoutExpandWidth); //fixedDeltaTime
+                GUILayout.Label(TimeWarp.fixedDeltaTime.ToString("F3"), GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
             }
 
@@ -117,14 +117,14 @@ namespace MuMech
             arrows.seeThrough = GUILayout.Toggle(arrows.seeThrough, Localizer.Format("#MechJeb_AttitudeAdjust_checkbox6")); //Visible through object
 
             arrows.comSphereActive = GUILayout.Toggle(arrows.comSphereActive, Localizer.Format("#MechJeb_AttitudeAdjust_checkbox7"),
-                GUILayout.ExpandWidth(false)); //Display the CoM
+                GuiUtils.LayoutNoExpandWidth); //Display the CoM
             arrows.colSphereActive = GUILayout.Toggle(arrows.colSphereActive, Localizer.Format("#MechJeb_AttitudeAdjust_checkbox8"),
-                GUILayout.ExpandWidth(false)); //Display the CoL
+                GuiUtils.LayoutNoExpandWidth); //Display the CoL
             arrows.cotSphereActive = GUILayout.Toggle(arrows.cotSphereActive, Localizer.Format("#MechJeb_AttitudeAdjust_checkbox9"),
-                GUILayout.ExpandWidth(false)); //Display the CoT
+                GuiUtils.LayoutNoExpandWidth); //Display the CoT
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label10"), GUILayout.ExpandWidth(true)); //Radius of Sphere
-            arrows.comSphereRadius.Text = GUILayout.TextField(arrows.comSphereRadius.Text, GUILayout.Width(40));
+            GUILayout.Label(Localizer.Format("#MechJeb_AttitudeAdjust_Label10"), GuiUtils.LayoutExpandWidth); //Radius of Sphere
+            arrows.comSphereRadius.Text = GUILayout.TextField(arrows.comSphereRadius.Text, GuiUtils.LayoutWidth(40));
             GUILayout.EndHorizontal();
             arrows.displayAtCoM =
                 GUILayout.Toggle(arrows.displayAtCoM, Localizer.Format("#MechJeb_AttitudeAdjust_checkbox10")); //Arrows origins at the CoM
@@ -157,7 +157,7 @@ namespace MuMech
             base.WindowGUI(windowID);
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(350), GUILayout.Height(150) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(350), GUILayout.Height(150) };
 
         public override string GetName() => Localizer.Format("#MechJeb_AttitudeAdjust_title"); //Attitude Adjustment
 

--- a/MechJeb2/MechJebModuleCustomInfoWindow.cs
+++ b/MechJeb2/MechJebModuleCustomInfoWindow.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -142,7 +142,7 @@ namespace MuMech
             Profiler.EndSample();
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(250), GUILayout.Height(30) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(250), GUILayout.Height(30) };
 
         public override void DrawGUI(bool inEditor)
         {
@@ -525,11 +525,11 @@ namespace MuMech
                 List<ComputerModule> allWindows = Core.GetComputerModules<MechJebModuleCustomInfoWindow>();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_WindowEd_Edtitle"), GUILayout.ExpandWidth(false)); //Title:
+                GUILayout.Label(Localizer.Format("#MechJeb_WindowEd_Edtitle"), GuiUtils.LayoutNoExpandWidth); //Title:
                 int editedWindowIndex = allWindows.IndexOf(editedWindow);
                 editedWindowIndex = GuiUtils.ArrowSelector(editedWindowIndex, allWindows.Count, () =>
                 {
-                    string newTitle = GUILayout.TextField(editedWindow.title, GUILayout.Width(120), GUILayout.ExpandWidth(false));
+                    string newTitle = GUILayout.TextField(editedWindow.title, GuiUtils.LayoutWidth(120), GuiUtils.LayoutNoExpandWidth);
 
                     if (editedWindow.title != newTitle)
                     {
@@ -543,7 +543,7 @@ namespace MuMech
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(Localizer.Format("#MechJeb_WindowEd_label1")); //Show in:
                 editedWindow.ShowInFlight =
-                    GUILayout.Toggle(editedWindow.ShowInFlight, Localizer.Format("#MechJeb_WindowEd_checkbox1"), GUILayout.Width(60));    //Flight
+                    GUILayout.Toggle(editedWindow.ShowInFlight, Localizer.Format("#MechJeb_WindowEd_checkbox1"), GuiUtils.LayoutWidth(60));    //Flight
                 editedWindow.ShowInEditor = GUILayout.Toggle(editedWindow.ShowInEditor, Localizer.Format("#MechJeb_WindowEd_checkbox2")); //Editor
                 GUILayout.EndHorizontal();
 
@@ -648,7 +648,7 @@ namespace MuMech
             Profiler.EndSample();
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(200), GUILayout.Height(540) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(200), GUILayout.Height(540) };
 
         public override string GetName() => CachedLocalizer.Instance.MechJebWindowEdTitle; //Custom Window Editor
 
@@ -764,6 +764,8 @@ namespace MuMech
         private int    cacheValidity = -1;
         public  bool   externalRefresh;
 
+        private readonly GUILayoutOption[] _widthOption;
+
         public ValueInfoItem(object obj, MemberInfo member, ValueInfoItemAttribute attribute)
             : base(attribute)
         {
@@ -784,6 +786,8 @@ namespace MuMech
                 _getterCache.Add(member, CompileAccessor(obj, member));
 
             getValue = _getterCache[member];
+
+            _widthOption = new[] { width > 0 ? GuiUtils.LayoutWidth(width) : GuiUtils.LayoutNoExpandWidth };
 
             Profiler.EndSample();
         }
@@ -887,7 +891,7 @@ namespace MuMech
             if (!externalRefresh) UpdateItemCache();
             GUILayout.BeginHorizontal();
             GUILayout.Label(localizedName); //
-            GUILayout.Label(stringValue, width > 0 ? GUILayout.Width(width) : GUILayout.ExpandWidth(false));
+            GUILayout.Label(stringValue, _widthOption);
             GUILayout.EndHorizontal();
         }
     }

--- a/MechJeb2/MechJebModuleDockingGuidance.cs
+++ b/MechJeb2/MechJebModuleDockingGuidance.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System.Linq;
 using KSP.Localization;
 using UnityEngine;
@@ -89,9 +89,9 @@ namespace MuMech
 
 
             GUILayout.Label(Localizer.Format("#MechJeb_Docking_label7", autopilot.safeDistance.ToString("F2")),
-                GUILayout.ExpandWidth(false)); //"safeDistance "
+                GuiUtils.LayoutNoExpandWidth); //"safeDistance "
             GUILayout.Label(Localizer.Format("#MechJeb_Docking_label8", autopilot.targetSize.ToString("F2")),
-                GUILayout.ExpandWidth(false)); //"targetSize   "
+                GuiUtils.LayoutNoExpandWidth); //"targetSize   "
 
             if (autopilot.speedLimit < 0)
                 autopilot.speedLimit = 0;
@@ -99,10 +99,10 @@ namespace MuMech
 
             GUILayout.BeginHorizontal();
             autopilot.forceRol =
-                GUILayout.Toggle(autopilot.forceRol, Localizer.Format("#MechJeb_Docking_checkbox6"), GUILayout.ExpandWidth(false)); //"Force Roll :"
+                GUILayout.Toggle(autopilot.forceRol, Localizer.Format("#MechJeb_Docking_checkbox6"), GuiUtils.LayoutNoExpandWidth); //"Force Roll :"
 
-            autopilot.rol.Text = GUILayout.TextField(autopilot.rol.Text, GUILayout.Width(30));
-            GUILayout.Label("°", GUILayout.ExpandWidth(false));
+            autopilot.rol.Text = GUILayout.TextField(autopilot.rol.Text, GuiUtils.LayoutWidth(30));
+            GUILayout.Label("°", GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             if (autopilot.Enabled != active)
@@ -138,7 +138,7 @@ namespace MuMech
             base.WindowGUI(windowID);
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(300), GUILayout.Height(50) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(300), GUILayout.Height(50) };
 
         protected override void OnModuleDisabled()
         {

--- a/MechJeb2/MechJebModuleFlightRecorderGraph.cs
+++ b/MechJeb2/MechJebModuleFlightRecorderGraph.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using KSP.Localization;
 using UnityEngine;
@@ -120,36 +120,36 @@ namespace MuMech
             GUILayout.BeginHorizontal();
 
             if (GUILayout.Button(paused ? Localizer.Format("#MechJeb_Flightrecord_Button1_1") : Localizer.Format("#MechJeb_Flightrecord_Button1_2"),
-                    GUILayout.ExpandWidth(false))) //"Resume""Pause"
+                    GuiUtils.LayoutNoExpandWidth)) //"Resume""Pause"
             {
                 paused = !paused;
             }
 
             if (GUILayout.Button(
                     downrange ? Localizer.Format("#MechJeb_Flightrecord_Button2_1") : Localizer.Format("#MechJeb_Flightrecord_Button2_2"),
-                    GUILayout.ExpandWidth(false))) //"Downrange""Time"
+                    GuiUtils.LayoutNoExpandWidth)) //"Downrange""Time"
             {
                 downrange = !downrange;
             }
 
-            //GUILayout.Label("Size " + (8 * typeCount * recorder.history.Length >> 10).ToString() + "kB", GUILayout.ExpandWidth(false));
+            //GUILayout.Label("Size " + (8 * typeCount * recorder.history.Length >> 10).ToString() + "kB", GuiUtils.LayoutNoExpandWidth);
 
             GUILayout.Label(Localizer.Format("#MechJeb_Flightrecord_Label1", GuiUtils.TimeToDHMS(recorder.TimeSinceMark)),
-                GUILayout.ExpandWidth(false)); //Time <<1>>
+                GuiUtils.LayoutNoExpandWidth); //Time <<1>>
 
             GUILayout.Label(Localizer.Format("#MechJeb_Flightrecord_Label2", recorder.History[recorder.HistoryIdx].DownRange.ToSI()) + "m",
-                GUILayout.ExpandWidth(false)); //Downrange <<1>>
+                GuiUtils.LayoutNoExpandWidth); //Downrange <<1>>
 
-            //GUILayout.Label("", GUILayout.ExpandWidth(true));
+            //GUILayout.Label("", GuiUtils.LayoutExpandWidth);
             GUILayout.FlexibleSpace();
 
-            if (GUILayout.Button(Localizer.Format("#MechJeb_Flightrecord_Button3"), GUILayout.ExpandWidth(false))) //"Mark"
+            if (GUILayout.Button(Localizer.Format("#MechJeb_Flightrecord_Button3"), GuiUtils.LayoutNoExpandWidth)) //"Mark"
             {
                 ResetScale(); // TODO : should check something else to catch Mark calls from other code
                 recorder.Mark();
             }
 
-            if (GUILayout.Button(Localizer.Format("#MechJeb_Flightrecord_Button4"), GUILayout.ExpandWidth(false))) //"Reset Scale"
+            if (GUILayout.Button(Localizer.Format("#MechJeb_Flightrecord_Button4"), GuiUtils.LayoutNoExpandWidth)) //"Reset Scale"
             {
                 ResetScale();
             }
@@ -158,9 +158,9 @@ namespace MuMech
 
             GUILayout.BeginHorizontal();
 
-            autoScale = GUILayout.Toggle(autoScale, Localizer.Format("#MechJeb_Flightrecord_checkbox1"), GUILayout.ExpandWidth(false)); //Auto Scale
+            autoScale = GUILayout.Toggle(autoScale, Localizer.Format("#MechJeb_Flightrecord_checkbox1"), GuiUtils.LayoutNoExpandWidth); //Auto Scale
 
-            if (!autoScale && GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+            if (!autoScale && GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
             {
                 if (downrange)
                     downrangeScale--;
@@ -179,9 +179,9 @@ namespace MuMech
 
             double scaleX = downrange ? Math.Pow(2, activeScaleX) : precision * Math.Pow(2, activeScaleX);
 
-            GUILayout.Label(downrange ? scaleX.ToSI(2) + "m/px" : GuiUtils.TimeToDHMS(scaleX, 1) + "/px", GUILayout.ExpandWidth(false));
+            GUILayout.Label(downrange ? scaleX.ToSI(2) + "m/px" : GuiUtils.TimeToDHMS(scaleX, 1) + "/px", GuiUtils.LayoutNoExpandWidth);
 
-            if (!autoScale && GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+            if (!autoScale && GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
             {
                 if (downrange)
                     downrangeScale++;
@@ -189,28 +189,28 @@ namespace MuMech
                     timeScale++;
             }
 
-            if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
             {
                 hSize--;
             }
 
-            GUILayout.Label(width.ToString(), GUILayout.ExpandWidth(false));
+            GUILayout.Label(width.ToString(), GuiUtils.LayoutNoExpandWidth);
 
-            if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
             {
                 hSize++;
             }
 
-            GUILayout.Label("x", GUILayout.ExpandWidth(false));
+            GUILayout.Label("x", GuiUtils.LayoutNoExpandWidth);
 
-            if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
             {
                 vSize--;
             }
 
-            GUILayout.Label(height.ToString(), GUILayout.ExpandWidth(false));
+            GUILayout.Label(height.ToString(), GuiUtils.LayoutNoExpandWidth);
 
-            if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
             {
                 vSize++;
             }
@@ -222,22 +222,22 @@ namespace MuMech
 
             bool oldRealAtmo = realAtmo;
 
-            realAtmo = GUILayout.Toggle(realAtmo, Localizer.Format("#MechJeb_Flightrecord_checkbox2"), GUILayout.ExpandWidth(false)); //Real Atmo
+            realAtmo = GUILayout.Toggle(realAtmo, Localizer.Format("#MechJeb_Flightrecord_checkbox2"), GuiUtils.LayoutNoExpandWidth); //Real Atmo
 
             if (oldRealAtmo != realAtmo)
                 MechJebModuleAscentClassicPathMenu.UpdateAtmoTexture(backgroundTexture, Vessel.mainBody, lastMaximumAltitude, realAtmo);
 
-            //GUILayout.Label("", GUILayout.ExpandWidth(true));
+            //GUILayout.Label("", GuiUtils.LayoutExpandWidth);
             GUILayout.FlexibleSpace();
 
-            if (GUILayout.Button(Localizer.Format("#MechJeb_Flightrecord_Button5"), GUILayout.ExpandWidth(false))) //CSV
+            if (GUILayout.Button(Localizer.Format("#MechJeb_Flightrecord_Button5"), GuiUtils.LayoutNoExpandWidth)) //CSV
             {
                 recorder.DumpCsv();
             }
 
             GUILayout.Label(
                 Localizer.Format("#MechJeb_Flightrecord_Label3", (100 * recorder.HistoryIdx / (float)recorder.History.Length).ToString("F1")),
-                GUILayout.ExpandWidth(false)); //Storage: <<1>> %
+                GuiUtils.LayoutNoExpandWidth); //Storage: <<1>> %
 
             GUILayout.EndHorizontal();
 
@@ -248,38 +248,38 @@ namespace MuMech
             // Blue, Navy, Teal, Magenta, Purple all have poor contrast on black or against other colors here
             // Maybe some of them could be lightened up, but many of the lighter variants are already in this list.
 
-            //ascentPath = GUILayout.Toggle(ascentPath, "Ascent path", GUILayout.ExpandWidth(false));
-            stages = GUILayout.Toggle(stages, Localizer.Format("#MechJeb_Flightrecord_checkbox3"), GUILayout.ExpandWidth(false)); //"Stages"
+            //ascentPath = GUILayout.Toggle(ascentPath, "Ascent path", GuiUtils.LayoutNoExpandWidth);
+            stages = GUILayout.Toggle(stages, Localizer.Format("#MechJeb_Flightrecord_checkbox3"), GuiUtils.LayoutNoExpandWidth); //"Stages"
 
             GUI.color = XKCDColors.White;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.ALTITUDE_ASL].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.ALTITUDE_ASL].display, Localizer.Format("#MechJeb_Flightrecord_checkbox4"),
-                GUILayout.ExpandWidth(false)); //"Altitude"
+                GuiUtils.LayoutNoExpandWidth); //"Altitude"
 
             GUI.color = XKCDColors.Grey;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.ALTITUDE_TRUE].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.ALTITUDE_TRUE].display, Localizer.Format("#MechJeb_Flightrecord_checkbox5"),
-                GUILayout.ExpandWidth(false)); //"True Altitude"
+                GuiUtils.LayoutNoExpandWidth); //"True Altitude"
 
             GUI.color = XKCDColors.LightRed;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.ACCELERATION].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.ACCELERATION].display, Localizer.Format("#MechJeb_Flightrecord_checkbox6"),
-                GUILayout.ExpandWidth(false)); //"Acceleration"
+                GuiUtils.LayoutNoExpandWidth); //"Acceleration"
 
             GUI.color = XKCDColors.Yellow;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.SPEED_SURFACE].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.SPEED_SURFACE].display, Localizer.Format("#MechJeb_Flightrecord_checkbox7"),
-                GUILayout.ExpandWidth(false)); //"Surface speed"
+                GuiUtils.LayoutNoExpandWidth); //"Surface speed"
 
             GUI.color = XKCDColors.Apricot;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.SPEED_ORBITAL].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.SPEED_ORBITAL].display, Localizer.Format("#MechJeb_Flightrecord_checkbox8"),
-                GUILayout.ExpandWidth(false)); //"Orbital speed"
+                GuiUtils.LayoutNoExpandWidth); //"Orbital speed"
 
             GUI.color = XKCDColors.Pink;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.MASS].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.MASS].display, Localizer.Format("#MechJeb_Flightrecord_checkbox9"),
-                GUILayout.ExpandWidth(false)); //"Mass"
+                GuiUtils.LayoutNoExpandWidth); //"Mass"
 
             GUILayout.EndHorizontal();
             GUILayout.BeginHorizontal();
@@ -287,47 +287,47 @@ namespace MuMech
             GUI.color = XKCDColors.Cyan;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.Q].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.Q].display, Localizer.Format("#MechJeb_Flightrecord_checkbox10"),
-                GUILayout.ExpandWidth(false)); //"Q"
+                GuiUtils.LayoutNoExpandWidth); //"Q"
 
             GUI.color = XKCDColors.Lavender;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.AO_A].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.AO_A].display, Localizer.Format("#MechJeb_Flightrecord_checkbox11"),
-                GUILayout.ExpandWidth(false)); //"AoA"
+                GuiUtils.LayoutNoExpandWidth); //"AoA"
 
             GUI.color = XKCDColors.Lime;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.AO_S].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.AO_S].display, Localizer.Format("#MechJeb_Flightrecord_checkbox12"),
-                GUILayout.ExpandWidth(false)); //"AoS"
+                GuiUtils.LayoutNoExpandWidth); //"AoS"
 
             GUI.color = XKCDColors.Orange;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.AO_D].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.AO_D].display, Localizer.Format("#MechJeb_Flightrecord_checkbox13"),
-                GUILayout.ExpandWidth(false)); //"AoD"
+                GuiUtils.LayoutNoExpandWidth); //"AoD"
 
             GUI.color = XKCDColors.Mint;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.PITCH].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.PITCH].display, Localizer.Format("#MechJeb_Flightrecord_checkbox14"),
-                GUILayout.ExpandWidth(false)); //"Pitch"
+                GuiUtils.LayoutNoExpandWidth); //"Pitch"
 
             GUI.color = XKCDColors.Beige;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.DELTA_V_EXPENDED].display = GUILayout.Toggle(
-                graphStates[(int)MechJebModuleFlightRecorder.RecordType.DELTA_V_EXPENDED].display, "∆V", GUILayout.ExpandWidth(false));
+                graphStates[(int)MechJebModuleFlightRecorder.RecordType.DELTA_V_EXPENDED].display, "∆V", GuiUtils.LayoutNoExpandWidth);
 
             GUI.color = XKCDColors.Green;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.GRAVITY_LOSSES].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.GRAVITY_LOSSES].display, Localizer.Format("#MechJeb_Flightrecord_checkbox15"),
-                GUILayout.ExpandWidth(false)); //"Gravity Loss"
+                GuiUtils.LayoutNoExpandWidth); //"Gravity Loss"
 
             GUI.color = XKCDColors.LightBrown;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.DRAG_LOSSES].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.DRAG_LOSSES].display, Localizer.Format("#MechJeb_Flightrecord_checkbox16"),
-                GUILayout.ExpandWidth(false)); //"Drag Loss"
+                GuiUtils.LayoutNoExpandWidth); //"Drag Loss"
 
             GUI.color = XKCDColors.Cerise;
             graphStates[(int)MechJebModuleFlightRecorder.RecordType.STEERING_LOSSES].display = GUILayout.Toggle(
                 graphStates[(int)MechJebModuleFlightRecorder.RecordType.STEERING_LOSSES].display,
                 Localizer.Format("#MechJeb_Flightrecord_checkbox17"),
-                GUILayout.ExpandWidth(false)); //"Steering Loss"
+                GuiUtils.LayoutNoExpandWidth); //"Steering Loss"
 
             GUI.color = color;
 
@@ -339,14 +339,14 @@ namespace MuMech
 
             GUILayout.Space(50);
 
-            GUILayout.Box(Texture2D.blackTexture, GUILayout.Width(width), GUILayout.Height(height));
+            GUILayout.Box(Texture2D.blackTexture, GuiUtils.LayoutWidth(width), GUILayout.Height(height));
             Rect r = GUILayoutUtility.GetLastRect();
 
             DrawScaleLabels(r);
 
             GUILayout.BeginVertical();
 
-            //GUILayout.Label("X " + hPos.ToSI(2) + " " + (hPos+scaleX*width).ToSI(2), GUILayout.Width(110));
+            //GUILayout.Label("X " + hPos.ToSI(2) + " " + (hPos+scaleX*width).ToSI(2), GuiUtils.LayoutWidth(110));
 
             color = GUI.color;
 
@@ -366,134 +366,134 @@ namespace MuMech
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.ALTITUDE_ASL].display)
             {
                 GUI.color = XKCDColors.White;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.AltitudeASL, "ASL " + MuUtils.ToSI(graphStates[(int)recordType.AltitudeASL].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.AltitudeASL].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.AltitudeASL, "ASL " + MuUtils.ToSI(graphStates[(int)recordType.AltitudeASL].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.AltitudeASL].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.ALTITUDE_ASL,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox18"), GUILayout.ExpandWidth(true))) //"ASL"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox18"), GuiUtils.LayoutExpandWidth)) //"ASL"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.ALTITUDE_ASL;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.ALTITUDE_TRUE].display)
             {
                 GUI.color = XKCDColors.Grey;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.AltitudeTrue, "AGL " + MuUtils.ToSI(graphStates[(int)recordType.AltitudeTrue].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.AltitudeTrue].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.AltitudeTrue, "AGL " + MuUtils.ToSI(graphStates[(int)recordType.AltitudeTrue].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.AltitudeTrue].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.ALTITUDE_TRUE,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox19"), GUILayout.ExpandWidth(true))) //"AGL"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox19"), GuiUtils.LayoutExpandWidth)) //"AGL"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.ALTITUDE_TRUE;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.ACCELERATION].display)
             {
                 GUI.color = XKCDColors.LightRed;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.Acceleration, "Acc " + MuUtils.ToSI(graphStates[(int)recordType.Acceleration].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.Acceleration].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.Acceleration, "Acc " + MuUtils.ToSI(graphStates[(int)recordType.Acceleration].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.Acceleration].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.ACCELERATION,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox20"), GUILayout.ExpandWidth(true))) // "Acc"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox20"), GuiUtils.LayoutExpandWidth)) // "Acc"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.ACCELERATION;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.SPEED_SURFACE].display)
             {
                 GUI.color = XKCDColors.Yellow;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.SpeedSurface, "SrfVel " + MuUtils.ToSI(graphStates[(int)recordType.SpeedSurface].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.SpeedSurface].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.SpeedSurface, "SrfVel " + MuUtils.ToSI(graphStates[(int)recordType.SpeedSurface].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.SpeedSurface].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.SPEED_SURFACE,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox21"), GUILayout.ExpandWidth(true))) //"SrfVel"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox21"), GuiUtils.LayoutExpandWidth)) //"SrfVel"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.SPEED_SURFACE;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.SPEED_ORBITAL].display)
             {
                 GUI.color = XKCDColors.Apricot;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.SpeedOrbital, "ObtVel " + MuUtils.ToSI(graphStates[(int)recordType.SpeedOrbital].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.SpeedOrbital].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.SpeedOrbital, "ObtVel " + MuUtils.ToSI(graphStates[(int)recordType.SpeedOrbital].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.SpeedOrbital].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.SPEED_ORBITAL,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox22"), GUILayout.ExpandWidth(true))) //"ObtVel"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox22"), GuiUtils.LayoutExpandWidth)) //"ObtVel"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.SPEED_ORBITAL;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.MASS].display)
             {
                 GUI.color = XKCDColors.Pink;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.Mass, "Mass " + MuUtils.ToSI(graphStates[(int)recordType.Mass].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.Mass].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.Mass, "Mass " + MuUtils.ToSI(graphStates[(int)recordType.Mass].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.Mass].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.MASS,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox23"), GUILayout.ExpandWidth(true))) //"Mass"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox23"), GuiUtils.LayoutExpandWidth)) //"Mass"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.MASS;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.Q].display)
             {
                 GUI.color = XKCDColors.Cyan;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.Q, "Q " + MuUtils.ToSI(graphStates[(int)recordType.Q].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.Q].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.Q, "Q " + MuUtils.ToSI(graphStates[(int)recordType.Q].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.Q].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.Q, Localizer.Format("#MechJeb_Flightrecord_checkbox24"),
-                        GUILayout.ExpandWidth(true))) //"Q"
+                        GuiUtils.LayoutExpandWidth)) //"Q"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.Q;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.AO_A].display)
             {
                 GUI.color = XKCDColors.Lavender;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.AoA, "AoA " + MuUtils.ToSI(graphStates[(int)recordType.AoA].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.AoA].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.AoA, "AoA " + MuUtils.ToSI(graphStates[(int)recordType.AoA].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.AoA].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.AO_A,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox25"), GUILayout.ExpandWidth(true))) //"AoA"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox25"), GuiUtils.LayoutExpandWidth)) //"AoA"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.AO_A;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.AO_S].display)
             {
                 GUI.color = XKCDColors.Lime;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.AoS, "AoS " + MuUtils.ToSI(graphStates[(int)recordType.AoS].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.AoS].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.AoS, "AoS " + MuUtils.ToSI(graphStates[(int)recordType.AoS].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.AoS].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.AO_S,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox26"), GUILayout.ExpandWidth(true))) //"AoS"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox26"), GuiUtils.LayoutExpandWidth)) //"AoS"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.AO_S;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.AO_D].display)
             {
                 GUI.color = XKCDColors.Orange;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.AoD, "AoD " + MuUtils.ToSI(graphStates[(int)recordType.AoD].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.AoD].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.AoD, "AoD " + MuUtils.ToSI(graphStates[(int)recordType.AoD].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.AoD].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.AO_D,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox27"), GUILayout.ExpandWidth(true))) //"AoD"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox27"), GuiUtils.LayoutExpandWidth)) //"AoD"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.AO_D;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.PITCH].display)
             {
                 GUI.color = XKCDColors.Mint;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.Pitch, "Pitch " + MuUtils.ToSI(graphStates[(int)recordType.Pitch].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.Pitch].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.Pitch, "Pitch " + MuUtils.ToSI(graphStates[(int)recordType.Pitch].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.Pitch].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.PITCH,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox28"), GUILayout.ExpandWidth(true))) //"Pitch"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox28"), GuiUtils.LayoutExpandWidth)) //"Pitch"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.PITCH;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.DELTA_V_EXPENDED].display)
             {
                 GUI.color = XKCDColors.Beige;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.DeltaVExpended, "DeltaVExpended " + MuUtils.ToSI(graphStates[(int)recordType.DeltaVExpended].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.DeltaVExpended].maximum, -1, 3), GUILayout.ExpandWidth(true)))
-                if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.DELTA_V_EXPENDED, "∆V", GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.DeltaVExpended, "DeltaVExpended " + MuUtils.ToSI(graphStates[(int)recordType.DeltaVExpended].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.DeltaVExpended].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
+                if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.DELTA_V_EXPENDED, "∆V", GuiUtils.LayoutExpandWidth))
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.DELTA_V_EXPENDED;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.GRAVITY_LOSSES].display)
             {
                 GUI.color = XKCDColors.Green;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.GravityLosses, "GravityLosses " + MuUtils.ToSI(graphStates[(int)recordType.GravityLosses].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.GravityLosses].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.GravityLosses, "GravityLosses " + MuUtils.ToSI(graphStates[(int)recordType.GravityLosses].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.GravityLosses].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.GRAVITY_LOSSES,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox29"), GUILayout.ExpandWidth(true))) //"Gravity Loss"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox29"), GuiUtils.LayoutExpandWidth)) //"Gravity Loss"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.GRAVITY_LOSSES;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.DRAG_LOSSES].display)
             {
                 GUI.color = XKCDColors.LightBrown;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.DragLosses, "DragLosses " + MuUtils.ToSI(graphStates[(int)recordType.DragLosses].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.DragLosses].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.DragLosses, "DragLosses " + MuUtils.ToSI(graphStates[(int)recordType.DragLosses].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.DragLosses].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.DRAG_LOSSES,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox30"), GUILayout.ExpandWidth(true))) //"Drag Loss"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox30"), GuiUtils.LayoutExpandWidth)) //"Drag Loss"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.DRAG_LOSSES;
             }
 
             if (graphStates[(int)MechJebModuleFlightRecorder.RecordType.STEERING_LOSSES].display)
             {
                 GUI.color = XKCDColors.Cerise;
-                //if (GUILayout.Toggle(scaleIdx == (int)recordType.SteeringLosses, "SteeringLosses " + MuUtils.ToSI(graphStates[(int)recordType.SteeringLosses].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.SteeringLosses].maximum, -1, 3), GUILayout.ExpandWidth(true)))
+                //if (GUILayout.Toggle(scaleIdx == (int)recordType.SteeringLosses, "SteeringLosses " + MuUtils.ToSI(graphStates[(int)recordType.SteeringLosses].minimum, -1, 3) + " " + MuUtils.ToSI(graphStates[(int)recordType.SteeringLosses].maximum, -1, 3), GuiUtils.LayoutExpandWidth))
                 if (GUILayout.Toggle(scaleIdx == (int)MechJebModuleFlightRecorder.RecordType.STEERING_LOSSES,
-                        Localizer.Format("#MechJeb_Flightrecord_checkbox31"), GUILayout.ExpandWidth(true))) //"Steering Loss"
+                        Localizer.Format("#MechJeb_Flightrecord_checkbox31"), GuiUtils.LayoutExpandWidth)) //"Steering Loss"
                     scaleIdx = (int)MechJebModuleFlightRecorder.RecordType.STEERING_LOSSES;
             }
 
@@ -513,7 +513,7 @@ namespace MuMech
             if (follow)
                 hPos = rightValue - visibleX;
             hPos   = GUILayout.HorizontalScrollbar(hPos, visibleX, 0, rightValue);
-            follow = GUILayout.Toggle(follow, "", GUILayout.ExpandWidth(false));
+            follow = GUILayout.Toggle(follow, "", GuiUtils.LayoutNoExpandWidth);
 
             GUILayout.EndHorizontal();
 
@@ -795,7 +795,7 @@ namespace MuMech
             return nf * Math.Pow(10.0, exp);
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(400), GUILayout.Height(300) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(400), GUILayout.Height(300) };
 
         public override string GetName() => Localizer.Format("#MechJeb_Flightrecord_title"); //"Flight Recorder"
 

--- a/MechJeb2/MechJebModuleInfoItems.cs
+++ b/MechJeb2/MechJebModuleInfoItems.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -956,8 +956,8 @@ namespace MuMech
                 }
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(body.bodyName, GUILayout.ExpandWidth(true));
-                GUILayout.Label(o.PhaseAngle(body.orbit, VesselState.time).ToString("F2") + "º", GUILayout.ExpandWidth(false));
+                GUILayout.Label(body.bodyName, GuiUtils.LayoutExpandWidth);
+                GUILayout.Label(o.PhaseAngle(body.orbit, VesselState.time).ToString("F2") + "º", GuiUtils.LayoutNoExpandWidth);
                 GUILayout.EndHorizontal();
             }
 
@@ -984,8 +984,8 @@ namespace MuMech
                     }
 
                     GUILayout.BeginHorizontal();
-                    GUILayout.Label(body.bodyName, GUILayout.ExpandWidth(true));
-                    GUILayout.Label(o.PhaseAngle(body.orbit, VesselState.time).ToString("F2") + "º", GUILayout.ExpandWidth(false));
+                    GUILayout.Label(body.bodyName, GuiUtils.LayoutExpandWidth);
+                    GUILayout.Label(o.PhaseAngle(body.orbit, VesselState.time).ToString("F2") + "º", GuiUtils.LayoutNoExpandWidth);
                     GUILayout.EndHorizontal();
                 }
             }
@@ -1102,6 +1102,6 @@ namespace MuMech
         }
 
         [GeneralInfoItem("#MechJeb_Separator", InfoItem.Category.Misc, showInEditor = true)] //Separator
-        public void HorizontalSeparator() => GUILayout.Label("", separatorStyle, GUILayout.ExpandWidth(true), GUILayout.Height(2));
+        public void HorizontalSeparator() => GUILayout.Label("", separatorStyle, GuiUtils.LayoutExpandWidth, GUILayout.Height(2));
     }
 }

--- a/MechJeb2/MechJebModuleLandingGuidance.cs
+++ b/MechJeb2/MechJebModuleLandingGuidance.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,7 +34,7 @@ namespace MuMech
                 InitLandingSitesList();
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(200), GUILayout.Height(150) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(200), GUILayout.Height(150) };
 
         private void MoveByMeter(ref EditableAngle angle, double distance, double alt)
         {
@@ -100,7 +100,7 @@ namespace MuMech
             {
                 GUILayout.BeginHorizontal();
                 _landingSiteIdx = GuiUtils.ComboBox.Box(_landingSiteIdx, availableLandingSites.Select(p => p.Name).ToArray(), this);
-                if (GUILayout.Button("Set", GUILayout.ExpandWidth(false)))
+                if (GUILayout.Button("Set", GuiUtils.LayoutNoExpandWidth))
                 {
                     Core.Target.SetPositionTarget(MainBody, availableLandingSites[_landingSiteIdx].Latitude,
                         availableLandingSites[_landingSiteIdx].Longitude);

--- a/MechJeb2/MechJebModuleManeuverPlanner.cs
+++ b/MechJeb2/MechJebModuleManeuverPlanner.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -153,23 +153,23 @@ namespace MuMech
 
                 GUILayout.BeginHorizontal();
                 Core.Node.Autowarp =
-                    GUILayout.Toggle(Core.Node.Autowarp, Localizer.Format("#MechJeb_Maneu_Autowarp"), GUILayout.ExpandWidth(true)); //"Auto-warp"
-                Core.Node.RCSOnly = GUILayout.Toggle(Core.Node.RCSOnly, "RCS Burn", GUILayout.ExpandWidth(true));
-                Core.Node.KillRollRotation = GUILayout.Toggle(Core.Node.KillRollRotation, "Kill Rotation", GUILayout.ExpandWidth(true));
+                    GUILayout.Toggle(Core.Node.Autowarp, Localizer.Format("#MechJeb_Maneu_Autowarp"), GuiUtils.LayoutExpandWidth); //"Auto-warp"
+                Core.Node.RCSOnly = GUILayout.Toggle(Core.Node.RCSOnly, "RCS Burn", GuiUtils.LayoutExpandWidth);
+                Core.Node.KillRollRotation = GUILayout.Toggle(Core.Node.KillRollRotation, "Kill Rotation", GuiUtils.LayoutExpandWidth);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_Maneu_Lead_time"), GUILayout.ExpandWidth(false)); //Lead time:
-                Core.Node.LeadTime.Text = GUILayout.TextField(Core.Node.LeadTime.Text, GUILayout.Width(35), GUILayout.ExpandWidth(false));
-                GUILayout.Label("s", GUILayout.ExpandWidth(false));
+                GUILayout.Label(Localizer.Format("#MechJeb_Maneu_Lead_time"), GuiUtils.LayoutNoExpandWidth); //Lead time:
+                Core.Node.LeadTime.Text = GUILayout.TextField(Core.Node.LeadTime.Text, GuiUtils.LayoutWidth(35), GuiUtils.LayoutNoExpandWidth);
+                GUILayout.Label("s", GuiUtils.LayoutNoExpandWidth);
 
-                if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+                if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
                     Core.Node.LeadTime.Val += 1;
 
-                if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+                if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
                     Core.Node.LeadTime.Val -= 1;
 
-                if (GUILayout.Button("R", GUILayout.ExpandWidth(false)))
+                if (GUILayout.Button("R", GuiUtils.LayoutNoExpandWidth))
                     Core.Node.LeadTime.Val = 3;
 
                 GUILayout.EndHorizontal();
@@ -187,7 +187,7 @@ namespace MuMech
             return Vessel.patchedConicSolver.maneuverNodes.Where(n => n != predictor.aerobrakeNode).ToList();
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(300), GUILayout.Height(150) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(300), GUILayout.Height(150) };
 
         public override string GetName() => Localizer.Format("#MechJeb_Maneuver_Planner_title"); //Maneuver Planner
 

--- a/MechJeb2/MechJebModuleMenu.cs
+++ b/MechJeb2/MechJebModuleMenu.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -159,14 +159,14 @@ namespace MuMech
                 }
             }
 
-            if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
             {
                 columns--;
             }
 
-            GUILayout.Label(columns.ToString(), GUILayout.ExpandWidth(false));
+            GUILayout.Label(columns.ToString(), GuiUtils.LayoutNoExpandWidth);
 
-            if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
             {
                 columns++;
             }
@@ -569,7 +569,7 @@ namespace MuMech
             if (windowStat != WindowStat.HIDDEN)
             {
                 WindowPos = GUILayout.Window(GetType().FullName.GetHashCode(), displayedPos, WindowGUI, "MechJeb " + Core.version,
-                    GUILayout.Width(colWidth), GUILayout.Height(20));
+                    GuiUtils.LayoutWidth(colWidth), GUILayout.Height(20));
             }
             else
             {

--- a/MechJeb2/MechJebModuleNodeEditor.cs
+++ b/MechJeb2/MechJebModuleNodeEditor.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using JetBrainsAnnotations::JetBrains.Annotations;
 using KSP.Localization;
@@ -114,14 +114,14 @@ namespace MuMech
                 node.UpdateNode(new Vector3d(radialPlus, normalPlus, prograde), node.UT);
             }
 
-            progradeDelta.Text = GUILayout.TextField(progradeDelta.Text, GUILayout.Width(50));
+            progradeDelta.Text = GUILayout.TextField(progradeDelta.Text, GuiUtils.LayoutWidth(50));
             if (LimitedRepeatButtoon("+"))
             {
                 prograde += progradeDelta;
                 node.UpdateNode(new Vector3d(radialPlus, normalPlus, prograde), node.UT);
             }
 
-            GUILayout.Label("m/s", GUILayout.ExpandWidth(false));
+            GUILayout.Label("m/s", GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
@@ -132,14 +132,14 @@ namespace MuMech
                 node.UpdateNode(new Vector3d(radialPlus, normalPlus, prograde), node.UT);
             }
 
-            radialPlusDelta.Text = GUILayout.TextField(radialPlusDelta.Text, GUILayout.Width(50));
+            radialPlusDelta.Text = GUILayout.TextField(radialPlusDelta.Text, GuiUtils.LayoutWidth(50));
             if (LimitedRepeatButtoon("+"))
             {
                 radialPlus += radialPlusDelta;
                 node.UpdateNode(new Vector3d(radialPlus, normalPlus, prograde), node.UT);
             }
 
-            GUILayout.Label("m/s", GUILayout.ExpandWidth(false));
+            GUILayout.Label("m/s", GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
@@ -150,27 +150,27 @@ namespace MuMech
                 node.UpdateNode(new Vector3d(radialPlus, normalPlus, prograde), node.UT);
             }
 
-            normalPlusDelta.Text = GUILayout.TextField(normalPlusDelta.Text, GUILayout.Width(50));
+            normalPlusDelta.Text = GUILayout.TextField(normalPlusDelta.Text, GuiUtils.LayoutWidth(50));
             if (LimitedRepeatButtoon("+"))
             {
                 normalPlus += normalPlusDelta;
                 node.UpdateNode(new Vector3d(radialPlus, normalPlus, prograde), node.UT);
             }
 
-            GUILayout.Label("m/s", GUILayout.ExpandWidth(false));
+            GUILayout.Label("m/s", GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_NodeEd_Label5"), GUILayout.ExpandWidth(true)); //"Set delta to:"
-            if (GUILayout.Button("0.01", GUILayout.ExpandWidth(true)))
+            GUILayout.Label(Localizer.Format("#MechJeb_NodeEd_Label5"), GuiUtils.LayoutExpandWidth); //"Set delta to:"
+            if (GUILayout.Button("0.01", GuiUtils.LayoutExpandWidth))
                 progradeDelta = radialPlusDelta = normalPlusDelta = 0.01;
-            if (GUILayout.Button("0.1", GUILayout.ExpandWidth(true)))
+            if (GUILayout.Button("0.1", GuiUtils.LayoutExpandWidth))
                 progradeDelta = radialPlusDelta = normalPlusDelta = 0.1;
-            if (GUILayout.Button("1", GUILayout.ExpandWidth(true)))
+            if (GUILayout.Button("1", GuiUtils.LayoutExpandWidth))
                 progradeDelta = radialPlusDelta = normalPlusDelta = 1;
-            if (GUILayout.Button("10", GUILayout.ExpandWidth(true)))
+            if (GUILayout.Button("10", GuiUtils.LayoutExpandWidth))
                 progradeDelta = radialPlusDelta = normalPlusDelta = 10;
-            if (GUILayout.Button("100", GUILayout.ExpandWidth(true)))
+            if (GUILayout.Button("100", GuiUtils.LayoutExpandWidth))
                 progradeDelta = radialPlusDelta = normalPlusDelta = 100;
             GUILayout.EndHorizontal();
 
@@ -178,24 +178,24 @@ namespace MuMech
                 node.UpdateNode(new Vector3d(radialPlus, normalPlus, prograde), node.UT); //"Update"
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_NodeEd_Label6"), GUILayout.ExpandWidth(true)); //"Shift time"
-            if (GUILayout.Button("-o", GUILayout.ExpandWidth(false)))
+            GUILayout.Label(Localizer.Format("#MechJeb_NodeEd_Label6"), GuiUtils.LayoutExpandWidth); //"Shift time"
+            if (GUILayout.Button("-o", GuiUtils.LayoutNoExpandWidth))
             {
                 node.UpdateNode(node.DeltaV, node.UT - node.patch.period);
             }
 
-            if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
             {
                 node.UpdateNode(node.DeltaV, node.UT - timeOffset);
             }
 
-            timeOffset.Text = GUILayout.TextField(timeOffset.Text, GUILayout.Width(100));
-            if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+            timeOffset.Text = GUILayout.TextField(timeOffset.Text, GuiUtils.LayoutWidth(100));
+            if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
             {
                 node.UpdateNode(node.DeltaV, node.UT + timeOffset);
             }
 
-            if (GUILayout.Button("+o", GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button("+o", GuiUtils.LayoutNoExpandWidth))
             {
                 node.UpdateNode(node.DeltaV, node.UT + node.patch.period);
             }
@@ -203,7 +203,7 @@ namespace MuMech
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button3"), GUILayout.ExpandWidth(true))) //"Snap node to"
+            if (GUILayout.Button(Localizer.Format("#MechJeb_NodeEd_button3"), GuiUtils.LayoutExpandWidth)) //"Snap node to"
             {
                 Orbit o = node.patch;
                 double UT = node.UT;
@@ -281,7 +281,7 @@ namespace MuMech
 
                 GUILayout.BeginHorizontal();
                 Core.Node.Autowarp =
-                    GUILayout.Toggle(Core.Node.Autowarp, Localizer.Format("#MechJeb_NodeEd_checkbox1"), GUILayout.ExpandWidth(true)); //"Auto-warp"
+                    GUILayout.Toggle(Core.Node.Autowarp, Localizer.Format("#MechJeb_NodeEd_checkbox1"), GuiUtils.LayoutExpandWidth); //"Auto-warp"
                 GUILayout.EndHorizontal();
             }
 
@@ -294,7 +294,7 @@ namespace MuMech
 
         private static bool LimitedRepeatButtoon(string text)
         {
-            if (GUILayout.RepeatButton(text, GUILayout.ExpandWidth(false)) && nextClick < Time.time)
+            if (GUILayout.RepeatButton(text, GuiUtils.LayoutNoExpandWidth) && nextClick < Time.time)
             {
                 nextClick = Time.time + 0.2f;
                 return true;
@@ -310,7 +310,7 @@ namespace MuMech
             GUILayout.BeginVertical();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_NodeEd_Label8"), GUILayout.ExpandWidth(false)); //"Conics mode:"
+            GUILayout.Label(Localizer.Format("#MechJeb_NodeEd_Label8"), GuiUtils.LayoutNoExpandWidth); //"Conics mode:"
             int newRelativityMode = GUILayout.SelectionGrid((int)Vessel.patchedConicRenderer.relativityMode, relativityModeStrings, 5);
             Vessel.patchedConicRenderer.relativityMode = (PatchRendering.RelativityMode)newRelativityMode;
             GUILayout.EndHorizontal();
@@ -321,7 +321,7 @@ namespace MuMech
             GUILayout.EndVertical();
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(300), GUILayout.Height(150) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(300), GUILayout.Height(150) };
 
         public override string GetName() => Localizer.Format("#MechJeb_NodeEd_title"); //"Maneuver Node Editor"
 

--- a/MechJeb2/MechJebModuleRCSBalancer.cs
+++ b/MechJeb2/MechJebModuleRCSBalancer.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System.Collections.Generic;
 using System.Linq;
 using KSP.Localization;
@@ -68,7 +68,7 @@ namespace MuMech
             string error = solverThread.ErrorString;
             if (!string.IsNullOrEmpty(error))
             {
-                GUILayout.Label(error, GUILayout.ExpandWidth(true));
+                GUILayout.Label(error, GuiUtils.LayoutExpandWidth);
             }
 
             GUILayout.EndVertical();

--- a/MechJeb2/MechJebModuleRCSBalancerWindow.cs
+++ b/MechJeb2/MechJebModuleRCSBalancerWindow.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using KSP.Localization;
 using UnityEngine;
@@ -24,8 +24,8 @@ namespace MuMech
         private void SimpleTextInfo(string left, string right)
         {
             GUILayout.BeginHorizontal();
-            GUILayout.Label(left, GUILayout.ExpandWidth(true));
-            GUILayout.Label(right, GUILayout.ExpandWidth(false));
+            GUILayout.Label(left, GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(right, GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
         }
 
@@ -38,7 +38,7 @@ namespace MuMech
             GUILayout.BeginHorizontal();
             balancer.smartTranslation =
                 GUILayout.Toggle(balancer.smartTranslation, Localizer.Format("#MechJeb_RCSBalancer_checkbox1"),
-                    GUILayout.Width(130)); //"Smart translation"
+                    GuiUtils.LayoutWidth(130)); //"Smart translation"
             GUILayout.EndHorizontal();
 
             if (wasEnabled != balancer.smartTranslation)
@@ -116,7 +116,7 @@ namespace MuMech
             base.WindowGUI(windowID);
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(240), GUILayout.Height(30) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(240), GUILayout.Height(30) };
 
         public override string GetName() => Localizer.Format("#MechJeb_RCSBalancer_title"); //"RCS Balancer"
 

--- a/MechJeb2/MechJebModuleRCSController.cs
+++ b/MechJeb2/MechJebModuleRCSController.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using UnityEngine;
 
@@ -108,32 +108,32 @@ namespace MuMech
             if (rcsManualPID)
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label("P", GUILayout.ExpandWidth(false));
-                Kp.Text = GUILayout.TextField(Kp.Text, GUILayout.ExpandWidth(true), GUILayout.Width(60));
+                GUILayout.Label("P", GuiUtils.LayoutNoExpandWidth);
+                Kp.Text = GUILayout.TextField(Kp.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(60));
 
-                GUILayout.Label("I", GUILayout.ExpandWidth(false));
-                Kd.Text = GUILayout.TextField(Kd.Text, GUILayout.ExpandWidth(true), GUILayout.Width(60));
+                GUILayout.Label("I", GuiUtils.LayoutNoExpandWidth);
+                Kd.Text = GUILayout.TextField(Kd.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(60));
 
-                GUILayout.Label("D", GUILayout.ExpandWidth(false));
-                Ki.Text = GUILayout.TextField(Ki.Text, GUILayout.ExpandWidth(true), GUILayout.Width(60));
+                GUILayout.Label("D", GuiUtils.LayoutNoExpandWidth);
+                Ki.Text = GUILayout.TextField(Ki.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(60));
                 GUILayout.EndHorizontal();
             }
             else
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label("Tf", GUILayout.ExpandWidth(false));
-                Tf.Text = GUILayout.TextField(Tf.Text, GUILayout.ExpandWidth(true), GUILayout.Width(40));
+                GUILayout.Label("Tf", GuiUtils.LayoutNoExpandWidth);
+                Tf.Text = GUILayout.TextField(Tf.Text, GuiUtils.LayoutExpandWidth, GuiUtils.LayoutWidth(40));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label("P", GUILayout.ExpandWidth(false));
-                GUILayout.Label(Kp.Val.ToString("F4"), GUILayout.ExpandWidth(true));
+                GUILayout.Label("P", GuiUtils.LayoutNoExpandWidth);
+                GUILayout.Label(Kp.Val.ToString("F4"), GuiUtils.LayoutExpandWidth);
 
-                GUILayout.Label("I", GUILayout.ExpandWidth(false));
-                GUILayout.Label(Ki.Val.ToString("F4"), GUILayout.ExpandWidth(true));
+                GUILayout.Label("I", GuiUtils.LayoutNoExpandWidth);
+                GUILayout.Label(Ki.Val.ToString("F4"), GuiUtils.LayoutExpandWidth);
 
-                GUILayout.Label("D", GUILayout.ExpandWidth(false));
-                GUILayout.Label(Kd.Val.ToString("F4"), GUILayout.ExpandWidth(true));
+                GUILayout.Label("D", GuiUtils.LayoutNoExpandWidth);
+                GUILayout.Label(Kd.Val.ToString("F4"), GuiUtils.LayoutExpandWidth);
                 GUILayout.EndHorizontal();
             }
 

--- a/MechJeb2/MechJebModuleRendezvousAutopilotWindow.cs
+++ b/MechJeb2/MechJebModuleRendezvousAutopilotWindow.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using KSP.Localization;
 using UnityEngine;
 
@@ -62,7 +62,7 @@ namespace MuMech
             base.WindowGUI(windowID);
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(300), GUILayout.Height(50) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(300), GUILayout.Height(50) };
 
         public override string GetName() => Localizer.Format("#MechJeb_RZauto_title"); //"Rendezvous Autopilot"
 

--- a/MechJeb2/MechJebModuleRendezvousGuidance.cs
+++ b/MechJeb2/MechJebModuleRendezvousGuidance.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System.Linq;
 using KSP.Localization;
 using UnityEngine;
@@ -102,8 +102,8 @@ namespace MuMech
                 }
             }
 
-            phasingOrbitAltitude.Text = GUILayout.TextField(phasingOrbitAltitude.Text, GUILayout.Width(70));
-            GUILayout.Label("km", GUILayout.ExpandWidth(false));
+            phasingOrbitAltitude.Text = GUILayout.TextField(phasingOrbitAltitude.Text, GuiUtils.LayoutWidth(70));
+            GUILayout.Label("km", GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             if (GUILayout.Button(Localizer.Format("#MechJeb_RZplan_button3"))) //"Intercept with Hohmann transfer"
@@ -162,7 +162,7 @@ namespace MuMech
 
                 GUILayout.BeginHorizontal();
                 Core.Node.Autowarp =
-                    GUILayout.Toggle(Core.Node.Autowarp, Localizer.Format("#MechJeb_RZplan_checkbox"), GUILayout.ExpandWidth(true)); //"Auto-warp"
+                    GUILayout.Toggle(Core.Node.Autowarp, Localizer.Format("#MechJeb_RZplan_checkbox"), GuiUtils.LayoutExpandWidth); //"Auto-warp"
                 GUILayout.EndHorizontal();
             }
 
@@ -171,7 +171,7 @@ namespace MuMech
             base.WindowGUI(windowID);
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(300), GUILayout.Height(150) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(300), GUILayout.Height(150) };
 
         public override string GetName() => Localizer.Format("#MechJeb_RZplan_title"); //"Rendezvous Planner"
 

--- a/MechJeb2/MechJebModuleRoverWindow.cs
+++ b/MechJeb2/MechJebModuleRoverWindow.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System.Collections;
 using KSP.Localization;
 using UnityEngine;
@@ -17,7 +17,7 @@ namespace MuMech
 
         public override string IconName() => "Rover Autopilot";
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(200), GUILayout.Height(50) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(200), GUILayout.Height(50) };
 
         protected override void WindowGUI(int windowID)
         {
@@ -34,18 +34,18 @@ namespace MuMech
             ed.registry.Find(i => i.id == "Toggle:RoverController.ControlHeading").DrawItem();
             GUILayout.BeginHorizontal();
             ed.registry.Find(i => i.id == "Editable:RoverController.heading").DrawItem();
-            if (GUILayout.Button("-", GUILayout.Width(18))) { autopilot.heading.Val -= GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1; }
+            if (GUILayout.Button("-", GuiUtils.LayoutWidth(18))) { autopilot.heading.Val -= GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1; }
 
-            if (GUILayout.Button("+", GUILayout.Width(18))) { autopilot.heading.Val += GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1; }
+            if (GUILayout.Button("+", GuiUtils.LayoutWidth(18))) { autopilot.heading.Val += GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1; }
 
             GUILayout.EndHorizontal();
             ed.registry.Find(i => i.id == "Value:RoverController.headingErr").DrawItem();
             ed.registry.Find(i => i.id == "Toggle:RoverController.ControlSpeed").DrawItem();
             GUILayout.BeginHorizontal();
             ed.registry.Find(i => i.id == "Editable:RoverController.speed").DrawItem();
-            if (GUILayout.Button("-", GUILayout.Width(18))) { autopilot.speed.Val -= GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1; }
+            if (GUILayout.Button("-", GuiUtils.LayoutWidth(18))) { autopilot.speed.Val -= GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1; }
 
-            if (GUILayout.Button("+", GUILayout.Width(18))) { autopilot.speed.Val += GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1; }
+            if (GUILayout.Button("+", GuiUtils.LayoutWidth(18))) { autopilot.speed.Val += GameSettings.MODIFIER_KEY.GetKey() ? 5 : 1; }
 
             GUILayout.EndHorizontal();
             ed.registry.Find(i => i.id == "Value:RoverController.speedErr").DrawItem();
@@ -65,13 +65,13 @@ namespace MuMech
             GUILayout.BeginVertical();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_Rover_label1"), GUILayout.ExpandWidth(true)); // "Target Speed"
-            GUILayout.Label(autopilot.tgtSpeed.ToString("F1"), GUILayout.ExpandWidth(false));
+            GUILayout.Label(Localizer.Format("#MechJeb_Rover_label1"), GuiUtils.LayoutExpandWidth); // "Target Speed"
+            GUILayout.Label(autopilot.tgtSpeed.ToString("F1"), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_Rover_label2"), GUILayout.ExpandWidth(true)); // "Waypoints"
-            GUILayout.Label("Index " + (autopilot.WaypointIndex + 1) + " of " + autopilot.Waypoints.Count, GUILayout.ExpandWidth(false));
+            GUILayout.Label(Localizer.Format("#MechJeb_Rover_label2"), GuiUtils.LayoutExpandWidth); // "Waypoints"
+            GUILayout.Label("Index " + (autopilot.WaypointIndex + 1) + " of " + autopilot.Waypoints.Count, GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
 
 //			GUILayout.Label("Debug1: " + autopilot.debug1.ToString("F3"));

--- a/MechJeb2/MechJebModuleSettings.cs
+++ b/MechJeb2/MechJebModuleSettings.cs
@@ -1,4 +1,4 @@
-﻿using KSP.IO;
+using KSP.IO;
 using KSP.Localization;
 using UnityEngine;
 
@@ -96,8 +96,8 @@ namespace MuMech
             }
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_Settings_label2"), GUILayout.ExpandWidth(true)); //"UI Scale:"
-            UIScale.Text = GUILayout.TextField(UIScale.Text, GUILayout.Width(60));
+            GUILayout.Label(Localizer.Format("#MechJeb_Settings_label2"), GuiUtils.LayoutExpandWidth); //"UI Scale:"
+            UIScale.Text = GUILayout.TextField(UIScale.Text, GuiUtils.LayoutWidth(60));
             GUILayout.EndHorizontal();
 
             GuiUtils.SetGUIScale(UIScale.Val);
@@ -134,6 +134,6 @@ namespace MuMech
 
         public override string IconName() => "Settings";
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(200), GUILayout.Height(100) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(200), GUILayout.Height(100) };
     }
 }

--- a/MechJeb2/MechJebModuleSmartASS.cs
+++ b/MechJeb2/MechJebModuleSmartASS.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using System.Linq;
 using KSP.Localization;
@@ -179,7 +179,7 @@ namespace MuMech
 
         protected void ModeButton(Mode bt)
         {
-            if (GUILayout.Button(ModeTexts[(int)bt], mode == bt ? btActive : btNormal, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true)))
+            if (GUILayout.Button(ModeTexts[(int)bt], mode == bt ? btActive : btNormal, GuiUtils.LayoutExpandWidth, GUILayout.ExpandHeight(true)))
             {
                 mode = bt;
             }
@@ -187,7 +187,7 @@ namespace MuMech
 
         protected void TargetButton(Target bt)
         {
-            if (GUILayout.Button(TargetTexts[(int)bt], target == bt ? btActive : btNormal, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true)))
+            if (GUILayout.Button(TargetTexts[(int)bt], target == bt ? btActive : btNormal, GuiUtils.LayoutExpandWidth, GUILayout.ExpandHeight(true)))
             {
                 target = bt;
                 Engage();
@@ -196,7 +196,7 @@ namespace MuMech
 
         protected void TargetButtonNoEngage(Target bt)
         {
-            if (GUILayout.Button(TargetTexts[(int)bt], target == bt ? btActive : btNormal, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true)))
+            if (GUILayout.Button(TargetTexts[(int)bt], target == bt ? btActive : btNormal, GuiUtils.LayoutExpandWidth, GUILayout.ExpandHeight(true)))
             {
                 target = bt;
             }
@@ -206,14 +206,14 @@ namespace MuMech
         {
             GUILayout.BeginHorizontal();
             bool _forceRol = forceRol;
-            forceRol = GUILayout.Toggle(forceRol, Localizer.Format("#MechJeb_SmartASS_checkbox3"), GUILayout.ExpandWidth(false)); //"Force Roll :"
+            forceRol = GUILayout.Toggle(forceRol, Localizer.Format("#MechJeb_SmartASS_checkbox3"), GuiUtils.LayoutNoExpandWidth); //"Force Roll :"
             if (_forceRol != forceRol)
             {
                 Engage();
             }
 
-            rol.Text = GUILayout.TextField(rol.Text, GUILayout.Width(30));
-            GUILayout.Label("°", GUILayout.ExpandWidth(false));
+            rol.Text = GUILayout.TextField(rol.Text, GuiUtils.LayoutWidth(30));
+            GUILayout.Label("°", GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
         }
 
@@ -256,7 +256,7 @@ namespace MuMech
                         Core.Attitude.Users.Remove(this); // so we don't suddenly turn on when the other autopilot finishes
                 }
 
-                GUILayout.Button(Localizer.Format("#MechJeb_SmartASS_button57"), btAuto, GUILayout.ExpandWidth(true)); //"AUTO"
+                GUILayout.Button(Localizer.Format("#MechJeb_SmartASS_button57"), btAuto, GuiUtils.LayoutExpandWidth); //"AUTO"
             }
             else
             {
@@ -271,7 +271,7 @@ namespace MuMech
                 }
                 else
                 {
-                    GUILayout.Button("-", GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+                    GUILayout.Button("-", GuiUtils.LayoutExpandWidth, GUILayout.ExpandHeight(true));
                 }
 
                 GUILayout.EndHorizontal();
@@ -318,40 +318,40 @@ namespace MuMech
                         {
                             bool changed = false;
                             GUILayout.BeginHorizontal();
-                            forceYaw = GUILayout.Toggle(forceYaw, "", GUILayout.ExpandWidth(false));
+                            forceYaw = GUILayout.Toggle(forceYaw, "", GuiUtils.LayoutNoExpandWidth);
                             GuiUtils.SimpleTextBox("HDG", srfHdg, "°", 37);
 
-                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("--", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfHdg -= LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfHdg -= val;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfHdg += val;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("++", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfHdg += LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("0", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfHdg = 0;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("90", GUILayout.Width(35)))
+                            if (GUILayout.Button("90", GuiUtils.LayoutWidth(35)))
                             {
                                 srfHdg = 90;
                                 changed = true;
@@ -359,40 +359,40 @@ namespace MuMech
 
                             GUILayout.EndHorizontal();
                             GUILayout.BeginHorizontal();
-                            forcePitch = GUILayout.Toggle(forcePitch, "", GUILayout.ExpandWidth(false));
+                            forcePitch = GUILayout.Toggle(forcePitch, "", GuiUtils.LayoutNoExpandWidth);
                             GuiUtils.SimpleTextBox("PIT", srfPit, "°", 37);
 
-                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("--", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfPit -= LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfPit -= val;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfPit += val;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("++", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfPit += LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("0", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfPit = 0;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("90", GUILayout.Width(35)))
+                            if (GUILayout.Button("90", GuiUtils.LayoutWidth(35)))
                             {
                                 srfPit = 90;
                                 changed = true;
@@ -400,41 +400,41 @@ namespace MuMech
 
                             GUILayout.EndHorizontal();
                             GUILayout.BeginHorizontal();
-                            forceRol = GUILayout.Toggle(forceRol, "", GUILayout.ExpandWidth(false));
+                            forceRol = GUILayout.Toggle(forceRol, "", GuiUtils.LayoutNoExpandWidth);
                             GuiUtils.SimpleTextBox("ROL", srfRol, "°", 37);
 
-                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("--", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfRol -= LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfRol -= val;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfRol += val;
                                 changed = true;
                             }
 
 
-                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("++", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfRol += LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("0", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfRol = 0;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("180", GUILayout.Width(35)))
+                            if (GUILayout.Button("180", GuiUtils.LayoutWidth(35)))
                             {
                                 srfRol = 180;
                                 changed = true;
@@ -461,40 +461,40 @@ namespace MuMech
                         {
                             bool changed = false;
                             GUILayout.BeginHorizontal();
-                            forceRol = GUILayout.Toggle(forceRol, "", GUILayout.ExpandWidth(false));
+                            forceRol = GUILayout.Toggle(forceRol, "", GuiUtils.LayoutNoExpandWidth);
                             GuiUtils.SimpleTextBox("ROL", srfVelRol, "°", 37);
 
-                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("--", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelRol -= LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelRol -= val;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelRol += val;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("++", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelRol += LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("CUR", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelRol = -VesselState.vesselRoll.Value;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("0", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelRol = 0;
                                 changed = true;
@@ -502,39 +502,39 @@ namespace MuMech
 
                             GUILayout.EndHorizontal();
                             GUILayout.BeginHorizontal();
-                            forcePitch = GUILayout.Toggle(forcePitch, "", GUILayout.ExpandWidth(false));
+                            forcePitch = GUILayout.Toggle(forcePitch, "", GuiUtils.LayoutNoExpandWidth);
                             GuiUtils.SimpleTextBox("PIT", srfVelPit, "°", 37);
-                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("--", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelPit -= LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelPit -= val;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelPit += val;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("++", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelPit += LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("CUR", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelPit = VesselState.AoA.Value;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("0", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelPit = 0;
                                 changed = true;
@@ -542,40 +542,40 @@ namespace MuMech
 
                             GUILayout.EndHorizontal();
                             GUILayout.BeginHorizontal();
-                            forceYaw = GUILayout.Toggle(forceYaw, "", GUILayout.ExpandWidth(false));
+                            forceYaw = GUILayout.Toggle(forceYaw, "", GuiUtils.LayoutNoExpandWidth);
                             GuiUtils.SimpleTextBox("YAW", srfVelYaw, "°", 37);
 
-                            if (GUILayout.Button("--", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("--", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelYaw -= LARGE_INCREMENT;
                                 changed = true;
                             }
-                            if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelYaw -= val;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelYaw += val;
                                 changed = true;
                             }
 
 
-                            if (GUILayout.Button("++", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("++", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelYaw += LARGE_INCREMENT;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("CUR", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("CUR", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelYaw = -VesselState.AoS.Value;
                                 changed = true;
                             }
 
-                            if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
+                            if (GUILayout.Button("0", GuiUtils.LayoutNoExpandWidth))
                             {
                                 srfVelYaw = 0;
                                 changed = true;
@@ -631,7 +631,7 @@ namespace MuMech
 
                         ForceRoll();
 
-                        if (GUILayout.Button(Localizer.Format("#MechJeb_SmartASS_button58"), btNormal, GUILayout.ExpandWidth(true))) //"EXECUTE"
+                        if (GUILayout.Button(Localizer.Format("#MechJeb_SmartASS_button58"), btNormal, GuiUtils.LayoutExpandWidth)) //"EXECUTE"
                         {
                             target = Target.ADVANCED;
                             Engage();
@@ -658,7 +658,7 @@ namespace MuMech
         {
             GUILayout.BeginHorizontal();
             hasSmoothControl = true;
-            smoothControl = GUILayout.Toggle(smoothControl, "Smooth Control:", GUILayout.ExpandWidth(false));
+            smoothControl = GUILayout.Toggle(smoothControl, "Smooth Control:", GuiUtils.LayoutNoExpandWidth);
             GuiUtils.SimpleTextBox("", degreesPerSecond, "°/s", 40);
             GUILayout.EndHorizontal();
         }
@@ -868,7 +868,7 @@ namespace MuMech
             }
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(180), GUILayout.Height(100) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(180), GUILayout.Height(100) };
 
         public override string GetName() =>
             Core.eduMode

--- a/MechJeb2/MechJebModuleSmartRcs.cs
+++ b/MechJeb2/MechJebModuleSmartRcs.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System.Linq;
 using KSP.Localization;
 using UnityEngine;
@@ -30,7 +30,7 @@ namespace MuMech
 
         protected void TargetButton(Target bt)
         {
-            if (GUILayout.Button(TargetTexts[(int)bt], target == bt ? btActive : btNormal, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true)))
+            if (GUILayout.Button(TargetTexts[(int)bt], target == bt ? btActive : btNormal, GuiUtils.LayoutExpandWidth, GUILayout.ExpandHeight(true)))
             {
                 target = bt;
                 Engage();
@@ -74,7 +74,7 @@ namespace MuMech
                         Core.RCS.Users.Remove(this); // so we don't suddenly turn on when the other autopilot finishes
                 }
 
-                GUILayout.Button(Localizer.Format("#MechJeb_SmartRcs_button3"), btAuto, GUILayout.ExpandWidth(true)); //"AUTO"
+                GUILayout.Button(Localizer.Format("#MechJeb_SmartRcs_button3"), btAuto, GuiUtils.LayoutExpandWidth); //"AUTO"
             }
             else if (Core.Target.Target == null)
             {
@@ -112,7 +112,7 @@ namespace MuMech
             }
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(180), GUILayout.Height(100) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(180), GUILayout.Height(100) };
 
         public override string GetName() => Localizer.Format("#MechJeb_SmartRcs_title"); //"SmartRcs"
 

--- a/MechJeb2/MechJebModuleThrustWindow.cs
+++ b/MechJeb2/MechJebModuleThrustWindow.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using KSP.Localization;
 using MechJebLibBindings;
 using UnityEngine;
@@ -72,7 +72,7 @@ namespace MuMech
                 GUILayout.Toggle(Core.Thrust.SmoothThrottle, Localizer.Format("#MechJeb_Utilities_checkbox2")); //"Smooth throttle"
             Core.Thrust.ManageIntakes =
                 GUILayout.Toggle(Core.Thrust.ManageIntakes, Localizer.Format("#MechJeb_Utilities_checkbox3")); //"Manage air intakes"
-            GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));
+            GUILayout.BeginHorizontal(GuiUtils.LayoutExpandWidth);
             try
             {
                 GUILayout.Label(Localizer.Format("#MechJeb_Utilities_label2")); //"Jet safety margin"
@@ -124,7 +124,7 @@ namespace MuMech
             base.WindowGUI(windowID);
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(250), GUILayout.Height(30) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(250), GUILayout.Height(30) };
 
         public override bool IsActive() => Core.Thrust.Limiter != MechJebModuleThrustController.LimitMode.NONE;
 

--- a/MechJeb2/MechJebModuleTranslatron.cs
+++ b/MechJeb2/MechJebModuleTranslatron.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using System.Collections.Generic;
 using KSP.Localization;
@@ -43,7 +43,7 @@ namespace MuMech
 
         public override string IconName() => "Translatron";
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(130) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(130) };
 
         protected override void WindowGUI(int windowID)
         {
@@ -70,7 +70,7 @@ namespace MuMech
                 buttonStyle.normal.textColor = Color.red;
                 buttonStyle.onActive = buttonStyle.onFocused = buttonStyle.onHover =
                     buttonStyle.onNormal = buttonStyle.active = buttonStyle.focused = buttonStyle.hover = buttonStyle.normal;
-                GUILayout.Button(Localizer.Format("#MechJeb_Trans_auto"), buttonStyle, GUILayout.ExpandWidth(true));
+                GUILayout.Button(Localizer.Format("#MechJeb_Trans_auto"), buttonStyle, GuiUtils.LayoutExpandWidth);
             }
             else
             {
@@ -89,23 +89,23 @@ namespace MuMech
                         : 1; // change by 5 if the mod_key is held down, else by 1 -- would be better if it actually worked...
 
                 Core.Thrust.TransKillH = GUILayout.Toggle(Core.Thrust.TransKillH, Localizer.Format("#MechJeb_Trans_kill_h"),
-                    GUILayout.ExpandWidth(true));
-                GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));
+                    GuiUtils.LayoutExpandWidth);
+                GUILayout.BeginHorizontal(GuiUtils.LayoutExpandWidth);
                 GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_Trans_spd"), trans_spd, "", 37);
                 bool change = false;
-                if (GUILayout.Button("-", GUILayout.ExpandWidth(false)))
+                if (GUILayout.Button("-", GuiUtils.LayoutNoExpandWidth))
                 {
                     trans_spd -= val;
                     change    =  true;
                 }
 
-                if (GUILayout.Button("0", GUILayout.ExpandWidth(false)))
+                if (GUILayout.Button("0", GuiUtils.LayoutNoExpandWidth))
                 {
                     trans_spd = 0;
                     change    = true;
                 }
 
-                if (GUILayout.Button("+", GUILayout.ExpandWidth(false)))
+                if (GUILayout.Button("+", GuiUtils.LayoutNoExpandWidth))
                 {
                     trans_spd += val;
                     change    =  true;
@@ -113,7 +113,7 @@ namespace MuMech
 
                 GUILayout.EndHorizontal();
 
-                if (GUILayout.Button(Localizer.Format("#MechJeb_Trans_spd_act") + ":", buttonStyle, GUILayout.ExpandWidth(true)) || change)
+                if (GUILayout.Button(Localizer.Format("#MechJeb_Trans_spd_act") + ":", buttonStyle, GuiUtils.LayoutExpandWidth) || change)
                 {
                     Core.Thrust.TransSpdAct    = (float)trans_spd.Val;
                     GUIUtility.keyboardControl = 0;
@@ -123,19 +123,19 @@ namespace MuMech
             if (Core.Thrust.Tmode != MechJebModuleThrustController.TMode.OFF)
             {
                 GUILayout.Label(Localizer.Format("#MechJeb_Trans_current_spd") + Core.Thrust.TransSpdAct.ToSI() + "m/s",
-                    GUILayout.ExpandWidth(true));
+                    GuiUtils.LayoutExpandWidth);
             }
 
             GUILayout.FlexibleSpace();
 
-            GUILayout.Label("Automation", GuiUtils.UpperCenterLabel, GUILayout.ExpandWidth(true));
+            GUILayout.Label("Automation", GuiUtils.UpperCenterLabel, GuiUtils.LayoutExpandWidth);
 
             buttonStyle.normal.textColor = buttonStyle.focused.textColor = buttonStyle.hover.textColor = buttonStyle.active.textColor =
                 buttonStyle.onNormal.textColor = buttonStyle.onFocused.textColor = buttonStyle.onHover.textColor =
                     buttonStyle.onActive.textColor = abort != AbortStage.OFF ? Color.red : Color.green;
 
             if (GUILayout.Button(abort != AbortStage.OFF ? Localizer.Format("#MechJeb_Trans_NOPANIC") : Localizer.Format("#MechJeb_Trans_PANIC"),
-                    buttonStyle, GUILayout.ExpandWidth(true)))
+                    buttonStyle, GuiUtils.LayoutExpandWidth))
             {
                 PanicSwitch();
             }

--- a/MechJeb2/MechJebModuleWarpHelper.cs
+++ b/MechJeb2/MechJebModuleWarpHelper.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using System.Linq;
 using JetBrainsAnnotations::JetBrains.Annotations;
@@ -30,15 +30,15 @@ namespace MuMech
             GUILayout.BeginVertical();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label(Localizer.Format("#MechJeb_WarpHelper_label1"), GUILayout.ExpandWidth(false)); //"Warp to: "
+            GUILayout.Label(Localizer.Format("#MechJeb_WarpHelper_label1"), GuiUtils.LayoutNoExpandWidth); //"Warp to: "
             warpTarget = (WarpTarget)GuiUtils.ComboBox.Box((int)warpTarget, warpTargetStrings, this);
             GUILayout.EndHorizontal();
 
             if (warpTarget == WarpTarget.Time)
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(Localizer.Format("#MechJeb_WarpHelper_label2"), GUILayout.ExpandWidth(true)); //"Warp for: "
-                timeOffset.Text = GUILayout.TextField(timeOffset.Text, GUILayout.Width(100));
+                GUILayout.Label(Localizer.Format("#MechJeb_WarpHelper_label2"), GuiUtils.LayoutExpandWidth); //"Warp for: "
+                timeOffset.Text = GUILayout.TextField(timeOffset.Text, GuiUtils.LayoutWidth(100));
                 GUILayout.EndHorizontal();
             }
             else if (warpTarget == WarpTarget.PhaseAngleT)
@@ -189,7 +189,7 @@ namespace MuMech
             }
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(240), GUILayout.Height(50) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(240), GUILayout.Height(50) };
 
         public override bool IsActive() => warping;
 

--- a/MechJeb2/MechJebModuleWaypointWindow.cs
+++ b/MechJeb2/MechJebModuleWaypointWindow.cs
@@ -1,4 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
+extern alias JetBrainsAnnotations;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -597,7 +597,7 @@ namespace MuMech
             set => SelIndex = value;
         }
 
-        protected override GUILayoutOption[] WindowOptions() => new[] { GUILayout.Width(500), GUILayout.Height(400) };
+        protected override GUILayoutOption[] WindowOptions() => new[] { GuiUtils.LayoutWidth(500), GUILayout.Height(400) };
 
         private void DrawPageWaypoints()
         {
@@ -673,32 +673,32 @@ namespace MuMech
                     {
                         GUILayout.BeginHorizontal();
 
-                        GUILayout.Label("  Radius: ", GUILayout.ExpandWidth(false));
-                        _tmpRadius = GUILayout.TextField(_tmpRadius, GUILayout.Width(50));
+                        GUILayout.Label("  Radius: ", GuiUtils.LayoutNoExpandWidth);
+                        _tmpRadius = GUILayout.TextField(_tmpRadius, GuiUtils.LayoutWidth(50));
                         float.TryParse(_tmpRadius, out wp.Radius);
-                        if (GUILayout.Button("A", GUILayout.ExpandWidth(false)))
+                        if (GUILayout.Button("A", GuiUtils.LayoutNoExpandWidth))
                         {
                             _ap.Waypoints.GetRange(i, _ap.Waypoints.Count - i).ForEach(fewp => fewp.Radius = wp.Radius);
                         }
 
-                        GUILayout.Label("- Speed: ", GUILayout.ExpandWidth(false));
-                        _tmpMinSpeed = GUILayout.TextField(_tmpMinSpeed, GUILayout.Width(40));
+                        GUILayout.Label("- Speed: ", GuiUtils.LayoutNoExpandWidth);
+                        _tmpMinSpeed = GUILayout.TextField(_tmpMinSpeed, GuiUtils.LayoutWidth(40));
                         float.TryParse(_tmpMinSpeed, out wp.MinSpeed);
-                        if (GUILayout.Button("A", GUILayout.ExpandWidth(false)))
+                        if (GUILayout.Button("A", GuiUtils.LayoutNoExpandWidth))
                         {
                             _ap.Waypoints.GetRange(i, _ap.Waypoints.Count - i).ForEach(fewp => fewp.MinSpeed = wp.MinSpeed);
                         }
 
-                        GUILayout.Label(" - ", GUILayout.ExpandWidth(false));
-                        _tmpMaxSpeed = GUILayout.TextField(_tmpMaxSpeed, GUILayout.Width(40));
+                        GUILayout.Label(" - ", GuiUtils.LayoutNoExpandWidth);
+                        _tmpMaxSpeed = GUILayout.TextField(_tmpMaxSpeed, GuiUtils.LayoutWidth(40));
                         float.TryParse(_tmpMaxSpeed, out wp.MaxSpeed);
-                        if (GUILayout.Button("A", GUILayout.ExpandWidth(false)))
+                        if (GUILayout.Button("A", GuiUtils.LayoutNoExpandWidth))
                         {
                             _ap.Waypoints.GetRange(i, _ap.Waypoints.Count - i).ForEach(fewp => fewp.MaxSpeed = wp.MaxSpeed);
                         }
 
                         GUILayout.FlexibleSpace();
-                        if (GUILayout.Button("QS", wp.Quicksave ? _styleQuicksave : _styleInactive, GUILayout.ExpandWidth(false)))
+                        if (GUILayout.Button("QS", wp.Quicksave ? _styleQuicksave : _styleInactive, GuiUtils.LayoutNoExpandWidth))
                         {
                             if (alt)
                             {
@@ -715,12 +715,12 @@ namespace MuMech
 
                         GUILayout.BeginHorizontal();
 
-                        GUILayout.Label("Lat ", GUILayout.ExpandWidth(false));
-                        _tmpLat     = GUILayout.TextField(_tmpLat, GUILayout.Width(125));
+                        GUILayout.Label("Lat ", GuiUtils.LayoutNoExpandWidth);
+                        _tmpLat     = GUILayout.TextField(_tmpLat, GuiUtils.LayoutWidth(125));
                         wp.Latitude = ParseCoord(_tmpLat);
 
-                        GUILayout.Label(" -  Lon ", GUILayout.ExpandWidth(false));
-                        _tmpLon      = GUILayout.TextField(_tmpLon, GUILayout.Width(125));
+                        GUILayout.Label(" -  Lon ", GuiUtils.LayoutNoExpandWidth);
+                        _tmpLon      = GUILayout.TextField(_tmpLon, GuiUtils.LayoutWidth(125));
                         wp.Longitude = ParseCoord(_tmpLon, true);
 
                         GUILayout.EndHorizontal();
@@ -738,7 +738,7 @@ namespace MuMech
             GUILayout.EndScrollView();
 
             GUILayout.BeginHorizontal();
-            if (GUILayout.Button(alt ? "Reverse" : !_waitingForPick ? "Add Waypoint" : "Abort Adding", GUILayout.Width(110)))
+            if (GUILayout.Button(alt ? "Reverse" : !_waitingForPick ? "Add Waypoint" : "Abort Adding", GuiUtils.LayoutWidth(110)))
             {
                 if (alt)
                 {
@@ -765,7 +765,7 @@ namespace MuMech
                 }
             }
 
-            if (GUILayout.Button(alt ? "Clear" : "Remove", GUILayout.Width(65)) && _ap.Waypoints.Count > 0)
+            if (GUILayout.Button(alt ? "Clear" : "Remove", GuiUtils.LayoutWidth(65)) && _ap.Waypoints.Count > 0)
             {
                 if (alt)
                 {
@@ -783,7 +783,7 @@ namespace MuMech
                 SelIndex = -1;
             }
 
-            if (GUILayout.Button(alt ? "Top" : "Up", GUILayout.Width(57)) && SelIndex > 0 && SelIndex < _ap.Waypoints.Count &&
+            if (GUILayout.Button(alt ? "Top" : "Up", GuiUtils.LayoutWidth(57)) && SelIndex > 0 && SelIndex < _ap.Waypoints.Count &&
                 _ap.Waypoints.Count >= 2)
             {
                 if (alt)
@@ -799,7 +799,7 @@ namespace MuMech
                 }
             }
 
-            if (GUILayout.Button(alt ? "Bottom" : "Down", GUILayout.Width(57)) && SelIndex >= 0 && SelIndex < _ap.Waypoints.Count - 1 &&
+            if (GUILayout.Button(alt ? "Bottom" : "Down", GuiUtils.LayoutWidth(57)) && SelIndex >= 0 && SelIndex < _ap.Waypoints.Count - 1 &&
                 _ap.Waypoints.Count >= 2)
             {
                 if (alt)
@@ -947,7 +947,7 @@ namespace MuMech
 
                 if (i == _saveIndex)
                 {
-                    if (GUILayout.Button("Delete", GUILayout.Width(70)))
+                    if (GUILayout.Button("Delete", GuiUtils.LayoutWidth(70)))
                     {
                         _routes.RemoveAll(r => r.Name == bodyWPs[i].Name && r.Body == Vessel.mainBody && r.Mode == Mode.ToString());
                         SaveRoutes();
@@ -961,8 +961,8 @@ namespace MuMech
             GUILayout.EndScrollView();
 
             GUILayout.BeginHorizontal();
-            _saveName = GUILayout.TextField(_saveName, GUILayout.Width(150));
-            if (GUILayout.Button("Save", GUILayout.Width(50)))
+            _saveName = GUILayout.TextField(_saveName, GuiUtils.LayoutWidth(150));
+            if (GUILayout.Button("Save", GuiUtils.LayoutWidth(50)))
             {
                 if (_saveName != "" && _ap.Waypoints.Count > 0)
                 {
@@ -983,7 +983,7 @@ namespace MuMech
                 }
             }
 
-            if (GUILayout.Button(alt ? "Add" : "Load", GUILayout.Width(50)))
+            if (GUILayout.Button(alt ? "Add" : "Load", GuiUtils.LayoutWidth(50)))
             {
                 if (_saveIndex > -1)
                 {

--- a/MechJeb2/MechJebStageStatsHelper.cs
+++ b/MechJeb2/MechJebStageStatsHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using KSP.Localization;
 using UnityEngine;
@@ -219,7 +219,7 @@ namespace MuMech
             GUILayout.BeginHorizontal();
             GUILayout.Label(CachedLocalizer.Instance.MechJebInfoItemsLabel1); //"Stage stats"
 
-            if (GUILayout.Button(timeSeconds ? "s" : "dhms", GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button(timeSeconds ? "s" : "dhms", GuiUtils.LayoutNoExpandWidth))
             {
                 timeSeconds           = !timeSeconds;
                 infoItems.timeSeconds = timeSeconds;
@@ -227,19 +227,19 @@ namespace MuMech
 
             if (GUILayout.Button(
                     showEmpty ? CachedLocalizer.Instance.MechJebInfoItemsShowEmpty : CachedLocalizer.Instance.MechJebInfoItemsHideEmpty,
-                    GUILayout.ExpandWidth(false)))
+                    GuiUtils.LayoutNoExpandWidth))
             {
                 showEmpty           = !showEmpty;
                 infoItems.showEmpty = showEmpty;
             }
 
-            if (GUILayout.Button(StageDisplayStates[StageDisplayState], GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button(StageDisplayStates[StageDisplayState], GuiUtils.LayoutNoExpandWidth))
             {
                 StageDisplayState = (StageDisplayState + 1) % StageDisplayStates.Length;
                 SetVisibility(StageDisplayState);
             }
 
-            if (GUILayout.Button(showRcs ? "RCS" : "Engine", GUILayout.ExpandWidth(false)))
+            if (GUILayout.Button(showRcs ? "RCS" : "Engine", GuiUtils.LayoutNoExpandWidth))
             {
                 showRcs           = !showRcs;
                 infoItems.showRcs = showRcs;
@@ -250,7 +250,7 @@ namespace MuMech
             {
                 if (GUILayout.Button(
                         liveSLT ? CachedLocalizer.Instance.MechJebInfoItemsButton5 : CachedLocalizer.Instance.MechJebInfoItemsButton6,
-                        GUILayout.ExpandWidth(false))) //"Live SLT" "0Alt SLT"
+                        GuiUtils.LayoutNoExpandWidth)) //"Live SLT" "0Alt SLT"
                 {
                     liveSLT           = !liveSLT;
                     infoItems.liveSLT = liveSLT;
@@ -272,17 +272,17 @@ namespace MuMech
                 GUILayout.BeginVertical();
 
                 GUILayout.BeginHorizontal();
-                altSLTScale           = GUILayout.HorizontalSlider(altSLTScale, 0, 1, GUILayout.ExpandWidth(true));
+                altSLTScale           = GUILayout.HorizontalSlider(altSLTScale, 0, 1, GuiUtils.LayoutExpandWidth);
                 infoItems.altSLTScale = altSLTScale;
                 stats.AltSLT          = Math.Pow(altSLTScale, 2) * stats.EditorBody.atmosphereDepth;
-                GUILayout.Label(stats.AltSLT.ToSI() + "m", GUILayout.Width(80));
+                GUILayout.Label(stats.AltSLT.ToSI() + "m", GuiUtils.LayoutWidth(80));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                machScale           = GUILayout.HorizontalSlider(machScale, 0, 1, GUILayout.ExpandWidth(true));
+                machScale           = GUILayout.HorizontalSlider(machScale, 0, 1, GuiUtils.LayoutExpandWidth);
                 infoItems.machScale = machScale;
                 stats.Mach          = Math.Pow(machScale * 2, 3);
-                GUILayout.Label(stats.Mach.ToString("F1") + " M", GUILayout.Width(80));
+                GUILayout.Label(stats.Mach.ToString("F1") + " M", GuiUtils.LayoutWidth(80));
                 GUILayout.EndHorizontal();
 
                 GUILayout.EndVertical();

--- a/MechJeb2/VesselState.cs
+++ b/MechJeb2/VesselState.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -886,12 +886,12 @@ namespace MuMech
             GUILayout.BeginVertical();
             GUILayout.Label(Localizer.Format("#MechJeb_RCSTranslation")); //"RCS Translation"
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Pos", GUILayout.ExpandWidth(true)); //
-            GUILayout.Label(MuUtils.PrettyPrint(rcsThrustAvailable.Positive), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Pos", GuiUtils.LayoutExpandWidth); //
+            GUILayout.Label(MuUtils.PrettyPrint(rcsThrustAvailable.Positive), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Neg", GUILayout.ExpandWidth(true)); //
-            GUILayout.Label(MuUtils.PrettyPrint(rcsThrustAvailable.Negative), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Neg", GuiUtils.LayoutExpandWidth); //
+            GUILayout.Label(MuUtils.PrettyPrint(rcsThrustAvailable.Negative), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
             GUILayout.EndVertical();
         }
@@ -902,14 +902,14 @@ namespace MuMech
             GUILayout.BeginVertical();
             GUILayout.Label(Localizer.Format("#MechJeb_RCSTorque")); //"RCS Torque"
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Pos", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(rcsTorqueAvailable.Positive), GUILayout.ExpandWidth(false));
-            //GUILayout.Label(MuUtils.PrettyPrint(torqueRcs.positive), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Pos", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(rcsTorqueAvailable.Positive), GuiUtils.LayoutNoExpandWidth);
+            //GUILayout.Label(MuUtils.PrettyPrint(torqueRcs.positive), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Neg", GUILayout.ExpandWidth(true));
-            GUILayout.Label(MuUtils.PrettyPrint(rcsTorqueAvailable.Negative), GUILayout.ExpandWidth(false));
-            //GUILayout.Label(MuUtils.PrettyPrint(torqueRcs.negative), GUILayout.ExpandWidth(false));
+            GUILayout.Label("Neg", GuiUtils.LayoutExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(rcsTorqueAvailable.Negative), GuiUtils.LayoutNoExpandWidth);
+            //GUILayout.Label(MuUtils.PrettyPrint(torqueRcs.negative), GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndHorizontal();
             GUILayout.EndVertical();
         }
@@ -1301,15 +1301,15 @@ namespace MuMech
             GUILayout.EndVertical();
 
             GUILayout.BeginVertical();
-            GUILayout.Label(MuUtils.PrettyPrint(reactionTorque), GuiUtils.LabelNoWrap, GUILayout.ExpandWidth(false));
-            //GUILayout.Label(MuUtils.PrettyPrint(rcsTorque), GuiUtils.LabelNoWrap, GUILayout.ExpandWidth(false));
+            GUILayout.Label(MuUtils.PrettyPrint(reactionTorque), GuiUtils.LabelNoWrap, GuiUtils.LayoutNoExpandWidth);
+            //GUILayout.Label(MuUtils.PrettyPrint(rcsTorque), GuiUtils.LabelNoWrap, GuiUtils.LayoutNoExpandWidth);
 
-            GUILayout.Label(MuUtils.PrettyPrint(rcsTorqueMJ), GuiUtils.LabelNoWrap, GUILayout.ExpandWidth(false));
+            GUILayout.Label(MuUtils.PrettyPrint(rcsTorqueMJ), GuiUtils.LabelNoWrap, GuiUtils.LayoutNoExpandWidth);
 
-            GUILayout.Label(MuUtils.PrettyPrint(controlTorque), GuiUtils.LabelNoWrap, GUILayout.ExpandWidth(false));
-            GUILayout.Label(MuUtils.PrettyPrint(gimbalTorque), GuiUtils.LabelNoWrap, GUILayout.ExpandWidth(false));
-            GUILayout.Label(MuUtils.PrettyPrint(diffTorque), GuiUtils.LabelNoWrap, GUILayout.ExpandWidth(false));
-            GUILayout.Label(MuUtils.PrettyPrint(othersTorque), GuiUtils.LabelNoWrap, GUILayout.ExpandWidth(false));
+            GUILayout.Label(MuUtils.PrettyPrint(controlTorque), GuiUtils.LabelNoWrap, GuiUtils.LayoutNoExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(gimbalTorque), GuiUtils.LabelNoWrap, GuiUtils.LayoutNoExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(diffTorque), GuiUtils.LabelNoWrap, GuiUtils.LayoutNoExpandWidth);
+            GUILayout.Label(MuUtils.PrettyPrint(othersTorque), GuiUtils.LabelNoWrap, GuiUtils.LayoutNoExpandWidth);
             GUILayout.EndVertical();
 
             GUILayout.EndHorizontal();


### PR DESCRIPTION
There are already helpers in place but half of the code isn't using those.