### PR TITLE
PSG: fix coast MaxT

### DIFF
--- a/MechJebLib/PSG/Optimizer.cs
+++ b/MechJebLib/PSG/Optimizer.cs
@@ -336,23 +336,7 @@ namespace MechJebLib.PSG
                 int        idx       = thisPhase.BtIdx();
 
                 bndl[idx] = Phases[p].MinT;
-                bndu[idx] = Phases[p].MaxT / Phases[p].MinThrottle;
-
-                /*
-                if (Phases[p].Coast)
-                {
-                    bndl[idx] = Phases[p].mint;
-                    bndu[idx] = Phases[p].maxt;
-                }
-                else
-                {
-                    bndl[idx] = Phases[p].AllowShutdown ? 0 : Phases[p].bt;
-                    if (Phases[p].AllowInfiniteBurntime)
-                        bndu[idx] = Phases[p].Infinite ? double.PositiveInfinity : 0.999 * Phases[p].tau;
-                    else
-                        bndu[idx] = Phases[p].bt;
-                }
-                */
+                bndu[idx] = Phases[p].MaxT;
 
                 if (bndu[idx] <= bndl[idx])
                     boxConstrained[idx] = true;

--- a/MechJebLib/PSG/Phase.cs
+++ b/MechJebLib/PSG/Phase.cs
@@ -95,7 +95,7 @@ namespace MechJebLib.PSG
             var phase = new Phase(m0, thrust, isp, mf, bt, kspStage, mjPhase, ispCurrent)
             {
                 MinT = allowShutdown ? 0 : bt,
-                MaxT = bt,
+                MaxT = bt / minThrottle,
                 Unguided = unguided,
                 MassContinuity = massContinuity,
                 MinThrottle = minThrottle


### PR DESCRIPTION
makes MaxT the responsiblity of the Phase and not the optimizer.

previously, the calculation in the optimizer was dividing by zero for coasts where minThrottle = 0 and that value just doesn't make and sense.  so make the burn phase factory method responsible for setting MaxT to be correct for a burn phase and adjusting by minThrottle.