### PR TITLE
Better objectpooled vec class and blas1 vecops

### DIFF
--- a/MechJebLib/Primitives/Vec.cs
+++ b/MechJebLib/Primitives/Vec.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using MechJebLib.Utils;
+
+namespace MechJebLib.Primitives
+{
+    public sealed class Vec : IList<double>, IReadOnlyList<double>, IDisposable
+    {
+        private static readonly ObjectPool<Vec>[] _pools = MakePools();
+
+        private static ObjectPool<Vec>[] MakePools()
+        {
+            var arr = new ObjectPool<Vec>[Bucket.COUNT];
+            for (int k = 0; k < Bucket.COUNT; k++)
+            {
+                int capacity = Bucket.SizeFor(k);
+                int k1       = k;
+                arr[k] = new ObjectPool<Vec>(
+                    () => new Vec(new double[capacity], k1),
+                    v => v.Length = 0);
+            }
+
+            return arr;
+        }
+
+        private Vec(double[] data, int bucket)
+        {
+            Data = data;
+            _bucket = bucket;
+            Length = 0;
+        }
+
+        public readonly double[] Data;
+        public int Length; // warn: do not write this
+        private readonly int _bucket;
+
+        public int Capacity
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Data.Length;
+        }
+
+        public static Vec Rent(int length, bool zero = false)
+        {
+            if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
+            int bucket = Bucket.IndexFor(length);
+            Vec v      = _pools[bucket].Borrow();
+            v.Length = length;
+            if (zero) Array.Clear(v.Data, 0, length);
+            return v;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose() => _pools[_bucket].Release(this);
+
+        public double this[int i]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Data[i];
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set => Data[i] = value;
+        }
+
+        // ---- Convenience BLAS-1 wrappers (delegate to VecOps, length = this.Length) ----
+        // All other vectors are assumed to have Length ≥ this.Length. No runtime check.
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Fill(double value) =>
+            VecOps.Fill(Data, value, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Scal(double a) =>
+            VecOps.Scal(a, Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void MaxZero() =>
+            VecOps.MaxZero(Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyTo(Vec destination) =>
+            VecOps.Copy(Data, destination.Data, Length);
+
+        // this ← a·x + this
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Axpy(double a, Vec x) =>
+            VecOps.Axpy(a, x.Data, Data, Length);
+
+        // this ← a·x + b·this
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Axpby(double a, Vec x, double b) =>
+            VecOps.Axpby(a, x.Data, b, Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Swap(Vec other) =>
+            VecOps.Swap(Data, other.Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double Dot(Vec other) =>
+            VecOps.Dot(Data, other.Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double Nrm2() => VecOps.Nrm2(Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double NrmInf() => VecOps.NrmInf(Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double Asum() => VecOps.Asum(Data, Length);
+
+        // Hides LINQ's Enumerable.Sum extension on Vec — instance methods win
+        // overload resolution, so callers using System.Linq still get this fast path.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double Sum() => VecOps.Sum(Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Iamax() => VecOps.Iamax(Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void LinComb2(Vec y0,
+            double a1, Vec x1, double a2, Vec x2) =>
+            VecOps.LinComb2(Data, y0.Data,
+                a1, x1.Data, a2, x2.Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void LinComb3(Vec y0,
+            double a1, Vec x1, double a2, Vec x2, double a3, Vec x3) =>
+            VecOps.LinComb3(Data, y0.Data,
+                a1, x1.Data, a2, x2.Data, a3, x3.Data, Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void LinComb4(Vec y0,
+            double a1, Vec x1, double a2, Vec x2,
+            double a3, Vec x3, double a4, Vec x4) =>
+            VecOps.LinComb4(Data, y0.Data,
+                a1, x1.Data, a2, x2.Data,
+                a3, x3.Data, a4, x4.Data, Length);
+
+        public void LinComb5(Vec y0,
+            double a1, Vec x1, double a2, Vec x2,
+            double a3, Vec x3, double a4, Vec x4, double a5, Vec x5) =>
+            VecOps.LinComb5(Data, y0.Data,
+                a1, x1.Data, a2, x2.Data, a3, x3.Data,
+                a4, x4.Data, a5, x5.Data, Length);
+
+        public void LinComb6(Vec y0,
+            double a1, Vec x1, double a2, Vec x2,
+            double a3, Vec x3, double a4, Vec x4,
+            double a5, Vec x5, double a6, Vec x6) =>
+            VecOps.LinComb6(Data, y0.Data,
+                a1, x1.Data, a2, x2.Data, a3, x3.Data,
+                a4, x4.Data, a5, x5.Data, a6, x6.Data, Length);
+
+        public void LinComb7(Vec y0,
+            double a1, Vec x1, double a2, Vec x2,
+            double a3, Vec x3, double a4, Vec x4,
+            double a5, Vec x5, double a6, Vec x6, double a7, Vec x7) =>
+            VecOps.LinComb7(Data, y0.Data,
+                a1, x1.Data, a2, x2.Data, a3, x3.Data,
+                a4, x4.Data, a5, x5.Data, a6, x6.Data,
+                a7, x7.Data, Length);
+
+        public void LinComb8(Vec y0,
+            double a1, Vec x1, double a2, Vec x2,
+            double a3, Vec x3, double a4, Vec x4,
+            double a5, Vec x5, double a6, Vec x6,
+            double a7, Vec x7, double a8, Vec x8) =>
+            VecOps.LinComb8(Data, y0.Data,
+                a1, x1.Data, a2, x2.Data, a3, x3.Data,
+                a4, x4.Data, a5, x5.Data, a6, x6.Data,
+                a7, x7.Data, a8, x8.Data, Length);
+
+        public void LinComb9(Vec y0,
+            double a1, Vec x1, double a2, Vec x2,
+            double a3, Vec x3, double a4, Vec x4,
+            double a5, Vec x5, double a6, Vec x6,
+            double a7, Vec x7, double a8, Vec x8, double a9, Vec x9) =>
+            VecOps.LinComb9(Data, y0.Data,
+                a1, x1.Data, a2, x2.Data, a3, x3.Data,
+                a4, x4.Data, a5, x5.Data, a6, x6.Data,
+                a7, x7.Data, a8, x8.Data, a9, x9.Data, Length);
+
+        // ---- IList<double> (explicit so the class indexer is the fast path) ----
+        double IList<double>.this[int i]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Data[i];
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set => Data[i] = value;
+        }
+
+        int ICollection<double>.Count
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Length;
+        }
+
+        bool ICollection<double>.IsReadOnly => false;
+
+        int IList<double>.IndexOf(double item)
+        {
+            for (int i = 0; i < Length; i++)
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (Data[i] == item)
+                    return i;
+            return -1;
+        }
+
+        bool ICollection<double>.Contains(double item)
+        {
+            for (int i = 0; i < Length; i++)
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (Data[i] == item)
+                    return true;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void ICollection<double>.CopyTo(double[] array, int arrayIndex) => Array.Copy(Data, 0, array, arrayIndex, Length);
+
+        void IList<double>.      Insert(int index, double item) => throw new NotSupportedException();
+        void IList<double>.      RemoveAt(int index)            => throw new NotSupportedException();
+        void ICollection<double>.Add(double item)               => throw new NotSupportedException();
+        void ICollection<double>.Clear()                        => throw new NotSupportedException();
+        bool ICollection<double>.Remove(double item)            => throw new NotSupportedException();
+
+        // ---- IReadOnlyList<double> ----
+        double IReadOnlyList<double>.this[int i]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Data[i];
+        }
+
+        int IReadOnlyCollection<double>.Count
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Length;
+        }
+
+        // ---- Enumeration (struct enumerator avoids boxing on foreach over Vec) ----
+        public Enumerator                       GetEnumerator() => new Enumerator(this);
+        IEnumerator<double> IEnumerable<double>.GetEnumerator() => new Enumerator(this);
+        IEnumerator IEnumerable.                GetEnumerator() => new Enumerator(this);
+
+        public struct Enumerator : IEnumerator<double>
+        {
+            private readonly Vec _vec;
+            private int _index;
+
+            internal Enumerator(Vec vec)
+            {
+                _vec = vec;
+                _index = -1;
+            }
+
+            public double Current
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => _vec.Data[_index];
+            }
+
+            object IEnumerator.Current
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => Current;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool MoveNext() => ++_index < _vec.Length;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Reset() => _index = -1;
+
+            public void Dispose() { }
+        }
+
+        private static class Bucket
+        {
+            // 2^30 = ~1B doubles = ~8GB. Plenty for any sane PIPG/ODE buffer.
+            public const int COUNT = 31;
+
+            private static readonly int[] _log2 = { 0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30, 8, 12, 20, 28, 15, 17, 24, 7, 19, 27, 23, 6, 26, 5, 4, 31 };
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static int IndexFor(int length)
+            {
+                if (length <= 1) return 0;
+                uint v = (uint)(length - 1);
+                v |= v >> 1;
+                v |= v >> 2;
+                v |= v >> 4;
+                v |= v >> 8;
+                v |= v >> 16;
+                return _log2[(v * 0x07C4ACDDu) >> 27] + 1;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static int SizeFor(int bucket) => 1 << bucket;
+        }
+    }
+}

--- a/MechJebLib/Primitives/VecOps.cs
+++ b/MechJebLib/Primitives/VecOps.cs
@@ -1,0 +1,267 @@
+using System;
+
+namespace MechJebLib.Primitives
+{
+    // BLAS Level-1 operations on dense double[] vectors.
+    // Length is passed explicitly (not derived from x.Length) so callers can
+    // operate on the logical region of an oversized buffer (e.g. PooledVector).
+    //
+    // Aliasing rule: for in-place ops (Axpy, Axpby), x and y must not refer to
+    // the same array. Same as real BLAS. Caller's problem.
+    //
+    // Nrm2 uses naive sqrt(dot(x, x)). Inputs are assumed bounded so that
+    // Σ x[i]² fits in a double — true for PIPG iterates (bounded by projection
+    // radii) and typical ODE state vectors. If you ever need overflow safety,
+    // swap in the two-pass scaled version; it's a drop-in.
+    public static class VecOps
+    {
+        public static void Copy(double[] src, double[] dst, int n) => Array.Copy(src, 0, dst, 0, n);
+
+        public static void Fill(double[] x, double value, int n)
+        {
+            for (int i = 0; i < n; i++) x[i] = value;
+        }
+
+        public static void Scal(double a, double[] x, int n)
+        {
+            for (int i = 0; i < n; i++) x[i] *= a;
+        }
+
+        // y ← a·x + y
+        public static void Axpy(double a, double[] x, double[] y, int n)
+        {
+            for (int i = 0; i < n; i++) y[i] += a * x[i];
+        }
+
+        // y ← a·x + b·y
+        public static void Axpby(double a, double[] x, double b, double[] y, int n)
+        {
+            for (int i = 0; i < n; i++) y[i] = a * x[i] + b * y[i];
+        }
+
+        public static double Dot(double[] x, double[] y, int n)
+        {
+            double s = 0.0;
+            for (int i = 0; i < n; i++) s += x[i] * y[i];
+            return s;
+        }
+
+        public static double Nrm2(double[] x, int n) => Math.Sqrt(Dot(x, x, n));
+
+        public static double NrmInf(double[] x, int n)
+        {
+            double m = 0.0;
+            for (int i = 0; i < n; i++)
+            {
+                double a = Math.Abs(x[i]);
+                if (a > m) m = a;
+            }
+
+            return m;
+        }
+
+        // x ← max(x, 0). Used by cone projections (clip ℝ₊).
+        public static void MaxZero(double[] x, int n)
+        {
+            for (int i = 0; i < n; i++)
+                if (x[i] < 0.0)
+                    x[i] = 0.0;
+        }
+
+        // Σ|x[i]|  (BLAS dasum, the L1 norm)
+        public static double Asum(double[] x, int n)
+        {
+            double s = 0.0;
+            for (int i = 0; i < n; i++) s += Math.Abs(x[i]);
+            return s;
+        }
+
+        // Σ x[i]  (signed sum; not in classic BLAS but a common useful primitive)
+        public static double Sum(double[] x, int n)
+        {
+            double s = 0.0;
+            for (int i = 0; i < n; i++) s += x[i];
+            return s;
+        }
+
+        // Index of the element with largest |x[i]| (BLAS idamax — but 0-based here).
+        // Returns -1 when n ≤ 0. On ties, returns the first occurrence.
+        public static int Iamax(double[] x, int n)
+        {
+            if (n <= 0) return -1;
+            int    idx = 0;
+            double m   = Math.Abs(x[0]);
+            for (int i = 1; i < n; i++)
+            {
+                double a = Math.Abs(x[i]);
+                if (a > m)
+                {
+                    m = a;
+                    idx = i;
+                }
+            }
+
+            return idx;
+        }
+
+        // x ↔ y  (BLAS dswap)
+        public static void Swap(double[] x, double[] y, int n)
+        {
+            for (int i = 0; i < n; i++)
+            {
+                (x[i], y[i]) = (y[i], x[i]);
+            }
+        }
+
+        // z[i] ← x[i] * y[i]  (Hadamard product).
+        // Aliasing z = x or z = y is safe — each iteration reads x[i],y[i] then writes z[i].
+        public static void Mul(double[] x, double[] y, double[] z, int n)
+        {
+            for (int i = 0; i < n; i++) z[i] = x[i] * y[i];
+        }
+
+        // z[i] ← x[i] / y[i]  (element-wise divide).
+        // Aliasing z = x or z = y is safe.
+        // Division by zero follows IEEE 754: ±Inf for nonzero numerator, NaN for 0/0.
+        public static void Div(double[] x, double[] y, double[] z, int n)
+        {
+            for (int i = 0; i < n; i++) z[i] = x[i] / y[i];
+        }
+
+        // Apply a Givens (plane) rotation to (x, y):
+        //   x[i] ←  c·x[i] + s·y[i]
+        //   y[i] ← -s·x[i] + c·y[i]
+        // c, s typically come from Rotg. Both vectors are modified in place.
+        public static void Rot(double[] x, double[] y, double c, double s, int n)
+        {
+            for (int i = 0; i < n; i++)
+            {
+                double xi = x[i];
+                double yi = y[i];
+                x[i] = c * xi + s * yi;
+                y[i] = -s * xi + c * yi;
+            }
+        }
+
+        // Construct a Givens rotation (c, s) such that
+        //   [ c  s] [a]   [r]
+        //   [-s  c] [b] = [0]
+        // Output r = ±sqrt(a² + b²), sign chosen by netlib's drotg convention
+        // (sign of whichever of a, b is larger in magnitude). c² + s² = 1.
+        //
+        // We don't return BLAS's `z` reconstruction parameter — a, b are inputs
+        // by value, and r is delivered as an explicit out.
+        public static void Rotg(double a, double b, out double c, out double s, out double r)
+        {
+            double absA  = Math.Abs(a);
+            double absB  = Math.Abs(b);
+            double scale = absA + absB;
+            if (scale == 0.0)
+            {
+                c = 1.0;
+                s = 0.0;
+                r = 0.0;
+                return;
+            }
+
+            // sigma = sign(roe) where roe = a if |a| > |b| else b.
+            double sigma = absA > absB ? a < 0.0 ? -1.0 : 1.0
+                : b < 0.0 ? -1.0 : 1.0;
+            double aS = a / scale;
+            double bS = b / scale;
+            r = sigma * scale * Math.Sqrt(aS * aS + bS * bS);
+            c = a / r;
+            s = b / r;
+        }
+
+        // Fused linear combination:  y[i] ← y0[i] + Σₖ aₖ · xₖ[i]
+        //
+        // One pass over the data — call site reads like an axpy chain but executes
+        // as a single loop. The shape comes from RK k-vector mixing, e.g.
+        //   Ynew = Y + h·(A51·K1 + A52·K2 + A53·K3 + A54·K4)
+        // is LinComb4(Ynew, Y, h·A51, K1, h·A52, K2, h·A53, K3, h·A54, K4, N).
+        //
+        // Aliasing y = y0 (in-place update) and y = any xₖ are both safe — each
+        // element is read once and written once per iteration.
+
+        public static void LinComb2(double[] y, double[] y0,
+            double a1, double[] x1, double a2, double[] x2, int n)
+        {
+            for (int i = 0; i < n; i++)
+                y[i] = y0[i] + a1 * x1[i] + a2 * x2[i];
+        }
+
+        public static void LinComb3(double[] y, double[] y0,
+            double a1, double[] x1, double a2, double[] x2,
+            double a3, double[] x3, int n)
+        {
+            for (int i = 0; i < n; i++)
+                y[i] = y0[i] + a1 * x1[i] + a2 * x2[i] + a3 * x3[i];
+        }
+
+        public static void LinComb4(double[] y, double[] y0,
+            double a1, double[] x1, double a2, double[] x2,
+            double a3, double[] x3, double a4, double[] x4, int n)
+        {
+            for (int i = 0; i < n; i++)
+                y[i] = y0[i] + a1 * x1[i] + a2 * x2[i] + a3 * x3[i] + a4 * x4[i];
+        }
+
+        public static void LinComb5(double[] y, double[] y0,
+            double a1, double[] x1, double a2, double[] x2,
+            double a3, double[] x3, double a4, double[] x4,
+            double a5, double[] x5, int n)
+        {
+            for (int i = 0; i < n; i++)
+                y[i] = y0[i] + a1 * x1[i] + a2 * x2[i] + a3 * x3[i]
+                    + a4 * x4[i] + a5 * x5[i];
+        }
+
+        public static void LinComb6(double[] y, double[] y0,
+            double a1, double[] x1, double a2, double[] x2,
+            double a3, double[] x3, double a4, double[] x4,
+            double a5, double[] x5, double a6, double[] x6, int n)
+        {
+            for (int i = 0; i < n; i++)
+                y[i] = y0[i] + a1 * x1[i] + a2 * x2[i] + a3 * x3[i]
+                    + a4 * x4[i] + a5 * x5[i] + a6 * x6[i];
+        }
+
+        public static void LinComb7(double[] y, double[] y0,
+            double a1, double[] x1, double a2, double[] x2,
+            double a3, double[] x3, double a4, double[] x4,
+            double a5, double[] x5, double a6, double[] x6,
+            double a7, double[] x7, int n)
+        {
+            for (int i = 0; i < n; i++)
+                y[i] = y0[i] + a1 * x1[i] + a2 * x2[i] + a3 * x3[i]
+                    + a4 * x4[i] + a5 * x5[i] + a6 * x6[i]
+                    + a7 * x7[i];
+        }
+
+        public static void LinComb8(double[] y, double[] y0,
+            double a1, double[] x1, double a2, double[] x2,
+            double a3, double[] x3, double a4, double[] x4,
+            double a5, double[] x5, double a6, double[] x6,
+            double a7, double[] x7, double a8, double[] x8, int n)
+        {
+            for (int i = 0; i < n; i++)
+                y[i] = y0[i] + a1 * x1[i] + a2 * x2[i] + a3 * x3[i]
+                    + a4 * x4[i] + a5 * x5[i] + a6 * x6[i]
+                    + a7 * x7[i] + a8 * x8[i];
+        }
+
+        public static void LinComb9(double[] y, double[] y0,
+            double a1, double[] x1, double a2, double[] x2,
+            double a3, double[] x3, double a4, double[] x4,
+            double a5, double[] x5, double a6, double[] x6,
+            double a7, double[] x7, double a8, double[] x8,
+            double a9, double[] x9, int n)
+        {
+            for (int i = 0; i < n; i++)
+                y[i] = y0[i] + a1 * x1[i] + a2 * x2[i] + a3 * x3[i]
+                    + a4 * x4[i] + a5 * x5[i] + a6 * x6[i]
+                    + a7 * x7[i] + a8 * x8[i] + a9 * x9[i];
+        }
+    }
+}

--- a/MechJebLib/Utils/AutoDiff.cs
+++ b/MechJebLib/Utils/AutoDiff.cs
@@ -24,6 +24,7 @@ namespace MechJebLib.Utils
                 buf = new Dual[n];
                 _dualBuffer.Value = buf;
             }
+
             return buf;
         }
 
@@ -35,13 +36,14 @@ namespace MechJebLib.Utils
                 buf = new DualV3[n];
                 _dualV3Buffer.Value = buf;
             }
+
             return buf;
         }
 
-        private static (double, Vn) Gradient(Func<Dual[], Dual> f, double[] point)
+        private static (double, Vec) Gradient(Func<Dual[], Dual> f, double[] point)
         {
             int n        = point.Length;
-            var partials = Vn.Rent(n);
+            var partials = Vec.Rent(n);
             var ans      = new Dual(0);
 
             Dual[] duals = RentDualArray(n);
@@ -62,10 +64,10 @@ namespace MechJebLib.Utils
             return (ans.M, partials);
         }
 
-        private static (double, Vn) GradientV3(Func<DualV3[], Dual> f, V3[] point)
+        private static (double, Vec) GradientV3(Func<DualV3[], Dual> f, V3[] point)
         {
             int n        = point.Length;
-            var partials = Vn.Rent(3 * n);
+            var partials = Vec.Rent(3 * n);
             var ans      = new Dual(0);
 
             DualV3[] duals = RentDualV3Array(n);
@@ -88,12 +90,12 @@ namespace MechJebLib.Utils
             return (ans.M, partials);
         }
 
-        public static (V3, Vn partialX, Vn partialY, Vn partialZ) JacobianV3(Func<DualV3[], DualV3> f, V3[] point)
+        public static (V3, Vec partialX, Vec partialY, Vec partialZ) JacobianV3(Func<DualV3[], DualV3> f, V3[] point)
         {
             int n        = point.Length;
-            var partialX = Vn.Rent(3 * n);
-            var partialY = Vn.Rent(3 * n);
-            var partialZ = Vn.Rent(3 * n);
+            var partialX = Vec.Rent(3 * n);
+            var partialY = Vec.Rent(3 * n);
+            var partialZ = Vec.Rent(3 * n);
             var ans      = new DualV3(V3.zero, V3.zero);
 
             DualV3[] duals = RentDualV3Array(n);
@@ -141,7 +143,7 @@ namespace MechJebLib.Utils
 
         public static int ApplyScalarConstraint(double[] f, alglib.sparsematrix j, int ci, Func<Dual[], Dual> g, double[] p, int[] idx)
         {
-            (double value, Vn partials) = Gradient(g, p);
+            (double value, Vec partials) = Gradient(g, p);
 
             int n = p.Length;
 
@@ -155,14 +157,14 @@ namespace MechJebLib.Utils
             f[ci++] = value;
             AppendSortedRow(j, elements);
 
-            Vn.Return(partials);
+            partials.Dispose();
 
             return ci;
         }
 
         public static int ApplyScalarConstraintV3(double[] f, alglib.sparsematrix j, int ci, Func<DualV3[], Dual> g, V3[] p, (int, int, int)[] idx)
         {
-            (double value, Vn partials) = GradientV3(g, p);
+            (double value, Vec partials) = GradientV3(g, p);
 
             int n = p.Length;
 
@@ -179,14 +181,14 @@ namespace MechJebLib.Utils
             f[ci++] = value;
             AppendSortedRow(j, elements);
 
-            Vn.Return(partials);
+            partials.Dispose();
 
             return ci;
         }
 
         public static int ApplyVectorConstraintV3(double[] f, alglib.sparsematrix j, int ci, Func<DualV3[], DualV3> g, V3[] p, (int, int, int)[] idx)
         {
-            (V3 value, Vn partialX, Vn partialY, Vn partialZ) = JacobianV3(g, p);
+            (V3 value, Vec partialX, Vec partialY, Vec partialZ) = JacobianV3(g, p);
 
             int n = p.Length;
 
@@ -227,9 +229,9 @@ namespace MechJebLib.Utils
             f[ci++] = value.z;
             AppendSortedRow(j, elements);
 
-            Vn.Return(partialX);
-            Vn.Return(partialY);
-            Vn.Return(partialZ);
+            partialX.Dispose();
+            partialY.Dispose();
+            partialZ.Dispose();
 
             return ci;
         }
@@ -415,9 +417,9 @@ namespace MechJebLib.Utils
         {
             const int NUM_VARS = 31;
             DualV3    ans;
-            var       jacX = Vn.Rent(NUM_VARS);
-            var       jacY = Vn.Rent(NUM_VARS);
-            var       jacZ = Vn.Rent(NUM_VARS);
+            var       jacX = Vec.Rent(NUM_VARS, true);
+            var       jacY = Vec.Rent(NUM_VARS, true);
+            var       jacZ = Vec.Rent(NUM_VARS, true);
 
             var d0  = new HermiteSimpsonDualPoint { R = segment.R0, V = segment.V0, U = segment.U0, M = segment.M0 };
             var d1  = new HermiteSimpsonDualPoint { R = segment.R1, V = segment.V1, U = segment.U1, M = segment.M1 };
@@ -510,13 +512,13 @@ namespace MechJebLib.Utils
                 if (jacZ[k] != 0)
                     alglib.sparseappendelement(j, indexes.Index(k), jacZ[k]);
 
-            Vn.Return(jacX);
-            Vn.Return(jacY);
-            Vn.Return(jacZ);
+            jacX.Dispose();
+            jacY.Dispose();
+            jacZ.Dispose();
 
-            jacX = Vn.Rent(NUM_VARS);
-            jacY = Vn.Rent(NUM_VARS);
-            jacZ = Vn.Rent(NUM_VARS);
+            jacX = Vec.Rent(NUM_VARS, true);
+            jacY = Vec.Rent(NUM_VARS, true);
+            jacZ = Vec.Rent(NUM_VARS, true);
 
             H = dbt / (n - 1);
             Dual H8 = H * 0.125;
@@ -606,13 +608,13 @@ namespace MechJebLib.Utils
 
             bool singleControlVariable = indexes.Index(21) == indexes.Index(22);
 
-            Vn.Return(jacX);
-            Vn.Return(jacY);
-            Vn.Return(jacZ);
+            jacX.Dispose();
+            jacY.Dispose();
+            jacZ.Dispose();
 
-            jacX = Vn.Rent(NUM_VARS);
-            jacY = Vn.Rent(NUM_VARS);
-            jacZ = Vn.Rent(NUM_VARS);
+            jacX = Vec.Rent(NUM_VARS, true);
+            jacY = Vec.Rent(NUM_VARS, true);
+            jacZ = Vec.Rent(NUM_VARS, true);
 
             for (int k = 0; k < NUM_VARS; k++)
             {
@@ -702,13 +704,13 @@ namespace MechJebLib.Utils
                     lastindex = index;
                 }
 
-            Vn.Return(jacX);
-            Vn.Return(jacY);
-            Vn.Return(jacZ);
+            jacX.Dispose();
+            jacY.Dispose();
+            jacZ.Dispose();
 
-            jacX = Vn.Rent(NUM_VARS);
-            jacY = Vn.Rent(NUM_VARS);
-            jacZ = Vn.Rent(NUM_VARS);
+            jacX = Vec.Rent(NUM_VARS, true);
+            jacY = Vec.Rent(NUM_VARS, true);
+            jacZ = Vec.Rent(NUM_VARS, true);
 
             for (int k = 0; k < NUM_VARS; k++)
             {

--- a/MechJebLibTest/Primitives/VecOpsTests.cs
+++ b/MechJebLibTest/Primitives/VecOpsTests.cs
@@ -1,0 +1,1131 @@
+using System;
+using MechJebLib.Primitives;
+using Xunit;
+
+namespace MechJebLibTest.Primitives
+{
+    public class VecOpsTests
+    {
+        // ---------- Copy ----------
+
+        [Fact]
+        public void Copy_CopiesFirstNElements()
+        {
+            double[] src = { 1.0, 2.0, 3.0, 4.0, 5.0 };
+            double[] dst = { 9.0, 9.0, 9.0, 9.0, 9.0 };
+            VecOps.Copy(src, dst, 3);
+            Assert.Equal(new[] { 1.0, 2.0, 3.0, 9.0, 9.0 }, dst);
+        }
+
+        [Fact]
+        public void Copy_NZero_NoOp()
+        {
+            double[] src = { 1.0 };
+            double[] dst = { 9.0 };
+            VecOps.Copy(src, dst, 0);
+            Assert.Equal(9.0, dst[0]);
+        }
+
+        // ---------- Fill ----------
+
+        [Fact]
+        public void Fill_SetsFirstNElements()
+        {
+            double[] x = { 1.0, 2.0, 3.0, 4.0 };
+            VecOps.Fill(x, 7.5, 3);
+            Assert.Equal(new[] { 7.5, 7.5, 7.5, 4.0 }, x);
+        }
+
+        [Fact]
+        public void Fill_NZero_NoOp()
+        {
+            double[] x = { 1.0 };
+            VecOps.Fill(x, 0.0, 0);
+            Assert.Equal(1.0, x[0]);
+        }
+
+        // ---------- Scal ----------
+
+        [Theory]
+        [InlineData(2.0, new[] { 1.0, -2.0, 3.0 }, new[] { 2.0, -4.0, 6.0 })]
+        [InlineData(0.0, new[] { 1.0, -2.0, 3.0 }, new[] { 0.0, 0.0, 0.0 })]
+        [InlineData(1.0, new[] { 1.0, -2.0, 3.0 }, new[] { 1.0, -2.0, 3.0 })]
+        [InlineData(-1.0, new[] { 1.0, -2.0, 3.0 }, new[] { -1.0, 2.0, -3.0 })]
+        public void Scal_ScalesByAlpha(double a, double[] input, double[] expected)
+        {
+            VecOps.Scal(a, input, input.Length);
+            Assert.Equal(expected, input);
+        }
+
+        // ---------- Axpy ----------
+
+        [Fact]
+        public void Axpy_ComputesAlphaXPlusY()
+        {
+            // y ← 2·x + y
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 10.0, 20.0, 30.0 };
+            VecOps.Axpy(2.0, x, y, 3);
+            Assert.Equal(new[] { 12.0, 24.0, 36.0 }, y);
+        }
+
+        [Fact]
+        public void Axpy_AlphaZero_LeavesYUnchanged()
+        {
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 10.0, 20.0, 30.0 };
+            VecOps.Axpy(0.0, x, y, 3);
+            Assert.Equal(new[] { 10.0, 20.0, 30.0 }, y);
+        }
+
+        [Fact]
+        public void Axpy_AlphaNegativeOne_PerformsSubtraction()
+        {
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 10.0, 20.0, 30.0 };
+            VecOps.Axpy(-1.0, x, y, 3);
+            Assert.Equal(new[] { 9.0, 18.0, 27.0 }, y);
+        }
+
+        [Fact]
+        public void Axpy_StopsAtN()
+        {
+            double[] x = { 1.0, 2.0, 3.0, 100.0 };
+            double[] y = { 0.0, 0.0, 0.0, 0.0 };
+            VecOps.Axpy(1.0, x, y, 3);
+            Assert.Equal(new[] { 1.0, 2.0, 3.0, 0.0 }, y);
+        }
+
+        // ---------- Axpby ----------
+
+        [Fact]
+        public void Axpby_ComputesAlphaXPlusBetaY()
+        {
+            // y ← 2·x + 3·y
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 10.0, 20.0, 30.0 };
+            VecOps.Axpby(2.0, x, 3.0, y, 3);
+            Assert.Equal(new[] { 32.0, 64.0, 96.0 }, y);
+        }
+
+        [Fact]
+        public void Axpby_BetaZero_OverwritesY()
+        {
+            // y ← 2·x + 0·y  (effectively y ← 2·x, ignoring previous y)
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 999.0, 999.0, 999.0 };
+            VecOps.Axpby(2.0, x, 0.0, y, 3);
+            Assert.Equal(new[] { 2.0, 4.0, 6.0 }, y);
+        }
+
+        [Fact]
+        public void Axpby_AlphaZero_BetaOne_LeavesYUnchanged()
+        {
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 10.0, 20.0, 30.0 };
+            VecOps.Axpby(0.0, x, 1.0, y, 3);
+            Assert.Equal(new[] { 10.0, 20.0, 30.0 }, y);
+        }
+
+        // ---------- Dot ----------
+
+        [Fact]
+        public void Dot_OrthogonalVectors_IsZero()
+        {
+            double[] x = { 1.0, 0.0 };
+            double[] y = { 0.0, 1.0 };
+            Assert.Equal(0.0, VecOps.Dot(x, y, 2));
+        }
+
+        [Fact]
+        public void Dot_ParallelVector_EqualsSumOfSquares()
+        {
+            double[] x = { 3.0, 4.0 };
+            Assert.Equal(25.0, VecOps.Dot(x, x, 2));
+        }
+
+        [Fact]
+        public void Dot_KnownValue()
+        {
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 4.0, 5.0, 6.0 };
+            // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
+            Assert.Equal(32.0, VecOps.Dot(x, y, 3));
+        }
+
+        [Fact]
+        public void Dot_NZero_IsZero()
+        {
+            double[] x = { 1.0 };
+            double[] y = { 1.0 };
+            Assert.Equal(0.0, VecOps.Dot(x, y, 0));
+        }
+
+        // ---------- Nrm2 ----------
+
+        [Fact]
+        public void Nrm2_KnownValue()
+        {
+            double[] x = { 3.0, 4.0 };
+            Assert.Equal(5.0, VecOps.Nrm2(x, 2));
+        }
+
+        [Fact]
+        public void Nrm2_ZeroVector_IsZero()
+        {
+            double[] x = { 0.0, 0.0, 0.0 };
+            Assert.Equal(0.0, VecOps.Nrm2(x, 3));
+        }
+
+        [Fact]
+        public void Nrm2_NegativeEntries_HandledByDotSelfSquaring()
+        {
+            double[] x = { -3.0, 4.0 };
+            Assert.Equal(5.0, VecOps.Nrm2(x, 2));
+        }
+
+        [Fact]
+        public void Nrm2_MatchesSqrtDot()
+        {
+            double[] x        = { 1.5, -2.5, 0.5, -0.5, 3.0 };
+            double   expected = Math.Sqrt(VecOps.Dot(x, x, 5));
+            Assert.Equal(expected, VecOps.Nrm2(x, 5));
+        }
+
+        // ---------- NrmInf ----------
+
+        [Fact]
+        public void NrmInf_ReturnsMaxAbs()
+        {
+            double[] x = { 1.0, -5.0, 3.0, -2.0 };
+            Assert.Equal(5.0, VecOps.NrmInf(x, 4));
+        }
+
+        [Fact]
+        public void NrmInf_ZeroVector_IsZero()
+        {
+            double[] x = { 0.0, 0.0, 0.0 };
+            Assert.Equal(0.0, VecOps.NrmInf(x, 3));
+        }
+
+        [Fact]
+        public void NrmInf_NZero_IsZero()
+        {
+            double[] x = { 99.0, 99.0 };
+            Assert.Equal(0.0, VecOps.NrmInf(x, 0));
+        }
+
+        [Fact]
+        public void NrmInf_StopsAtN()
+        {
+            // Element past n must not influence the result.
+            double[] x = { 1.0, 2.0, 1e9 };
+            Assert.Equal(2.0, VecOps.NrmInf(x, 2));
+        }
+
+        // ---------- MaxZero ----------
+
+        [Fact]
+        public void MaxZero_ClipsNegatives()
+        {
+            double[] x = { 1.0, -2.0, 3.0, -0.5, 0.0 };
+            VecOps.MaxZero(x, 5);
+            Assert.Equal(new[] { 1.0, 0.0, 3.0, 0.0, 0.0 }, x);
+        }
+
+        [Fact]
+        public void MaxZero_AllPositive_NoChange()
+        {
+            double[] x = { 1.0, 2.0, 3.0 };
+            VecOps.MaxZero(x, 3);
+            Assert.Equal(new[] { 1.0, 2.0, 3.0 }, x);
+        }
+
+        [Fact]
+        public void MaxZero_StopsAtN()
+        {
+            double[] x = { -1.0, -2.0, -3.0 };
+            VecOps.MaxZero(x, 2);
+            Assert.Equal(new[] { 0.0, 0.0, -3.0 }, x);
+        }
+
+        // ---------- Asum ----------
+
+        [Fact]
+        public void Asum_SumsAbsoluteValues()
+        {
+            double[] x = { 1.0, -2.0, 3.0, -4.0 };
+            Assert.Equal(10.0, VecOps.Asum(x, 4));
+        }
+
+        [Fact]
+        public void Asum_AllZero_IsZero()
+        {
+            double[] x = { 0.0, 0.0, 0.0 };
+            Assert.Equal(0.0, VecOps.Asum(x, 3));
+        }
+
+        [Fact]
+        public void Asum_NZero_IsZero()
+        {
+            double[] x = { 1.0, 2.0 };
+            Assert.Equal(0.0, VecOps.Asum(x, 0));
+        }
+
+        [Fact]
+        public void Asum_StopsAtN()
+        {
+            double[] x = { 1.0, 2.0, 1e9 };
+            Assert.Equal(3.0, VecOps.Asum(x, 2));
+        }
+
+        // ---------- Sum ----------
+
+        [Fact]
+        public void Sum_SignedSum()
+        {
+            double[] x = { 1.0, -2.0, 3.0, -4.0 };
+            Assert.Equal(-2.0, VecOps.Sum(x, 4));
+        }
+
+        [Fact]
+        public void Sum_CancelsToZero()
+        {
+            double[] x = { 5.0, -5.0, 2.0, -2.0 };
+            Assert.Equal(0.0, VecOps.Sum(x, 4));
+        }
+
+        [Fact]
+        public void Sum_NZero_IsZero()
+        {
+            double[] x = { 1.0, 2.0 };
+            Assert.Equal(0.0, VecOps.Sum(x, 0));
+        }
+
+        [Fact]
+        public void Sum_StopsAtN()
+        {
+            double[] x = { 1.0, 2.0, 1e9 };
+            Assert.Equal(3.0, VecOps.Sum(x, 2));
+        }
+
+        // ---------- Iamax ----------
+
+        [Fact]
+        public void Iamax_ReturnsArgmaxOfAbsoluteValue()
+        {
+            double[] x = { 1.0, -5.0, 3.0, 4.0 };
+            Assert.Equal(1, VecOps.Iamax(x, 4));
+        }
+
+        [Fact]
+        public void Iamax_HandlesAllNegatives()
+        {
+            double[] x = { -1.0, -7.0, -3.0 };
+            Assert.Equal(1, VecOps.Iamax(x, 3));
+        }
+
+        [Fact]
+        public void Iamax_OnTie_ReturnsFirstOccurrence()
+        {
+            double[] x = { 1.0, -5.0, 5.0, -5.0 };
+            Assert.Equal(1, VecOps.Iamax(x, 4));
+        }
+
+        [Fact]
+        public void Iamax_SingleElement_ReturnsZero()
+        {
+            double[] x = { -3.0 };
+            Assert.Equal(0, VecOps.Iamax(x, 1));
+        }
+
+        [Fact]
+        public void Iamax_NZero_ReturnsNegativeOne()
+        {
+            double[] x = { 99.0 };
+            Assert.Equal(-1, VecOps.Iamax(x, 0));
+        }
+
+        [Fact]
+        public void Iamax_StopsAtN()
+        {
+            // Largest abs value is past n — must not be picked.
+            double[] x = { 1.0, 2.0, 1e9 };
+            Assert.Equal(1, VecOps.Iamax(x, 2));
+        }
+
+        // ---------- Swap ----------
+
+        [Fact]
+        public void Swap_ExchangesContents()
+        {
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 10.0, 20.0, 30.0 };
+            VecOps.Swap(x, y, 3);
+            Assert.Equal(new[] { 10.0, 20.0, 30.0 }, x);
+            Assert.Equal(new[] { 1.0, 2.0, 3.0 }, y);
+        }
+
+        [Fact]
+        public void Swap_StopsAtN()
+        {
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 10.0, 20.0, 30.0 };
+            VecOps.Swap(x, y, 2);
+            Assert.Equal(new[] { 10.0, 20.0, 3.0 }, x);
+            Assert.Equal(new[] { 1.0, 2.0, 30.0 }, y);
+        }
+
+        [Fact]
+        public void Swap_NZero_NoOp()
+        {
+            double[] x = { 1.0, 2.0 };
+            double[] y = { 10.0, 20.0 };
+            VecOps.Swap(x, y, 0);
+            Assert.Equal(new[] { 1.0, 2.0 }, x);
+            Assert.Equal(new[] { 10.0, 20.0 }, y);
+        }
+
+        [Fact]
+        public void Swap_RoundTripIsIdentity()
+        {
+            double[] x     = { 1.0, 2.0, 3.0 };
+            double[] y     = { 10.0, 20.0, 30.0 };
+            double[] xOrig = (double[])x.Clone();
+            double[] yOrig = (double[])y.Clone();
+            VecOps.Swap(x, y, 3);
+            VecOps.Swap(x, y, 3);
+            Assert.Equal(xOrig, x);
+            Assert.Equal(yOrig, y);
+        }
+
+        // ---------- Mul ----------
+
+        [Fact]
+        public void Mul_ComputesHadamardProduct()
+        {
+            double[] x = { 1.0, 2.0, 3.0, 4.0 };
+            double[] y = { 10.0, 20.0, 30.0, 40.0 };
+            double[] z = new double[4];
+            VecOps.Mul(x, y, z, 4);
+            Assert.Equal(new[] { 10.0, 40.0, 90.0, 160.0 }, z);
+        }
+
+        [Fact]
+        public void Mul_Aliasing_ZEqualsX_OverwritesX()
+        {
+            double[] x = { 2.0, 3.0, 4.0 };
+            double[] y = { 5.0, 6.0, 7.0 };
+            VecOps.Mul(x, y, x, 3);
+            Assert.Equal(new[] { 10.0, 18.0, 28.0 }, x);
+            Assert.Equal(new[] { 5.0, 6.0, 7.0 }, y); // y untouched
+        }
+
+        [Fact]
+        public void Mul_Aliasing_ZEqualsY_OverwritesY()
+        {
+            double[] x = { 2.0, 3.0, 4.0 };
+            double[] y = { 5.0, 6.0, 7.0 };
+            VecOps.Mul(x, y, y, 3);
+            Assert.Equal(new[] { 2.0, 3.0, 4.0 }, x); // x untouched
+            Assert.Equal(new[] { 10.0, 18.0, 28.0 }, y);
+        }
+
+        [Fact]
+        public void Mul_Aliasing_AllSame_SquaresInPlace()
+        {
+            double[] x = { 1.0, -2.0, 3.0 };
+            VecOps.Mul(x, x, x, 3);
+            Assert.Equal(new[] { 1.0, 4.0, 9.0 }, x);
+        }
+
+        [Fact]
+        public void Mul_WithZero_ProducesZero()
+        {
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 0.0, 5.0, 0.0 };
+            double[] z = new double[3];
+            VecOps.Mul(x, y, z, 3);
+            Assert.Equal(new[] { 0.0, 10.0, 0.0 }, z);
+        }
+
+        [Fact]
+        public void Mul_NZero_LeavesZUnchanged()
+        {
+            double[] x = { 1.0, 2.0 };
+            double[] y = { 3.0, 4.0 };
+            double[] z = { 99.0, 99.0 };
+            VecOps.Mul(x, y, z, 0);
+            Assert.Equal(new[] { 99.0, 99.0 }, z);
+        }
+
+        [Fact]
+        public void Mul_StopsAtN()
+        {
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 4.0, 5.0, 6.0 };
+            double[] z = { 99.0, 99.0, 99.0 };
+            VecOps.Mul(x, y, z, 2);
+            Assert.Equal(new[] { 4.0, 10.0, 99.0 }, z);
+        }
+
+        // ---------- Div ----------
+
+        [Fact]
+        public void Div_ComputesElementwiseQuotient()
+        {
+            double[] x = { 10.0, 20.0, 30.0, 40.0 };
+            double[] y = { 2.0, 4.0, 5.0, 8.0 };
+            double[] z = new double[4];
+            VecOps.Div(x, y, z, 4);
+            Assert.Equal(new[] { 5.0, 5.0, 6.0, 5.0 }, z);
+        }
+
+        [Fact]
+        public void Div_BySelf_GivesOnes()
+        {
+            double[] x = { 1.0, -2.0, 3.0, -4.0 };
+            double[] z = new double[4];
+            VecOps.Div(x, x, z, 4);
+            Assert.Equal(new[] { 1.0, 1.0, 1.0, 1.0 }, z);
+        }
+
+        [Fact]
+        public void Div_ByOnes_PreservesNumerator()
+        {
+            double[] x = { 1.5, -2.5, 3.5 };
+            double[] y = { 1.0, 1.0, 1.0 };
+            double[] z = new double[3];
+            VecOps.Div(x, y, z, 3);
+            Assert.Equal(new[] { 1.5, -2.5, 3.5 }, z);
+        }
+
+        [Fact]
+        public void Div_Aliasing_ZEqualsX_OverwritesX()
+        {
+            double[] x = { 6.0, 8.0, 10.0 };
+            double[] y = { 2.0, 4.0, 5.0 };
+            VecOps.Div(x, y, x, 3);
+            Assert.Equal(new[] { 3.0, 2.0, 2.0 }, x);
+            Assert.Equal(new[] { 2.0, 4.0, 5.0 }, y);
+        }
+
+        [Fact]
+        public void Div_Aliasing_ZEqualsY_OverwritesY()
+        {
+            double[] x = { 6.0, 8.0, 10.0 };
+            double[] y = { 2.0, 4.0, 5.0 };
+            VecOps.Div(x, y, y, 3);
+            Assert.Equal(new[] { 6.0, 8.0, 10.0 }, x);
+            Assert.Equal(new[] { 3.0, 2.0, 2.0 }, y);
+        }
+
+        [Fact]
+        public void Div_ByZero_FollowsIEEE754()
+        {
+            double[] x = { 1.0, -1.0, 0.0 };
+            double[] y = { 0.0, 0.0, 0.0 };
+            double[] z = new double[3];
+            VecOps.Div(x, y, z, 3);
+            Assert.Equal(double.PositiveInfinity, z[0]);
+            Assert.Equal(double.NegativeInfinity, z[1]);
+            Assert.True(double.IsNaN(z[2]));
+        }
+
+        [Fact]
+        public void Div_NZero_LeavesZUnchanged()
+        {
+            double[] x = { 1.0 };
+            double[] y = { 1.0 };
+            double[] z = { 99.0 };
+            VecOps.Div(x, y, z, 0);
+            Assert.Equal(99.0, z[0]);
+        }
+
+        // ---------- Rot ----------
+
+        [Fact]
+        public void Rot_IdentityRotation_NoChange()
+        {
+            double[] x = { 1.0, 2.0, 3.0 };
+            double[] y = { 4.0, 5.0, 6.0 };
+            VecOps.Rot(x, y, 1.0, 0.0, 3);
+            Assert.Equal(new[] { 1.0, 2.0, 3.0 }, x);
+            Assert.Equal(new[] { 4.0, 5.0, 6.0 }, y);
+        }
+
+        [Fact]
+        public void Rot_NinetyDegrees_SwapsAndNegates()
+        {
+            // c=0, s=1: [0 1; -1 0] · [x; y] = [y; -x]
+            double[] x = { 1.0, 2.0 };
+            double[] y = { 10.0, 20.0 };
+            VecOps.Rot(x, y, 0.0, 1.0, 2);
+            Assert.Equal(new[] { 10.0, 20.0 }, x);
+            Assert.Equal(new[] { -1.0, -2.0 }, y);
+        }
+
+        [Fact]
+        public void Rot_FortyFiveDegrees_RotatesUnitVector()
+        {
+            double   c = Math.Cos(Math.PI / 4);
+            double   s = Math.Sin(Math.PI / 4);
+            double[] x = { 1.0 };
+            double[] y = { 0.0 };
+            VecOps.Rot(x, y, c, s, 1);
+            Assert.Equal(c, x[0], 12);
+            Assert.Equal(-s, y[0], 12);
+        }
+
+        [Fact]
+        public void Rot_RoundTripWithInverse_RestoresInputs()
+        {
+            // Inverse of [c s; -s c] is [c -s; s c] (since det = c²+s² = 1)
+            double   c     = Math.Cos(0.7);
+            double   s     = Math.Sin(0.7);
+            double[] x     = { 1.5, -2.5, 3.0 };
+            double[] y     = { 0.5, 1.5, -1.0 };
+            double[] xOrig = (double[])x.Clone();
+            double[] yOrig = (double[])y.Clone();
+
+            VecOps.Rot(x, y, c, s, 3);
+            VecOps.Rot(x, y, c, -s, 3);
+
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.Equal(xOrig[i], x[i], 12);
+                Assert.Equal(yOrig[i], y[i], 12);
+            }
+        }
+
+        [Fact]
+        public void Rot_StopsAtN()
+        {
+            double[] x = { 1.0, 2.0, 99.0 };
+            double[] y = { 4.0, 5.0, 99.0 };
+            VecOps.Rot(x, y, 0.0, 1.0, 2);
+            Assert.Equal(new[] { 4.0, 5.0, 99.0 }, x);
+            Assert.Equal(new[] { -1.0, -2.0, 99.0 }, y);
+        }
+
+        // ---------- Rotg ----------
+
+        [Fact]
+        public void Rotg_ZeroInputs_GivesIdentity()
+        {
+            VecOps.Rotg(0.0, 0.0, out double c, out double s, out double r);
+            Assert.Equal(1.0, c);
+            Assert.Equal(0.0, s);
+            Assert.Equal(0.0, r);
+        }
+
+        [Fact]
+        public void Rotg_OnlyA_GivesIdentity()
+        {
+            VecOps.Rotg(5.0, 0.0, out double c, out double s, out double r);
+            Assert.Equal(1.0, c, 12);
+            Assert.Equal(0.0, s, 12);
+            Assert.Equal(5.0, r, 12);
+        }
+
+        [Fact]
+        public void Rotg_OnlyB_GivesNinetyDegreeRotation()
+        {
+            VecOps.Rotg(0.0, 5.0, out double c, out double s, out double r);
+            Assert.Equal(0.0, c, 12);
+            Assert.Equal(1.0, s, 12);
+            Assert.Equal(5.0, r, 12);
+        }
+
+        [Fact]
+        public void Rotg_ThreeFourFive_GivesPythagoreanCS()
+        {
+            VecOps.Rotg(3.0, 4.0, out double c, out double s, out double r);
+            Assert.Equal(5.0, r, 12);
+            Assert.Equal(0.6, c, 12);
+            Assert.Equal(0.8, s, 12);
+        }
+
+        [Fact]
+        public void Rotg_EqualAB_GivesQuarterTurn()
+        {
+            VecOps.Rotg(1.0, 1.0, out double c, out double s, out double r);
+            Assert.Equal(Math.Sqrt(2.0), r, 12);
+            Assert.Equal(1.0 / Math.Sqrt(2.0), c, 12);
+            Assert.Equal(1.0 / Math.Sqrt(2.0), s, 12);
+        }
+
+        [Theory]
+        [InlineData(3.0, 4.0)]
+        [InlineData(-3.0, 4.0)]
+        [InlineData(3.0, -4.0)]
+        [InlineData(-3.0, -4.0)]
+        [InlineData(0.1, 1e-6)]
+        [InlineData(1e6, 1e-6)]
+        [InlineData(1.0, 1.0)]
+        public void Rotg_CSquaredPlusSSquared_IsOne(double a, double b)
+        {
+            VecOps.Rotg(a, b, out double c, out double s, out _);
+            Assert.Equal(1.0, c * c + s * s, 12);
+        }
+
+        [Theory]
+        [InlineData(3.0, 4.0)]
+        [InlineData(-3.0, 4.0)]
+        [InlineData(3.0, -4.0)]
+        [InlineData(-3.0, -4.0)]
+        [InlineData(7.0, 24.0)] // |r| = 25
+        [InlineData(1e6, 1.0)]
+        public void Rotg_ConstructedRotation_ZerosOutB(double a, double b)
+        {
+            VecOps.Rotg(a, b, out double c, out double s, out double r);
+
+            double[] xs = { a };
+            double[] ys = { b };
+            VecOps.Rot(xs, ys, c, s, 1);
+
+            // Relative tolerance: c*a + s*b and r can differ by O(eps * |r|)
+            // due to compound rounding. Allow ~few ULP.
+            double tol = 1e-12 * Math.Max(1.0, Math.Abs(r));
+            Assert.InRange(xs[0] - r, -tol, tol);
+            Assert.InRange(ys[0], -tol, tol);
+        }
+
+        [Fact]
+        public void Rotg_RMagnitudeMatchesHypot()
+        {
+            // |r| should equal sqrt(a² + b²) regardless of sign convention.
+            double a = -5.0, b = 12.0;
+            VecOps.Rotg(a, b, out _, out _, out double r);
+            Assert.Equal(13.0, Math.Abs(r), 12);
+        }
+
+        // ---------- LinComb (2..9) ----------
+
+        [Fact]
+        public void LinComb2_KnownValues()
+        {
+            double[] y0 = { 1.0, 2.0, 3.0 };
+            double[] x1 = { 10.0, 20.0, 30.0 };
+            double[] x2 = { 100.0, 200.0, 300.0 };
+            double[] y  = new double[3];
+            VecOps.LinComb2(y, y0, 2.0, x1, 3.0, x2, 3);
+            // y[i] = y0[i] + 2·x1[i] + 3·x2[i]
+            Assert.Equal(new[] { 1 + 20 + 300.0, 2 + 40 + 600.0, 3 + 60 + 900.0 }, y);
+        }
+
+        [Fact]
+        public void LinComb2_EquivalentToCopyAxpyAxpy()
+        {
+            // Verify the fused form matches the BLAS-chain decomposition exactly.
+            double[] y0 = { 1.5, -2.5, 0.5, 3.0 };
+            double[] x1 = { 0.5, 1.0, -1.5, 2.0 };
+            double[] x2 = { -1.0, 0.5, 2.5, -0.5 };
+
+            double[] fused = new double[4];
+            VecOps.LinComb2(fused, y0, 0.7, x1, -1.3, x2, 4);
+
+            double[] chained = new double[4];
+            VecOps.Copy(y0, chained, 4);
+            VecOps.Axpy(0.7, x1, chained, 4);
+            VecOps.Axpy(-1.3, x2, chained, 4);
+
+            for (int i = 0; i < 4; i++) Assert.Equal(chained[i], fused[i], 12);
+        }
+
+        [Fact]
+        public void LinComb2_AliasingInPlace_IsSafe()
+        {
+            // y = y + a1·x1 + a2·x2  (passing same array as y and y0)
+            double[] y  = { 1.0, 2.0, 3.0 };
+            double[] x1 = { 10.0, 20.0, 30.0 };
+            double[] x2 = { 100.0, 200.0, 300.0 };
+            VecOps.LinComb2(y, y, 1.0, x1, 1.0, x2, 3);
+            Assert.Equal(new[] { 111.0, 222.0, 333.0 }, y);
+        }
+
+        [Fact]
+        public void LinComb2_AliasingYEqualsX1_IsSafe()
+        {
+            // Each element of x1 is read once before y is overwritten.
+            double[] y0       = { 1.0, 2.0, 3.0 };
+            double[] y_and_x1 = { 10.0, 20.0, 30.0 };
+            double[] x2       = { 100.0, 200.0, 300.0 };
+            VecOps.LinComb2(y_and_x1, y0, 2.0, y_and_x1, 0.5, x2, 3);
+            // expected y[i] = y0[i] + 2·x1[i] + 0.5·x2[i]
+            Assert.Equal(new[] { 1 + 20 + 50.0, 2 + 40 + 100.0, 3 + 60 + 150.0 }, y_and_x1);
+        }
+
+        [Fact]
+        public void LinComb4_RkStyleUpdate()
+        {
+            // Y_new = Y + h·(A51·K1 + A52·K2 + A53·K3 + A54·K4)
+            // Use simple symbolic values to verify the shape.
+            int      N    = 3;
+            double   h    = 0.1;
+            double   A51  = 1.0, A52 = 2.0, A53 = 3.0, A54 = 4.0;
+            double[] Y    = { 5.0, 5.0, 5.0 };
+            double[] K1   = { 1.0, 1.0, 1.0 };
+            double[] K2   = { 1.0, 1.0, 1.0 };
+            double[] K3   = { 1.0, 1.0, 1.0 };
+            double[] K4   = { 1.0, 1.0, 1.0 };
+            double[] Ynew = new double[N];
+
+            VecOps.LinComb4(Ynew, Y,
+                h * A51, K1, h * A52, K2, h * A53, K3, h * A54, K4, N);
+
+            // Expected: 5 + 0.1·(1+2+3+4) = 5 + 1.0 = 6.0
+            Assert.Equal(new[] { 6.0, 6.0, 6.0 }, Ynew);
+        }
+
+        [Fact]
+        public void LinComb6_DormandPrinceFinalUpdate()
+        {
+            // Y_new = Y + Σ b_i K_i  (DP5-style; coefficients chosen to sum easily)
+            int      N  = 2;
+            double[] Y  = { 0.0, 0.0 };
+            double[] K1 = { 1.0, -1.0 };
+            double[] K2 = { 1.0, -1.0 };
+            double[] K3 = { 1.0, -1.0 };
+            double[] K4 = { 1.0, -1.0 };
+            double[] K5 = { 1.0, -1.0 };
+            double[] K6 = { 1.0, -1.0 };
+            double[] y  = new double[N];
+
+            VecOps.LinComb6(y, Y,
+                0.1, K1, 0.2, K2, 0.3, K3, 0.4, K4, 0.5, K5, 0.5, K6, N);
+
+            // Expected: 0 + (0.1+0.2+0.3+0.4+0.5+0.5)*1 = 2.0
+            Assert.Equal(2.0, y[0], 12);
+            Assert.Equal(-2.0, y[1], 12);
+        }
+
+        [Fact]
+        public void LinComb9_AllStagesContribute()
+        {
+            int        N = 1;
+            double[]   Y = { 100.0 };
+            double[][] X = new double[9][];
+            double[]   a = new double[9];
+            for (int k = 0; k < 9; k++)
+            {
+                X[k] = new[] { 1.0 };
+                a[k] = k + 1; // 1..9, sum = 45
+            }
+
+            double[] y = new double[N];
+            VecOps.LinComb9(y, Y,
+                a[0], X[0], a[1], X[1], a[2], X[2],
+                a[3], X[3], a[4], X[4], a[5], X[5],
+                a[6], X[6], a[7], X[7], a[8], X[8], N);
+
+            Assert.Equal(100.0 + 45.0, y[0], 12);
+        }
+
+        [Fact]
+        public void LinComb_StopsAtN()
+        {
+            double[] y0 = { 1.0, 2.0, 999.0 };
+            double[] x1 = { 1.0, 1.0, 999.0 };
+            double[] x2 = { 1.0, 1.0, 999.0 };
+            double[] y  = { 0.0, 0.0, 42.0 };
+            VecOps.LinComb2(y, y0, 1.0, x1, 1.0, x2, 2);
+            Assert.Equal(new[] { 3.0, 4.0, 42.0 }, y);
+        }
+
+        [Fact]
+        public void LinComb_NZero_LeavesYUnchanged()
+        {
+            double[] y0 = { 99.0 };
+            double[] x1 = { 1.0 };
+            double[] x2 = { 1.0 };
+            double[] y  = { 7.0 };
+            VecOps.LinComb2(y, y0, 5.0, x1, 5.0, x2, 0);
+            Assert.Equal(7.0, y[0]);
+        }
+
+        // ---------- Vec convenience methods ----------
+        // Vec wrappers delegate to VecOps using Vec.Length (not Capacity),
+        // so the logical region is respected even when the pool gives an
+        // oversized backing array.
+
+        [Fact]
+        public void Vec_Fill_Delegates()
+        {
+            using var v = Vec.Rent(5);
+            v.Fill(7.5);
+            for (int i = 0; i < v.Length; i++) Assert.Equal(7.5, v[i]);
+        }
+
+        [Fact]
+        public void Vec_Fill_RespectsLogicalLength_NotCapacity()
+        {
+            // Rent 5 → bucket 3, Capacity 8. Fill must only touch indices 0..4.
+            using var v = Vec.Rent(5, true);
+            for (int i = 5; i < v.Capacity; i++) v.Data[i] = -99.0;
+            v.Fill(1.0);
+            for (int i = 0; i < 5; i++) Assert.Equal(1.0, v[i]);
+            for (int i = 5; i < v.Capacity; i++) Assert.Equal(-99.0, v.Data[i]);
+        }
+
+        [Fact]
+        public void Vec_Scal_Delegates()
+        {
+            using var v = Vec.Rent(3);
+            v[0] = 1.0;
+            v[1] = 2.0;
+            v[2] = 3.0;
+            v.Scal(2.5);
+            Assert.Equal(2.5, v[0]);
+            Assert.Equal(5.0, v[1]);
+            Assert.Equal(7.5, v[2]);
+        }
+
+        [Fact]
+        public void Vec_MaxZero_Delegates()
+        {
+            using var v = Vec.Rent(4);
+            v[0] = 1.0;
+            v[1] = -2.0;
+            v[2] = 3.0;
+            v[3] = -0.5;
+            v.MaxZero();
+            Assert.Equal(new[] { 1.0, 0.0, 3.0, 0.0 }, new[] { v[0], v[1], v[2], v[3] });
+        }
+
+        [Fact]
+        public void Vec_CopyTo_Delegates()
+        {
+            using var src = Vec.Rent(3);
+            using var dst = Vec.Rent(3, true);
+            src[0] = 1.0;
+            src[1] = 2.0;
+            src[2] = 3.0;
+            src.CopyTo(dst);
+            Assert.Equal(1.0, dst[0]);
+            Assert.Equal(2.0, dst[1]);
+            Assert.Equal(3.0, dst[2]);
+        }
+
+        [Fact]
+        public void Vec_Axpy_UpdatesReceiver()
+        {
+            using var x = Vec.Rent(3);
+            using var y = Vec.Rent(3);
+            x[0] = 1.0;
+            x[1] = 2.0;
+            x[2] = 3.0;
+            y[0] = 10.0;
+            y[1] = 20.0;
+            y[2] = 30.0;
+            y.Axpy(2.0, x);
+            Assert.Equal(new[] { 12.0, 24.0, 36.0 }, new[] { y[0], y[1], y[2] });
+        }
+
+        [Fact]
+        public void Vec_Axpby_UpdatesReceiver()
+        {
+            using var x = Vec.Rent(3);
+            using var y = Vec.Rent(3);
+            x[0] = 1.0;
+            x[1] = 2.0;
+            x[2] = 3.0;
+            y[0] = 10.0;
+            y[1] = 20.0;
+            y[2] = 30.0;
+            y.Axpby(2.0, x, 3.0);
+            Assert.Equal(new[] { 32.0, 64.0, 96.0 }, new[] { y[0], y[1], y[2] });
+        }
+
+        [Fact]
+        public void Vec_Swap_Delegates()
+        {
+            using var x = Vec.Rent(3);
+            using var y = Vec.Rent(3);
+            x[0] = 1.0;
+            x[1] = 2.0;
+            x[2] = 3.0;
+            y[0] = 10.0;
+            y[1] = 20.0;
+            y[2] = 30.0;
+            x.Swap(y);
+            Assert.Equal(new[] { 10.0, 20.0, 30.0 }, new[] { x[0], x[1], x[2] });
+            Assert.Equal(new[] { 1.0, 2.0, 3.0 }, new[] { y[0], y[1], y[2] });
+        }
+
+        [Fact]
+        public void Vec_Dot_Delegates()
+        {
+            using var x = Vec.Rent(3);
+            using var y = Vec.Rent(3);
+            x[0] = 1.0;
+            x[1] = 2.0;
+            x[2] = 3.0;
+            y[0] = 4.0;
+            y[1] = 5.0;
+            y[2] = 6.0;
+            Assert.Equal(32.0, x.Dot(y));
+        }
+
+        [Fact]
+        public void Vec_Nrm2_Delegates()
+        {
+            using var v = Vec.Rent(2);
+            v[0] = 3.0;
+            v[1] = 4.0;
+            Assert.Equal(5.0, v.Nrm2());
+        }
+
+        [Fact]
+        public void Vec_NrmInf_Delegates()
+        {
+            using var v = Vec.Rent(4);
+            v[0] = 1.0;
+            v[1] = -7.0;
+            v[2] = 3.0;
+            v[3] = -2.0;
+            Assert.Equal(7.0, v.NrmInf());
+        }
+
+        [Fact]
+        public void Vec_Asum_Delegates()
+        {
+            using var v = Vec.Rent(4);
+            v[0] = 1.0;
+            v[1] = -2.0;
+            v[2] = 3.0;
+            v[3] = -4.0;
+            Assert.Equal(10.0, v.Asum());
+        }
+
+        [Fact]
+        public void Vec_Sum_Delegates()
+        {
+            using var v = Vec.Rent(4);
+            v[0] = 1.0;
+            v[1] = -2.0;
+            v[2] = 3.0;
+            v[3] = -4.0;
+            Assert.Equal(-2.0, v.Sum());
+        }
+
+        [Fact]
+        public void Vec_Sum_TakesPrecedenceOverLinqExtension()
+        {
+            // System.Linq is in scope (using directive at top). vec.Sum() should
+            // call our instance method, not Enumerable.Sum<double>(IEnumerable<double>).
+            // Confirm by writing junk past Length: if LINQ won the resolution it'd
+            // iterate the enumerator (which only yields the logical region) — same
+            // result on small inputs. Stronger check: when Length=0, instance
+            // returns 0 just like LINQ, but we verify the fast-path bypasses enumerator
+            // allocation by checking semantic correctness on oversized buffers.
+            using var v = Vec.Rent(3, true);
+            v.Data[0] = 1.0;
+            v.Data[1] = 2.0;
+            v.Data[2] = 3.0;
+            v.Data[3] = 1e9; // past Length=3 (Capacity is 4)
+            double s = v.Sum();
+            Assert.Equal(6.0, s); // 1+2+3, ignoring index 3
+        }
+
+        [Fact]
+        public void Vec_Iamax_Delegates()
+        {
+            using var v = Vec.Rent(4);
+            v[0] = 1.0;
+            v[1] = -5.0;
+            v[2] = 3.0;
+            v[3] = 4.0;
+            Assert.Equal(1, v.Iamax());
+        }
+
+        [Fact]
+        public void Vec_LinComb2_Delegates()
+        {
+            using var y  = Vec.Rent(3);
+            using var y0 = Vec.Rent(3);
+            using var x1 = Vec.Rent(3);
+            using var x2 = Vec.Rent(3);
+            y0[0] = 1.0;
+            y0[1] = 2.0;
+            y0[2] = 3.0;
+            x1[0] = 10.0;
+            x1[1] = 20.0;
+            x1[2] = 30.0;
+            x2[0] = 100.0;
+            x2[1] = 200.0;
+            x2[2] = 300.0;
+
+            y.LinComb2(y0, 2.0, x1, 3.0, x2);
+            Assert.Equal(1 + 20 + 300.0, y[0]);
+            Assert.Equal(2 + 40 + 600.0, y[1]);
+            Assert.Equal(3 + 60 + 900.0, y[2]);
+        }
+
+        [Fact]
+        public void Vec_LinComb4_RkStyleUpdate()
+        {
+            // The motivating use case: Ynew = Y + h·(A51·K1 + A52·K2 + A53·K3 + A54·K4)
+            using var Y    = Vec.Rent(2);
+            using var Ynew = Vec.Rent(2);
+            using var K1   = Vec.Rent(2);
+            using var K2   = Vec.Rent(2);
+            using var K3   = Vec.Rent(2);
+            using var K4   = Vec.Rent(2);
+
+            Y[0] = 5.0;
+            Y[1] = 5.0;
+            K1[0] = K2[0] = K3[0] = K4[0] = 1.0;
+            K1[1] = K2[1] = K3[1] = K4[1] = 1.0;
+            double h = 0.1, A51 = 1.0, A52 = 2.0, A53 = 3.0, A54 = 4.0;
+
+            Ynew.LinComb4(Y, h * A51, K1, h * A52, K2, h * A53, K3, h * A54, K4);
+
+            // 5 + 0.1·10 = 6
+            Assert.Equal(6.0, Ynew[0]);
+            Assert.Equal(6.0, Ynew[1]);
+        }
+
+        [Fact]
+        public void Vec_AxpyOnOversizedPool_UsesLengthNotCapacity()
+        {
+            // Rent 5 → Capacity 8. Past-Length slots in y must not be touched.
+            using var x = Vec.Rent(5, true);
+            using var y = Vec.Rent(5, true);
+            for (int i = 5; i < y.Capacity; i++) y.Data[i] = -99.0;
+            for (int i = 0; i < 5; i++)
+            {
+                x[i] = 1.0;
+                y[i] = 1.0;
+            }
+
+            y.Axpy(2.0, x);
+
+            for (int i = 0; i < 5; i++) Assert.Equal(3.0, y[i]);
+            for (int i = 5; i < y.Capacity; i++) Assert.Equal(-99.0, y.Data[i]);
+        }
+
+        // ---------- Composition with PooledVector ----------
+
+        [Fact]
+        public void VecOps_WorkOnPooledVectorData()
+        {
+            // Confirms the intended use pattern: hot loop unwraps .Data and calls
+            // static helpers — never touches the wrapper inside the loop.
+            using var x = Vec.Rent(3, true);
+            using var y = Vec.Rent(3, true);
+            x[0] = 1.0;
+            x[1] = 2.0;
+            x[2] = 3.0;
+            y[0] = 10.0;
+            y[1] = 20.0;
+            y[2] = 30.0;
+
+            VecOps.Axpy(2.0, x.Data, y.Data, x.Length);
+
+            Assert.Equal(12.0, y[0]);
+            Assert.Equal(24.0, y[1]);
+            Assert.Equal(36.0, y[2]);
+        }
+    }
+}

--- a/MechJebLibTest/Primitives/VecTests.cs
+++ b/MechJebLibTest/Primitives/VecTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using MechJebLib.Primitives;
+using Xunit;
+
+namespace MechJebLibTest.Primitives
+{
+    public class VecTests
+    {
+        [Theory]
+        [InlineData(0, 1)] // length 0 → bucket 0 → capacity 1
+        [InlineData(1, 1)]
+        [InlineData(2, 2)]
+        [InlineData(3, 4)]
+        [InlineData(4, 4)]
+        [InlineData(5, 8)]
+        [InlineData(7, 8)]
+        [InlineData(8, 8)]
+        [InlineData(9, 16)]
+        [InlineData(16, 16)]
+        [InlineData(17, 32)]
+        [InlineData(348, 512)] // ex1 z size: nxnu*(N-1) = 12*29
+        [InlineData(1024, 1024)]
+        [InlineData(1025, 2048)]
+        public void Rent_GivesPowerOfTwoCapacity(int length, int expectedCapacity)
+        {
+            using var v = Vec.Rent(length);
+            Assert.Equal(length, v.Length);
+            Assert.Equal(expectedCapacity, v.Capacity);
+        }
+
+        [Fact]
+        public void Rent_NegativeLength_Throws() => Assert.Throws<ArgumentOutOfRangeException>(() => Vec.Rent(-1));
+
+        [Fact]
+        public void Indexer_GetSet_RoundTrips()
+        {
+            using var v = Vec.Rent(10);
+            for (int i = 0; i < v.Length; i++) v[i] = i * 1.5;
+            for (int i = 0; i < v.Length; i++) Assert.Equal(i * 1.5, v[i]);
+        }
+
+        [Fact]
+        public void Data_PointsAtBackingArray()
+        {
+            using var v = Vec.Rent(5);
+            v[2] = 7.0;
+            Assert.Equal(7.0, v.Data[2]);
+            v.Data[3] = 9.0;
+            Assert.Equal(9.0, v[3]);
+        }
+
+        [Fact]
+        public void DisposeThenRent_SameSize_ReusesBackingArray()
+        {
+            double[] firstData;
+            using (var v = Vec.Rent(10))
+            {
+                firstData = v.Data;
+            } // Dispose returns to pool
+
+            using var second = Vec.Rent(10);
+            Assert.Same(firstData, second.Data);
+        }
+
+        [Fact]
+        public void DisposeThenRent_SameBucketDifferentLengths_ReusesBackingArray()
+        {
+            // 5 and 7 both round up to bucket 3 (capacity 8).
+            double[] firstData;
+            using (var v = Vec.Rent(5))
+            {
+                firstData = v.Data;
+            }
+
+            using var second = Vec.Rent(7);
+            Assert.Same(firstData, second.Data);
+            Assert.Equal(7, second.Length);
+            Assert.Equal(8, second.Capacity);
+        }
+
+        [Fact]
+        public void DisposeThenRent_DifferentBucket_AllocatesFresh()
+        {
+            double[] firstData;
+            using (var v = Vec.Rent(5)) // bucket 3, cap 8
+            {
+                firstData = v.Data;
+            }
+
+            using var second = Vec.Rent(20); // bucket 5, cap 32
+            Assert.NotSame(firstData, second.Data);
+            Assert.Equal(32, second.Capacity);
+        }
+
+        [Fact]
+        public void Rent_WithZeroFalse_LeavesLeftoverData()
+        {
+            // Write data, dispose, rent the same bucket without zeroing — old values still there.
+            using (var v = Vec.Rent(8))
+            {
+                for (int i = 0; i < 8; i++) v[i] = 99.0;
+            }
+
+            using var reused = Vec.Rent(8);
+            for (int i = 0; i < 8; i++) Assert.Equal(99.0, reused[i]);
+        }
+
+        [Fact]
+        public void Rent_WithZeroTrue_ClearsBuffer()
+        {
+            using (var v = Vec.Rent(8))
+            {
+                for (int i = 0; i < 8; i++) v[i] = 99.0;
+            }
+
+            using var reused = Vec.Rent(8, true);
+            for (int i = 0; i < 8; i++) Assert.Equal(0.0, reused[i]);
+        }
+
+        [Fact]
+        public void Rent_WithZeroTrue_OnlyClearsLogicalRegion()
+        {
+            // Bucket 3 (cap 8) — request length 5, zero only [0..5).
+            using (var v = Vec.Rent(8))
+            {
+                for (int i = 0; i < 8; i++) v[i] = 99.0;
+            }
+
+            using var reused = Vec.Rent(5, true);
+            for (int i = 0; i < 5; i++) Assert.Equal(0.0, reused[i]);
+            // Slots 5..7 in the backing array: zero flag did NOT touch them.
+            for (int i = 5; i < 8; i++) Assert.Equal(99.0, reused.Data[i]);
+        }
+
+        [Fact]
+        public void Foreach_IteratesOnlyOverLogicalRegion()
+        {
+            using (var v = Vec.Rent(8))
+            {
+                for (int i = 0; i < 8; i++) v[i] = 99.0;
+            }
+
+            using var smaller = Vec.Rent(3, true);
+            int       count   = 0;
+            double    sum     = 0.0;
+            foreach (double x in smaller)
+            {
+                count++;
+                sum += x;
+            }
+
+            Assert.Equal(3, count);
+            Assert.Equal(0.0, sum);
+        }
+
+        [Fact]
+        public void IList_Indexer_Works()
+        {
+            using var     v      = Vec.Rent(4);
+            IList<double> asList = v;
+            asList[0] = 1.0;
+            asList[1] = 2.0;
+            Assert.Equal(1.0, asList[0]);
+            Assert.Equal(2.0, asList[1]);
+            Assert.Equal(4, asList.Count);
+            Assert.False(asList.IsReadOnly);
+        }
+
+        [Fact]
+        public void IReadOnlyList_Works()
+        {
+            using var v = Vec.Rent(3);
+            v[0] = 10.0;
+            v[1] = 20.0;
+            v[2] = 30.0;
+            IReadOnlyList<double> ro = v;
+            Assert.Equal(3, ro.Count);
+            Assert.Equal(20.0, ro[1]);
+        }
+
+        [Fact]
+        public void IList_MutationOps_Throw()
+        {
+            using var     v      = Vec.Rent(3);
+            IList<double> asList = v;
+            Assert.Throws<NotSupportedException>(() => asList.Add(1.0));
+            Assert.Throws<NotSupportedException>(() => asList.Insert(0, 1.0));
+            Assert.Throws<NotSupportedException>(() => asList.RemoveAt(0));
+            Assert.Throws<NotSupportedException>(() => asList.Remove(1.0));
+            Assert.Throws<NotSupportedException>(() => asList.Clear());
+        }
+
+        [Fact]
+        public void IList_IndexOf_Contains_RespectLogicalLength()
+        {
+            using (var seed = Vec.Rent(8))
+            {
+                for (int i = 0; i < 8; i++) seed[i] = 99.0; // pollute backing array
+            }
+
+            using var v = Vec.Rent(3, true);
+            v[0] = 1.0;
+            v[1] = 2.0;
+            v[2] = 3.0;
+            IList<double> asList = v;
+            Assert.Equal(1, asList.IndexOf(2.0));
+            Assert.Equal(-1, asList.IndexOf(99.0)); // 99.0 lives at index 5..7 — past Length
+            Assert.True(asList.Contains(3.0));
+            Assert.False(asList.Contains(99.0));
+        }
+
+        [Fact]
+        public void IList_CopyTo_CopiesLogicalRegion()
+        {
+            using var v = Vec.Rent(4, true);
+            v[0] = 1.0;
+            v[1] = 2.0;
+            v[2] = 3.0;
+            v[3] = 4.0;
+
+            double[] dest = new double[6];
+            ((ICollection<double>)v).CopyTo(dest, 1);
+
+            Assert.Equal(0.0, dest[0]);
+            Assert.Equal(1.0, dest[1]);
+            Assert.Equal(2.0, dest[2]);
+            Assert.Equal(3.0, dest[3]);
+            Assert.Equal(4.0, dest[4]);
+            Assert.Equal(0.0, dest[5]);
+        }
+
+        [Fact]
+        public void RepeatedRentDispose_AllocatesOnceForGivenBucket()
+        {
+            // First rent populates the pool. Subsequent rounds reuse the same backing.
+            double[] expected;
+            using (var first = Vec.Rent(10))
+            {
+                expected = first.Data;
+            }
+
+            for (int i = 0; i < 1000; i++)
+            {
+                using var v = Vec.Rent(10);
+                Assert.Same(expected, v.Data);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This should be the replacement for Vn.

Implements a 2^n length objectpool and a bunch of blas level1 APIs and some helpers for writing RK methods.

Ports over the use of Vn in the AutoDiff module to Vec.

Vec does not zero-initialize by default.