### PR TITLE
Sync autostage post delay to KSP's value

### DIFF
--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -22,7 +22,7 @@ namespace MuMech
         public readonly EditableDouble AutostagePreDelay = 0.0;
 
         [Persistent(pass = (int)(Pass.TYPE | Pass.GLOBAL))]
-        public readonly EditableDouble AutostagePostDelay = 0.5;
+        public readonly EditableDouble AutostagePostDelay = PhysicsGlobals.StagingCooldownTimer;
 
         [Persistent(pass = (int)(Pass.TYPE | Pass.GLOBAL))]
         public readonly EditableInt AutostageLimit = 0;


### PR DESCRIPTION
This defaults to 0.5 in this code, but is actually 0.5625 in the Physics.cfg and could conceivably be tweaked, so use the real value here.