### PR TITLE
Move the StagingController to FixedUpdate

### DIFF
--- a/MechJeb2/MechJebCore.cs
+++ b/MechJeb2/MechJebCore.cs
@@ -567,6 +567,9 @@ namespace MuMech
 
             foreach (ComputerModule module in GetComputerModules<ComputerModule>())
             {
+                // Staging runs explicitly after the loop so it sees every other module's writes this tick.
+                if (module == Staging) continue;
+
                 Profiler.BeginSample(module.ProfilerName);
                 try
                 {
@@ -578,6 +581,21 @@ namespace MuMech
                 catch (Exception e)
                 {
                     Debug.LogError("MechJeb module " + module.GetType().Name + " threw an exception in OnFixedUpdate: " + e);
+                }
+
+                Profiler.EndSample();
+            }
+
+            if (Staging != null && Staging.Enabled)
+            {
+                Profiler.BeginSample(Staging.ProfilerName);
+                try
+                {
+                    Staging.OnFixedUpdate();
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("MechJeb module " + Staging.GetType().Name + " threw an exception in OnFixedUpdate: " + e);
                 }
 
                 Profiler.EndSample();

--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -250,7 +250,7 @@ namespace MuMech
         private Vessel _currentActiveVessel;
         private bool   _initializedOnce;
 
-        public override void OnUpdate()
+        public override void OnFixedUpdate()
         {
             if (!_initializedOnce)
             {


### PR DESCRIPTION
Right now this is being called in Update() which is just very weird.

Having it run every frame is just a total waste of CPU.

If there is a $reason for doing things this way, I suspect that it is to lazy the controller so that every other module can twiddle its variables and then it always runs after FixedUpdate().

So changed it so that it runs last in FixedUpdate() instead of running in Update().

This could very well introduce unforeseen bugs, but I think it is worth it for the performance improvement and it just eliminates weirdness with multiple staging controller actions for every physics tick in the logs, and that WTF factor is pretty large.