### PR TITLE
Hoverslam: account for KSP's stage delay

### DIFF
--- a/MechJeb2/MechJebModuleHoverslamSimulation.cs
+++ b/MechJeb2/MechJebModuleHoverslamSimulation.cs
@@ -230,6 +230,7 @@ namespace MuMech
             HoverslamSimulation.HoverslamSimulationBuilder builder = HoverslamSimulation.Builder();
 
             bool noBurnableStages = true;
+            int  lastKSPStage     = -1;
 
             for (int mjPhase = _vacStats.Count - 1; mjPhase >= 0; mjPhase--)
             {
@@ -238,8 +239,16 @@ namespace MuMech
                 if (fuelStats.DeltaV <= 0)
                     continue;
 
+                int nunExcessStages = lastKSPStage - fuelStats.KSPStage - 1;
+
+                // for every extra stage, we need to include a StagingCooldownTimer coast.
+                if (nunExcessStages > 0)
+                    builder.AddCoast(fuelStats.StartMass * 1000, PhysicsGlobals.StagingCooldownTimer*nunExcessStages, fuelStats.KSPStage, mjPhase);
+
                 builder.AddStage(fuelStats.StartMass * 1000, fuelStats.EndMass * 1000, fuelStats.Thrust * 1000, fuelStats.Isp,
                     fuelStats.KSPStage, mjPhase);
+
+                lastKSPStage = fuelStats.KSPStage;
 
                 noBurnableStages = false;
             }

--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -276,11 +276,6 @@ namespace MuMech
             // (e.g. bool PSGIsCoasting) since it is getting tightly coupled.
             if (Vessel.currentStage <= ActiveAutoStageModuleLimit())
             {
-                if (!HasFairing(Vessel.currentStage - 1))
-                {
-                    Debug.Log("next stage has no fairing in autostagelimit");
-                }
-
                 // force staging once if fairing conditions are met in the next stage
                 if (HasFairing(Vessel.currentStage - 1) && !WaitingForFairing())
                 {
@@ -299,7 +294,6 @@ namespace MuMech
             if (InverseStageDecouplesActiveOrIdleEngineOrTank(Vessel.currentStage - 1, _burnedResources, _activeModuleEngines) &&
                 !InverseStageReleasesClamps(Vessel.currentStage - 1))
             {
-                Debug.Log("check one");
                 return;
             }
 
@@ -307,7 +301,6 @@ namespace MuMech
             if (InverseStageHasUnstableEngines(Vessel.currentStage - 1) && Core.Thrust.AutoRCSUllaging && Vessel.hasEnabledRCSModules() &&
                 Core.Thrust.LastThrottle > 0)
             {
-                Debug.Log("check two");
                 if (!Vessel.ActionGroups[KSPActionGroup.RCS])
                     Vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
                 return;
@@ -324,14 +317,12 @@ namespace MuMech
                 !InverseStageFiresDecoupler(Vessel.currentStage - 1) && !InverseStageReleasesClamps(Vessel.currentStage - 1) &&
                 LastNonZeroDVStageBurnTime() > HotStagingLeadTime)
             {
-                Debug.Log("check three");
                 return;
             }
 
             // Don't fire a stage that will activate a parachute, unless that parachute gets decoupled:
             if (HasStayingChutes(Vessel.currentStage - 1))
             {
-                Debug.Log("check four");
                 return;
             }
 
@@ -344,7 +335,6 @@ namespace MuMech
             // only decouple fairings if the dynamic pressure, altitude, and aerothermal flux conditions are respected
             if (WaitingForFairing())
             {
-                Debug.Log("check five");
                 return;
             }
 
@@ -364,25 +354,21 @@ namespace MuMech
         {
             if (!HasFairing(Vessel.currentStage - 1))
             {
-                Debug.Log("no fairing in next stage");
                 return false;
             }
 
             if (Core.VesselState.dynamicPressure > FairingMaxDynamicPressure)
             {
-                Debug.Log("dynamic pressure constraint not met");
                 return true;
             }
 
             if (Core.VesselState.altitudeASL < FairingMinAltitude)
             {
-                Debug.Log("altitude constraint not met");
                 return true;
             }
 
             if (Core.VesselState.freeMolecularAerothermalFlux > FairingMaxAerothermalFlux)
             {
-                Debug.Log("heat flux constraint not met");
                 return true;
             }
 

--- a/MechJebLib/HoverslamSimulation/HoverslamSimulation.cs
+++ b/MechJebLib/HoverslamSimulation/HoverslamSimulation.cs
@@ -126,7 +126,7 @@ namespace MechJebLib.HoverslamSimulation
 
         private double AltitudeResidual(double t, object? o) => PropagateTrajectory(t).X.R.magnitude - _height;
 
-        public override void Run(object? o = null)
+        private (double maxT, double minT) GenerateBracketGuess()
         {
             // ignition point should be before we hit the ground
             double maxT = Astro.TimeToNextRadius(_mu, _r0, _v0, _height);
@@ -147,17 +147,27 @@ namespace MechJebLib.HoverslamSimulation
                 minT = Astro.TimeToLastRadius(_mu, _r0, _v0, _r0.magnitude * 2.0);
             }
 
-            double t1;
+            return (maxT, minT);
+        }
 
+        private double SafeRootSolve(double minT, double maxT)
+        {
             try
             {
-                t1 = BrentRoot.Solve(AltitudeResidual, minT, maxT, null, rtol: 1e-8);
+                return BrentRoot.Solve(AltitudeResidual, minT, maxT, null, rtol: 1e-8);
             }
             catch (Exception)
             {
                 Reset();
                 throw;
             }
+        }
+
+        public override void Run(object? o = null)
+        {
+            (double maxT, double minT) = GenerateBracketGuess();
+
+            double t1 = SafeRootSolve(minT, maxT);
 
             TrajectoryResult result = PropagateTrajectory(t1);
 

--- a/MechJebLib/HoverslamSimulation/HoverslamSimulationBuilder.cs
+++ b/MechJebLib/HoverslamSimulation/HoverslamSimulationBuilder.cs
@@ -74,6 +74,18 @@ namespace MechJebLib.HoverslamSimulation
                 return this;
             }
 
+            public HoverslamSimulationBuilder AddCoast(double m0, double ct, int kspStage, int mjPhase)
+            {
+                var sb = new StringBuilder();
+                sb.Append($"[MechJebLib.HoverslamSimulationBuilder] AddCoast({m0}, {ct}, {kspStage}, {mjPhase}");
+                sb.Append(")");
+                DebugPrint(sb.ToString());
+
+                _phases.Add(Phase.NewCoast(m0, ct, ct, kspStage, mjPhase));
+
+                return this;
+            }
+
             public HoverslamSimulationBuilder TargetConditions(double height, double descentSpeed)
             {
                 DebugPrint($"[MechJebLib.HoverslamSimulationBuilder] TargetConditions({height}, {descentSpeed})");

--- a/MechJebLibTest/HoverslamTests.cs
+++ b/MechJebLibTest/HoverslamTests.cs
@@ -1,4 +1,5 @@
-﻿using MechJebLib.HoverslamSimulation;
+﻿using MechJebLib.Functions;
+using MechJebLib.HoverslamSimulation;
 using MechJebLib.Primitives;
 using MechJebLib.Utils;
 using Xunit;
@@ -91,6 +92,70 @@ namespace MechJebLibTest
             (hoverslam.IgnitionUT - t0).ShouldEqual(6295.6858380440681, 1e-6);
             hoverslam.Vf.ShouldEqual(V3.Cross(w, hoverslam.Rf), 1e-6);
             hoverslam.Dv.ShouldEqual(887.5077419925741, 1e-6);
+        }
+
+        [Fact]
+        private void MunLanderTwoStage()
+        {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
+
+            var    r0           = new V3(276714.567061612, 53069.6146485938, 0.00770833757526462);
+            var    v0           = new V3(-116.600502880196, 177.393895536045, 7.72615181983542E-05);
+            double t0           = 104033.944130376;
+            double mu           = 65138397520.7807;
+            var    w            = new V3(0, 0, 4.52078533000628E-05);
+            double height       = 203079.078627833;
+            double descentSpeed = 111.496373594304;
+
+            HoverslamSimulation hoverslam = HoverslamSimulation.Builder()
+               .Initial(r0, v0, t0, mu, w)
+               .TargetConditions(height, descentSpeed)
+               .AddStage(1631.71526258703, 1478.0574232488, 64000.011946753, 290.00005572948, 2, 2)
+               .AddStage(1041.14351191796, 733.827833241511, 64000.0112782489, 290.000052700321, 0, 0)
+               .Build();
+
+            hoverslam.Run();
+
+            hoverslam.Rf.magnitude.ShouldEqual(height, 1e-6);
+            (hoverslam.IgnitionUT - t0).ShouldEqual(352.36724527248589, 1e-6);
+            hoverslam.Vf.ShouldEqual(V3.Cross(w, hoverslam.Rf) - descentSpeed * hoverslam.Rf.normalized , 1e-6);
+            hoverslam.Dv.ShouldEqual(384.35206383554907, 1e-6);
+        }
+
+        /*
+
+        [LOG 17:59:21.512] [MechJeb2] [MechJebLib.HoverslamSimulationBuilder] Initial(
+        new V3([277354.901930395, 52073.8040485903, 0.00727448590091598]),
+         new V3([-112.093343687681, 178.249208847387, 7.73831475858213E-05]), 104028.344130375, 65138397520.7807, new V3([0, 0, 4.52078533000628E-05]))
+        */
+
+        [Fact]
+        private void MunLanderTwoStageWithCoast()
+        {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
+
+            var    r0           = new V3(277354.901930395, 52073.8040485903, 0.00727448590091598);
+            var    v0           = new V3(-112.093343687681, 178.249208847387, 7.73831475858213E-05);
+            double t0           = 104028.344130375;
+            double mu           = 65138397520.7807;
+            var    w            = new V3(0, 0, 4.52078533000628E-05);
+            double height       = 203079.452561372;
+            double descentSpeed = 111.503169115681;
+
+            HoverslamSimulation hoverslam = HoverslamSimulation.Builder()
+               .Initial(r0, v0, t0, mu, w)
+               .TargetConditions(height, descentSpeed)
+               .AddStage(1631.71526258703, 1478.0574232488, 64000.0164757482, 290.000076251489, 2, 2)
+               .AddCoast(1041.14351191796, 0.5625, 0, 0)
+               .AddStage(1041.14351191796, 733.827833241511, 64000.0092904123, 290.000043692936, 0, 0)
+               .Build();
+
+            hoverslam.Run();
+
+            hoverslam.Rf.magnitude.ShouldEqual(height, 1e-6);
+            (hoverslam.IgnitionUT - t0).ShouldEqual(357.69288233217958, 1e-6);
+            hoverslam.Vf.ShouldEqual(V3.Cross(w, hoverslam.Rf) - descentSpeed * hoverslam.Rf.normalized , 1e-6);
+            hoverslam.Dv.ShouldEqual(384.68994637708414, 1e-6);
         }
     }
 }


### PR DESCRIPTION
KSP has a minimum post-stage delay baked into Physics.cfg

Also sets the default post delay in MJ to the default post delay in KSP

And removes some excess logspamming left over from old debugging in some issue.