### PR TITLE
Working on cleaning up Shepperd's method and tests

### DIFF
--- a/MechJebLib/TwoBody/Shepperd.cs
+++ b/MechJebLib/TwoBody/Shepperd.cs
@@ -6,14 +6,17 @@
 using System;
 using MechJebLib.Primitives;
 
+// ReSharper disable CompareOfFloatsByEqualityOperator
 namespace MechJebLib.TwoBody
 {
+    /// <summary>
+    ///     Shepperd SW. Universal Keplerian state transition matrix. Celestial Mechanics. 1985 Feb;35(2):129–44. doi:10.1007/BF01227666
+    ///     Shepperd SW. Naturally occurring continued fractions in the variation of Kepler’s equation. Celestial Mechanics. 1987 Mar;42(1–4):91–106. doi:10.1007/BF01232950
+    /// </summary>
     public static class Shepperd
     {
-        // NOTE: this isn't a faithful reproduction of Shepperd's method, it works
-        // better than Shepperd's method and uses different constants in the continued
-        // faction, although it otherwise has almost the same "shape" of algorithm.
-        // I don't yet understand exactly why or how it works.
+        // More robust version of Shepperd's method that solves for U3 directly to just propagate state, with a
+        // fallback to bisection.
         public static (V3 rf, V3 vf) Solve(double mu, double tau, V3 ri, V3 vi)
         {
             double tolerance = 1.0e-12;
@@ -44,18 +47,164 @@ namespace MechJebLib.TwoBody
 
             double uold  = double.MinValue;
             double dtold = double.MinValue;
+            double u1    = 0.0;
+            double u2    = 0.0;
+            double r1    = 0.0;
+
+            for (int i = 1; i < imax; i++)
+            {
+                double q = beta * u * u;
+                q /= 1.0 + q;
+
+                double n   = 0;
+                double r   = 1;
+                double l   = 1;
+                double s   = 1;
+                double d   = 3;
+                double gcf = 1;
+                double k   = -5;
+
+                double gold = 0;
+
+                // this solves for U3 directly by using G(3, 0, 3/2, q)
+                while (gcf != gold)
+                {
+                    k = -k;
+                    l += 2;
+                    d += 4 * l;
+                    n += (1 + k) * l;
+                    r = d / (d - n * r * q);
+                    s = (r - 1) * s;
+                    gold = gcf;
+                    gcf = gold + s;
+                }
+
+                double h0 = 1 - 2 * q;
+                double h1 = 2 * u * (1 - q);
+                double u0 = 2 * h0 * h0 - 1;
+                u1 = 2 * h0 * h1;
+                u2 = 2 * h1 * h1;
+                double u3 = 2 * h1 * u2 * gcf / 3;
+
+                if (orbits != 0)
+                {
+                    u3 += 2 * Math.PI * orbits / (beta * Math.Sqrt(beta));
+                }
+
+                r1 = r0 * u0 + n0 * u1 + mu * u2;
+                double dt    = r0 * u1 + n0 * u2 + mu * u3;
+                double slope = 4 * r1 / (1 + beta * u * u);
+
+                double terror = tdesired - dt;
+
+                if (Math.Abs(terror) < threshold)
+                    break;
+
+                if (i > 1 && u == uold)
+                    break;
+
+                if (i > 1 && dt == dtold)
+                    break;
+
+                uold = u;
+                dtold = dt;
+
+                double ustep = terror / slope;
+                if (ustep > 0)
+                {
+                    umin = u;
+                    u += ustep;
+
+                    if (u > umax)
+                        u = (umin + umax) / 2;
+                }
+                else
+                {
+                    umax = u;
+                    u += ustep;
+
+                    if (u < umin)
+                        u = (umin + umax) / 2;
+                }
+            }
+
+            double f  = 1.0 - mu / r0 * u2;
+            double gg = 1.0 - mu / r1 * u2;
+            double g  = r0 * u1 + n0 * u2;
+            double ff = -mu * u1 / (r0 * r1);
+
+            V3 rf = f * ri + g * vi;
+            V3 vf = ff * ri + gg * vi;
+
+            return (rf, vf);
+        }
+
+        // The STM is a 6x6 matrix which we return decomposed into 4 3x3 matrices
+        //
+        //  [ 𝛿r ] = [ stm00 stm01 ] [ r ]
+        //  [ 𝛿v ] = [ stm10 stm11 ] [ v ]
+        //
+        // More robust version of Shepperd's method that solves for U3 directly to just propagate state, with a
+        // fallback to bisection.  Then it solves for U5 with one additional continued fraction to generate U5
+        // and the STM matrix.
+        //
+        public static ( V3 rf, V3 vf, M3 stm00, M3 stm01, M3 stm10, M3 stm11) Solve2(double mu, double tau, V3 ri, V3 vi)
+
+        {
+            double tolerance = 1.0e-12;
+            double u         = 0;
+            int    imax      = 50;
+            double umax;
+            double umin;
+            double orbits    = 0;
+            double tdesired  = tau;
+            double threshold = tolerance * Math.Abs(tdesired);
+            double r0        = ri.magnitude;
+            double n0        = V3.Dot(ri, vi);
+
+            double beta = 2.0 * (mu / r0) - vi.sqrMagnitude;
+
+            if (beta != 0.0)
+            {
+                umax = 1.0 / Math.Sqrt(Math.Abs(beta));
+            }
+            else
+            {
+                umax = 1.0e24;
+            }
+
+            umin = -umax;
+
+            double delu = 0.0;
+
+            if (beta > 0.0)
+            {
+                orbits = beta * tau - 2 * n0;
+                orbits = 1 + orbits * Math.Sqrt(beta) / (Math.PI * mu);
+                orbits = Math.Floor(orbits / 2);
+            }
+
+            if (beta > 0.0)
+            {
+                double beta3 = beta * beta * beta;
+                double p     = 2.0 * Math.PI * mu * 1 / Math.Sqrt(beta3);
+                double norb  = Math.Truncate(1.0 / p * (tau + 0.5 * p - 2 * n0 / beta));
+                delu = 2.0 * norb * Math.PI * 1 / Math.Sqrt(beta3 * beta * beta);
+            }
+
+            double uold  = double.MinValue;
+            double dtold = double.MinValue;
             double u0;
             double u1 = 0.0;
             double u2 = 0.0;
-            double u3;
             double r1 = 0.0;
+            double q  = 0.0;
 
-            double q, n, r, l, s, d, gcf, k, gold, dt, slope, terror, ustep, h0, h1;
+            double n, r, l, s, d, gcf, k, gold, h0, h1, u3;
 
             for (int i = 1; i < imax; i++)
             {
                 q = beta * u * u;
-
                 q /= 1.0 + q;
 
                 n = 0;
@@ -68,6 +217,7 @@ namespace MechJebLib.TwoBody
 
                 gold = 0;
 
+                // this solves for U3 directly by using G(3, 0, 3/2, q)
                 while (gcf != gold)
                 {
                     k = -k;
@@ -93,10 +243,10 @@ namespace MechJebLib.TwoBody
                 }
 
                 r1 = r0 * u0 + n0 * u1 + mu * u2;
-                dt = r0 * u1 + n0 * u2 + mu * u3;
-                slope = 4 * r1 / (1 + beta * u * u);
+                double dt    = r0 * u1 + n0 * u2 + mu * u3;
+                double slope = 4.0 * r1 * (1.0 - q);
 
-                terror = tdesired - dt;
+                double terror = tdesired - dt;
 
                 if (Math.Abs(terror) < threshold)
                     break;
@@ -110,17 +260,14 @@ namespace MechJebLib.TwoBody
                 uold = u;
                 dtold = dt;
 
-                ustep = terror / slope;
-
+                double ustep = terror / slope;
                 if (ustep > 0)
                 {
                     umin = u;
                     u += ustep;
 
                     if (u > umax)
-                    {
                         u = (umin + umax) / 2;
-                    }
                 }
                 else
                 {
@@ -128,166 +275,7 @@ namespace MechJebLib.TwoBody
                     u += ustep;
 
                     if (u < umin)
-                    {
                         u = (umin + umax) / 2;
-                    }
-                }
-
-                if (i == imax)
-                {
-                    // FIXME: throw
-                }
-            }
-
-            double f  = 1.0 - mu / r0 * u2;
-            double gg = 1.0 - mu / r1 * u2;
-            double g  = r0 * u1 + n0 * u2;
-            double ff = -mu * u1 / (r0 * r1);
-
-            var rf = new V3();
-            var vf = new V3();
-
-            for (int i = 0; i < 3; i++)
-            {
-                rf[i] = f * ri[i] + g * vi[i];
-                vf[i] = ff * ri[i] + gg * vi[i];
-            }
-
-            return (rf, vf);
-        }
-
-        // The STM is a 6x6 matrix which we return decomposed into 4 3x3 matricies
-        //
-        //  [ 𝛿r ] = [ stm00 stm01 ] [ r ]
-        //  [ 𝛿v ] = [ stm10 stm11 ] [ v ]
-        //
-        // NOTE: this is a fairly faithful reproduction of Shepperd's method with a little added bisection method in
-        // case Newton's Method gets into trouble.
-        //
-        public static ( V3 rf, V3 vf, M3 stm00, M3 stm01, M3 stm10, M3 stm11) Solve2(double mu, double tau, V3 ri, V3 vi)
-
-        {
-            double tol  = 1.0e-12;
-            double n0   = V3.Dot(ri, vi);
-            double r0   = ri.magnitude;
-            double beta = 2.0 * (mu / r0) - vi.sqrMagnitude;
-            double u    = 0;
-            double umax = double.MaxValue;
-            double umin = double.MinValue;
-
-            if (beta != 0.0)
-            {
-                umax = 1.0 / Math.Sqrt(Math.Abs(beta));
-            }
-            else
-            {
-                umax = 1.0e24;
-            }
-
-            umin = -umax;
-
-            double delu = 0.0;
-
-            if (beta > 0.0)
-            {
-                double beta3 = beta * beta * beta;
-                double p     = 2.0 * Math.PI * mu * 1 / Math.Sqrt(beta3);
-                double norb  = Math.Truncate(1.0 / p * (tau + 0.5 * p - 2 * n0 / beta));
-                delu = 2.0 * norb * Math.PI * 1 / Math.Sqrt(beta3 * beta * beta);
-            }
-
-            double tsav = 1.0e99;
-
-            int niter = 0;
-
-            // kepler iteration loop
-
-            double q, u0, u1, u2, u3, uu, usav, dtdu, du, n, l, d, k, a, b, gcf, gsav, r1, t, terr;
-
-            while (true)
-            {
-                niter++;
-                q = beta * u * u;
-                q /= 1.0 + q;
-
-                u0 = 1.0 - 2 * q;
-                u1 = 2.0 * u * (1 - q);
-
-                // continued fraction iteration
-
-                n = 0;
-                l = 3;
-                d = 15;
-                k = -9;
-                a = 1;
-                b = 1;
-                gcf = 1;
-
-                while (true)
-                {
-                    gsav = gcf;
-
-                    k = -k;
-                    l += 2;
-                    d += 4 * l;
-                    n += (1 + k) * l;
-                    a = d / (d - n * a * q);
-                    b = (a - 1) * b;
-                    gcf += b;
-
-                    if (Math.Abs(gcf - gsav) < tol)
-                        break;
-                }
-
-                uu = 16.0 / 15.0 * u1 * u1 * u1 * u1 * u1 * gcf + delu;
-                u2 = 2.0 * u1 * u1;
-                u1 = 2.0 * u0 * u1;
-                u0 = 2.0 * u0 * u0 - 1.0;
-                u3 = beta * uu + u1 * u2 / 3.0;
-                r1 = r0 * u0 + n0 * u1 + mu * u2;
-                t = r0 * u1 + n0 * u2 + mu * u3;
-                dtdu = 4.0 * r1 * (1.0 - q);
-
-                // check for time convergence
-                if (Math.Abs(t - tsav) < tol)
-                    break;
-
-
-                usav = u;
-                tsav = t;
-                terr = tau - t;
-
-                if (Math.Abs(terr) < Math.Abs(tau) * tol)
-                    break;
-
-                du = terr / dtdu;
-                if (du < 0.0)
-                {
-                    umax = u;
-                    u += du;
-
-                    if (u < umin)
-                        u = 0.5 * (umin + umax);
-                }
-                else
-                {
-                    umin = u;
-                    u += du;
-
-                    if (u > umax)
-                        u = 0.5 * (umin + umax);
-                }
-
-                // check for independent variable convergence
-
-                if (Math.Abs(u - usav) < tol)
-                    break;
-
-
-                // check for more than 20 iterations
-                if (niter > 20)
-                {
-                    // FIXME: throw
                 }
             }
 
@@ -299,9 +287,38 @@ namespace MechJebLib.TwoBody
             double ff = -mu * u1 / (r0 * r1);
             double gg = 1.0 + ggm;
 
-            // compute final state vector
             V3 rf = f * ri + g * vi;
             V3 vf = ff * ri + gg * vi;
+
+            n = 0;
+            r = 1;
+            l = 3;
+            s = 1;
+            d = 15;
+            gcf = 1;
+            k = -9;
+
+            gold = 0;
+
+            // this solves for U5 directly by using G(5, 0, 5/2, q)
+            while (gcf != gold)
+            {
+                k = -k;
+                l += 2;
+                d += 4 * l;
+                n += (1 + k) * l;
+                r = d / (d - n * r * q);
+                s = (r - 1) * s;
+                gold = gcf;
+                gcf = gold + s;
+            }
+
+            h0 = 1 - 2 * q;
+            h1 = 2 * u * (1 - q);
+            double uu = 16.0 / 15.0 * h1 * h1 * h1 * h1 * h1 * gcf + delu;
+            u0 = 2 * h0 * h0 - 1;
+            u1 = 2 * h0 * h1;
+            u2 = 2 * h1 * h1;
 
             double w  = g * u2 + 3 * mu * uu;
             double a0 = mu / (r0 * r0 * r0);
@@ -318,39 +335,6 @@ namespace MechJebLib.TwoBody
                 fm * u2,
                 g * u2 - w
             );
-
-            /*
-            for (int i = 0; i < 3; i++)
-            {
-                double t001 = rf[i] * m[1, 0] + vf[i] * m[2, 0];
-                double t002 = rf[i] * m[1, 1] + vf[i] * m[2, 1];
-
-                double t011 = rf[i] * m[1, 1] + vf[i] * m[2, 1];
-                double t012 = rf[i] * m[1, 2] + vf[i] * m[2, 2];
-
-                double t101 = rf[i] * m[0, 0] + vf[i] * m[1, 0];
-                double t102 = rf[i] * m[0, 1] + vf[i] * m[1, 1];
-
-                double t111 = rf[i] * m[0, 1] + vf[i] * m[1, 1];
-                double t112 = rf[i] * m[0, 2] + vf[i] * m[1, 2];
-
-                for (int j = 0; j < 3; j++)
-                {
-                    stm00[i, j] = t001 * ri[j] + t002 * vi[j];
-                    stm01[i, j] = t011 * ri[j] + t012 * vi[j];
-                    stm10[i, j] = -t101 * ri[j] - t102 * vi[j];
-                    stm11[i, j] = -t111 * ri[j] - t112 * vi[j];
-                }
-            }
-
-            for (int i = 0; i < 3; i++)
-            {
-                stm00[i, i] += f;
-                stm01[i, i] += g;
-                stm10[i, i] += ff;
-                stm11[i, i] += gg;
-            }
-            */
 
             V3 t00 = rf * m[1, 0] + vf * m[2, 0];
             V3 t01 = rf * m[1, 1] + vf * m[2, 1];

--- a/MechJebLibTest/TwoBodyTests/FarnocchiaTests.cs
+++ b/MechJebLibTest/TwoBodyTests/FarnocchiaTests.cs
@@ -1,10 +1,11 @@
-﻿/*
+/*
  * Copyright Lamont Granquist, Sebastien Gaggini and the MechJeb contributors
  * SPDX-License-Identifier: MIT-0 OR LGPL-2.1+ OR CC0-1.0
  */
 
 using System;
 using System.Collections.Generic;
+using MechJebLib.Functions;
 using MechJebLib.ODE;
 using MechJebLib.Primitives;
 using MechJebLib.TwoBody;
@@ -12,6 +13,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static MechJebLib.Utils.Statics;
 using static System.Math;
+using Random = System.Random;
 
 namespace MechJebLibTest.TwoBodyTests
 {
@@ -24,30 +26,32 @@ namespace MechJebLibTest.TwoBodyTests
             _testOutputHelper = testOutputHelper;
         }
 
-        [Fact]
-        private void RandomForwardAndBack()
+        public static IEnumerable<object[]> Seeds()
         {
-            const int NTRIALS = 5000;
+            for (int i = 0; i <= 500; i++)
+                yield return new object[] { i };
+        }
 
-            var random = new Random();
+        [Theory]
+        [MemberData(nameof(Seeds))]
+        public void RandomForwardAndBack(int seed)
+        {
+            var rng = new Random(seed);
 
-            for (int i = 0; i < NTRIALS; i++)
+            var    r0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            var    v0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            double dt = 40 * rng.NextDouble() - 20;
+
+            (V3 rf, V3 vf) = Farnocchia.Solve(1.0, dt, r0, v0);
+            (V3 rp, V3 vp) = Farnocchia.Solve(1.0, -dt, rf, vf);
+
+            if ((rp - r0).magnitude / r0.magnitude > 1e-8 || (vp - v0).magnitude / v0.magnitude > 1e-8)
             {
-                var    r0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                var    v0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                double dt = 40 * random.NextDouble() - 20;
-
-                (V3 rf, V3 vf) = Farnocchia.Solve(1.0, dt, r0, v0);
-                (V3 rp, V3 vp) = Farnocchia.Solve(1.0, -dt, rf, vf);
-
-                if ((rp - r0).magnitude / r0.magnitude > 1e-8 || (vp - v0).magnitude / v0.magnitude > 1e-8)
-                {
-                    _testOutputHelper.WriteLine(r0 + " " + v0);
-                }
-
-                rp.ShouldEqual(r0, 1e-8);
-                vp.ShouldEqual(vp, 1e-8);
+                _testOutputHelper.WriteLine(r0 + " " + v0);
             }
+
+            rp.ShouldEqual(r0, 1e-8);
+            vp.ShouldEqual(v0, 1e-8);
         }
 
         private readonly VacuumKernel _ode = new VacuumKernel();
@@ -73,60 +77,56 @@ namespace MechJebLibTest.TwoBodyTests
             }
         }
 
-        [Fact]
-        private void RandomComparedToDormandPrince()
+        [Theory]
+        [MemberData(nameof(Seeds))]
+        public void RandomComparedToDP5(int seed)
         {
-            var solver = new DP5();
+            var solver = new DP5 { Rtol = 1e-6, Hmin = EPS, ThrowOnMaxIter = true, Maxiter = 2000 };
+            var rng    = new Random(seed);
 
-            solver.Rtol = 1e-9;
-            solver.Hmin = 1e-9;
-            solver.ThrowOnMaxIter = true;
-            solver.Maxiter = 2000;
+            var    r0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            var    v0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            double dt = 10 * rng.NextDouble() - 5;
 
-            const int NTRIALS = 50;
+            (double _, double ecc, double _, double _, double _, double _, double l) =
+                Astro.KeplerianFromStateVectors(1.0, r0, v0);
 
-            var random = new Random();
+            // RK methods have issue with small SLRs
+            if (l < 0.1)
+                return;
 
-            for (int i = 0; i < NTRIALS; i++)
+            (V3 rf, V3 vf) = Farnocchia.Solve(1.0, dt, r0, v0);
+
+            V3 rf2, vf2;
+
+            using (var y0 = Vec.Rent(6))
+            using (var yf = Vec.Rent(6))
             {
-                var    r0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                var    v0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                double dt = 10 * random.NextDouble() - 5;
+                y0.Set(0, r0);
+                y0.Set(3, v0);
 
-                (V3 rf, V3 vf) = Farnocchia.Solve(1.0, dt, r0, v0);
-
-                V3 rf2, vf2;
-
-                using (var y0 = Vec.Rent(6))
-                using (var yf = Vec.Rent(6))
+                try
                 {
-                    y0.Set(0, r0);
-                    y0.Set(3, v0);
-
-                    try
-                    {
-                        solver.Solve(_ode.dydt, y0, yf, 0, dt);
-                    }
-                    catch (ArgumentException)
-                    {
-                        // the ODE integrator can throw iterations exceeded for certain initial
-                        // conditions it inherently has issues with.
-                        continue;
-                    }
-
-                    rf2 = yf.Get(0);
-                    vf2 = yf.Get(3);
+                    solver.Solve(_ode.dydt, y0, yf, 0, dt);
+                }
+                catch (ArgumentException) // sometimes RK method still throws
+                {
+                    return;
                 }
 
-                if (!NearlyEqual(rf, rf2, 1e-5) || !NearlyEqual(vf, vf2, 1e-5))
-                {
-                    _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + "\nrf:" + rf + " vf:" + vf + "\nrf2:" + rf2 + " vf2:" +
-                        vf2 + "\n");
-                }
-
-                rf.ShouldEqual(rf2, 1e-5);
-                vf.ShouldEqual(vf2, 1e-5);
+                rf2 = yf.Get(0);
+                vf2 = yf.Get(3);
             }
+
+            if (!NearlyEqual(rf, rf2, 1e-5) || !NearlyEqual(vf, vf2, 1e-5))
+            {
+                _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + " ecc:" + ecc + "\nrf:" + rf + " vf:" + vf + "\nrf2:" +
+                    rf2 + " vf2:" +
+                    vf2 + "\n");
+            }
+
+            rf.ShouldEqual(rf2, 1e-5);
+            vf.ShouldEqual(vf2, 1e-5);
         }
     }
 }

--- a/MechJebLibTest/TwoBodyTests/ShepperdTests.cs
+++ b/MechJebLibTest/TwoBodyTests/ShepperdTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Lamont Granquist, Sebastien Gaggini and the MechJeb contributors
  * SPDX-License-Identifier: MIT-0 OR LGPL-2.1+ OR CC0-1.0
  */
@@ -13,6 +13,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static MechJebLib.Utils.Statics;
 using static System.Math;
+using Random = System.Random;
 
 namespace MechJebLibTest.TwoBodyTests
 {
@@ -25,74 +26,53 @@ namespace MechJebLibTest.TwoBodyTests
             _testOutputHelper = testOutputHelper;
         }
 
-        [Fact]
-        private void RandomForwardAndBack()
+        public static IEnumerable<object[]> Seeds()
         {
-            const int NTRIALS = 5000;
-
-            var random = new Random();
-
-            for (int i = 0; i < NTRIALS; i++)
-            {
-                var    r0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                var    v0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                double dt = 40 * random.NextDouble() - 20;
-
-                // XXX: this probably needs a test to reject random orbits that are near-parabolic.  See the
-                // Farnocchia paper.
-
-                (V3 rf, V3 vf) = Shepperd.Solve(1.0, dt, r0, v0);
-                (V3 rp, V3 vp) = Shepperd.Solve(1.0, -dt, rf, vf);
-
-                if (!NearlyEqual(rp, r0, 1e-8) || !NearlyEqual(vp, v0, 1e-8))
-                {
-                    _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + "\nrf:" + rf + " vf:" + vf + "\nrf2:" + rp + " vf2:" +
-                        vp + "\n");
-                }
-
-                if ((rp - r0).magnitude / r0.magnitude > 1e-8 || (vp - v0).magnitude / v0.magnitude > 1e-8)
-                {
-                    _testOutputHelper.WriteLine(r0 + " " + v0);
-                }
-
-                rp.ShouldEqual(r0, 1e-8);
-                vp.ShouldEqual(vp, 1e-8);
-            }
+            for (int i = 0; i <= 500; i++)
+                yield return new object[] { i };
         }
 
-        [Fact]
-        private void RandomForwardAndBack2()
+        [Theory]
+        [MemberData(nameof(Seeds))]
+        public void RandomForwardAndBack(int seed)
         {
-            const int NTRIALS = 5;
+            var rng = new Random(seed);
 
-            var random = new Random();
+            var    r0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            var    v0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            double dt = 40 * rng.NextDouble() - 20;
 
-            for (int i = 0; i < NTRIALS; i++)
+            (V3 rf, V3 vf) = Shepperd.Solve(1.0, dt, r0, v0);
+            (V3 rp, V3 vp) = Shepperd.Solve(1.0, -dt, rf, vf);
+
+            if (!NearlyEqual(rp, r0, 1e-8) || !NearlyEqual(vp, v0, 1e-8))
             {
-                var    r0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                var    v0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                double dt = 40 * random.NextDouble() - 20;
-
-                // XXX: this probably needs a test to reject random orbits that are near-parabolic.  See the
-                // Farnocchia paper.
-
-                (V3 rf, V3 vf, _, _, _, _) = Shepperd.Solve2(1.0, dt, r0, v0);
-                (V3 rp, V3 vp, _, _, _, _) = Shepperd.Solve2(1.0, -dt, rf, vf);
-
-                if (!NearlyEqual(rp, r0, 1e-8) || !NearlyEqual(vp, v0, 1e-8))
-                {
-                    _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + "\nrf:" + rf + " vf:" + vf + "\nrf2:" + rp + " vf2:" +
-                        vp + "\n");
-                }
-
-                if ((rp - r0).magnitude / r0.magnitude > 1e-8 || (vp - v0).magnitude / v0.magnitude > 1e-8)
-                {
-                    _testOutputHelper.WriteLine(r0 + " " + v0);
-                }
-
-                rp.ShouldEqual(r0, 1e-8);
-                vp.ShouldEqual(vp, 1e-8);
+                _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + "\nrf:" + rf + " vf:" + vf + "\nrf2:" + rp + " vf2:" +
+                    vp + "\n");
             }
+
+            rp.ShouldEqual(r0, 1e-8);
+            vp.ShouldEqual(v0, 1e-8);
+        }
+
+        [Theory]
+        [MemberData(nameof(Seeds))]
+        public void RandomForwardAndBack2(int seed)
+        {
+            var rng = new Random(seed);
+
+            var    r0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            var    v0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            double dt = 40 * rng.NextDouble() - 20;
+
+            (V3 rf, V3 vf, M3 _, M3 _, M3 _, M3 _) = Shepperd.Solve2(1.0, dt, r0, v0);
+            (V3 rp, V3 vp, M3 _, M3 _, M3 _, M3 _) = Shepperd.Solve2(1.0, -dt, rf, vf);
+
+            if (!NearlyEqual(rp, r0, 1e-8) || !NearlyEqual(vp, v0, 1e-8))
+                _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + "\nrf:" + rf + " vf:" + vf + "\nrp:" + rp + " vp:" + vp);
+
+            rp.ShouldEqual(r0, 1e-8);
+            vp.ShouldEqual(v0, 1e-8);
         }
 
         private readonly VacuumKernel _ode = new VacuumKernel();
@@ -118,144 +98,113 @@ namespace MechJebLibTest.TwoBodyTests
             }
         }
 
-        [Fact]
-        private void RandomComparedToDP5()
+        [Theory]
+        [MemberData(nameof(Seeds))]
+        public void RandomComparedToDP5(int seed)
         {
             var solver = new DP5 { Rtol = 1e-6, Hmin = EPS, ThrowOnMaxIter = true, Maxiter = 2000 };
+            var rng    = new Random(seed);
 
-            const int NTRIALS = 500;
+            var    r0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            var    v0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            double dt = 10 * rng.NextDouble() - 5;
 
-            var random = new Random();
+            (double _, double ecc, double _, double _, double _, double _, double l) =
+                Astro.KeplerianFromStateVectors(1.0, r0, v0);
 
-            int count = 0;
+            // RK methods have issue with small SLRs
+            if (l < 0.1)
+                return;
 
-            for (int i = 0; i < NTRIALS; i++)
+            (V3 rf, V3 vf) = Shepperd.Solve(1.0, dt, r0, v0);
+
+            V3 rf2, vf2;
+
+            using (var y0 = Vec.Rent(6))
+            using (var yf = Vec.Rent(6))
             {
-                var    r0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                var    v0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                double dt = 10 * random.NextDouble() - 5;
+                y0.Set(0, r0);
+                y0.Set(3, v0);
 
-                (double _, double ecc, double _, double _, double _, double _, double l) =
-                    Astro.KeplerianFromStateVectors(1.0, r0, v0);
-
-                // near-parabolic orbits are difficult for Shepperd, see the Farnocchia paper.
-                if (ecc < 1.01 && ecc > 0.99)
-                    continue;
-
-                // RK methods have issue with small SLRs
-                if (l < 0.1)
-                    continue;
-
-                (V3 rf, V3 vf) = Shepperd.Solve(1.0, dt, r0, v0);
-
-                V3 rf2, vf2;
-
-                using (var y0 = Vec.Rent(6))
-                using (var yf = Vec.Rent(6))
+                try
                 {
-                    y0.Set(0, r0);
-                    y0.Set(3, v0);
-
-                    try
-                    {
-                        solver.Solve(_ode.dydt, y0, yf, 0, dt);
-                    }
-                    catch (ArgumentException) // sometimes RK method still throws
-                    {
-                        continue;
-                    }
-
-                    rf2 = yf.Get(0);
-                    vf2 = yf.Get(3);
+                    solver.Solve(_ode.dydt, y0, yf, 0, dt);
+                }
+                catch (ArgumentException) // sometimes RK method still throws
+                {
+                    return;
                 }
 
-                count++;
-
-                if (!NearlyEqual(rf, rf2, 1e-5) || !NearlyEqual(vf, vf2, 1e-5))
-                {
-                    _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + " ecc:" + ecc + "\nrf:" + rf + " vf:" + vf + "\nrf2:" +
-                        rf2 + " vf2:" +
-                        vf2 + "\n");
-                }
-
-                rf.ShouldEqual(rf2, 1e-5);
-                vf.ShouldEqual(vf2, 1e-5);
+                rf2 = yf.Get(0);
+                vf2 = yf.Get(3);
             }
 
-            _testOutputHelper.WriteLine($"Successful: {count}");
-            Assert.True(count > NTRIALS * 0.90);
+            if (!NearlyEqual(rf, rf2, 1e-5) || !NearlyEqual(vf, vf2, 1e-5))
+            {
+                _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + " ecc:" + ecc + "\nrf:" + rf + " vf:" + vf + "\nrf2:" +
+                    rf2 + " vf2:" +
+                    vf2 + "\n");
+            }
+
+            rf.ShouldEqual(rf2, 1e-5);
+            vf.ShouldEqual(vf2, 1e-5);
         }
 
-        [Fact]
-        private void RandomComparedToTsit5()
+        [Theory]
+        [MemberData(nameof(Seeds))]
+        public void RandomComparedToTsit5(int seed)
         {
             var solver = new Tsit5 { Rtol = 1e-6, Hmin = EPS, ThrowOnMaxIter = true, Maxiter = 2000 };
+            var rng    = new Random(seed);
 
-            const int NTRIALS = 500;
+            var    r0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            var    v0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            double dt = 10 * rng.NextDouble() - 5;
 
-            var random = new Random();
+            (double _, double ecc, double _, double _, double _, double _, double l) =
+                Astro.KeplerianFromStateVectors(1.0, r0, v0);
 
-            int count = 0;
+            // RK methods have issue with small SLRs
+            if (l < 0.1)
+                return;
 
-            for (int i = 0; i < NTRIALS; i++)
+            (V3 rf, V3 vf) = Shepperd.Solve(1.0, dt, r0, v0);
+
+            V3 rf2, vf2;
+
+            using (var y0 = Vec.Rent(6))
+            using (var yf = Vec.Rent(6))
             {
-                var    r0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                var    v0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                double dt = 10 * random.NextDouble() - 5;
+                y0.Set(0, r0);
+                y0.Set(3, v0);
 
-                (double _, double ecc, double _, double _, double _, double _, double l) =
-                    Astro.KeplerianFromStateVectors(1.0, r0, v0);
-
-                // near-parabolic orbits are difficult for Shepperd, see the Farnocchia paper.
-                if (ecc < 1.01 && ecc > 0.99)
-                    continue;
-
-                // RK methods have issue with small SLRs
-                if (l < 0.1)
-                    continue;
-
-                (V3 rf, V3 vf) = Shepperd.Solve(1.0, dt, r0, v0);
-
-                V3 rf2, vf2;
-
-                using (var y0 = Vec.Rent(6))
-                using (var yf = Vec.Rent(6))
+                try
                 {
-                    y0.Set(0, r0);
-                    y0.Set(3, v0);
-
-                    try
-                    {
-                        solver.Solve(_ode.dydt, y0, yf, 0, dt);
-                    }
-                    catch (ArgumentException) // sometimes RK method still throws
-                    {
-                        continue;
-                    }
-
-                    rf2 = yf.Get(0);
-                    vf2 = yf.Get(3);
+                    solver.Solve(_ode.dydt, y0, yf, 0, dt);
+                }
+                catch (ArgumentException) // sometimes RK method still throws
+                {
+                    return;
                 }
 
-                count++;
-
-                if (!NearlyEqual(rf, rf2, 1e-5) || !NearlyEqual(vf, vf2, 1e-5))
-                {
-                    _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + " ecc:" + ecc + "\nrf:" + rf + " vf:" + vf + "\nrf2:" +
-                        rf2 + " vf2:" +
-                        vf2 + "\n");
-                }
-
-                rf.ShouldEqual(rf2, 1e-5);
-                vf.ShouldEqual(vf2, 1e-5);
+                rf2 = yf.Get(0);
+                vf2 = yf.Get(3);
             }
 
-            _testOutputHelper.WriteLine($"Successful: {count}");
-            Assert.True(count > NTRIALS * 0.90);
+            if (!NearlyEqual(rf, rf2, 1e-5) || !NearlyEqual(vf, vf2, 1e-5))
+            {
+                _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + " ecc:" + ecc + "\nrf:" + rf + " vf:" + vf + "\nrf2:" +
+                    rf2 + " vf2:" +
+                    vf2 + "\n");
+            }
+
+            rf.ShouldEqual(rf2, 1e-5);
+            vf.ShouldEqual(vf2, 1e-5);
         }
 
-        [Fact]
-        private void RandomComparedToDP8()
+        [Theory]
+        [MemberData(nameof(Seeds))]
+        public void RandomComparedToDP8(int seed)
         {
             var solver = new DP8
             {
@@ -265,71 +214,51 @@ namespace MechJebLibTest.TwoBodyTests
                 ThrowOnMaxIter = true,
                 Maxiter = 2000000
             };
+            var rng = new Random(seed);
 
-            const int NTRIALS = 500;
+            var    r0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            var    v0 = new V3(4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2, 4 * rng.NextDouble() - 2);
+            double dt = 10 * rng.NextDouble() - 5;
 
-            var random = new Random();
+            (double _, double ecc, double _, double _, double _, double _, double l) =
+                Astro.KeplerianFromStateVectors(1.0, r0, v0);
 
-            int count = 0;
+            // RK methods have issue with small SLRs
+            if (l < 0.1)
+                return;
 
-            for (int i = 0; i < NTRIALS; i++)
+            (V3 rf, V3 vf) = Shepperd.Solve(1.0, dt, r0, v0);
+
+            V3 rf2, vf2;
+
+            using (var y0 = Vec.Rent(6))
+            using (var yf = Vec.Rent(6))
             {
-                var    r0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                var    v0 = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                double dt = 10 * random.NextDouble() - 5;
+                y0.Set(0, r0);
+                y0.Set(3, v0);
 
-                (double sma, double ecc, double inc, double lan, double argp, double nu, double l) =
-                    Astro.KeplerianFromStateVectors(1.0, r0, v0);
-
-                //_testOutputHelper.WriteLine($"sma: {sma} ecc: {ecc} inc: {inc} lan: {lan} argp: {argp} nu: {nu} l: {l}");
-
-                // near-parabolic orbits are difficult for Shepperd, see the Farnocchia paper.
-                if (ecc < 1.01 && ecc > 0.99)
-                    continue;
-
-                // RK methods have issue with small SLRs
-                if (l < 0.1)
-                    continue;
-
-                (V3 rf, V3 vf) = Shepperd.Solve(1.0, dt, r0, v0);
-
-                V3 rf2, vf2;
-
-                using (var y0 = Vec.Rent(6))
-                using (var yf = Vec.Rent(6))
+                try
                 {
-                    y0.Set(0, r0);
-                    y0.Set(3, v0);
-
-                    try
-                    {
-                        solver.Solve(_ode.dydt, y0, yf, 0, dt);
-                    }
-                    catch (ArgumentException) // sometimes RK method still throws
-                    {
-                        continue;
-                    }
-
-                    rf2 = yf.Get(0);
-                    vf2 = yf.Get(3);
+                    solver.Solve(_ode.dydt, y0, yf, 0, dt);
+                }
+                catch (ArgumentException) // sometimes RK method still throws
+                {
+                    return;
                 }
 
-                count++;
-
-                if (!NearlyEqual(rf, rf2, 1e-5) || !NearlyEqual(vf, vf2, 1e-5))
-                {
-                    _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + " ecc:" + ecc + "\nrf:" + rf + " vf:" + vf + "\nrf2:" +
-                        rf2 + " vf2:" +
-                        vf2 + "\n");
-                }
-
-                rf.ShouldEqual(rf2, 1e-5);
-                vf.ShouldEqual(vf2, 1e-5);
+                rf2 = yf.Get(0);
+                vf2 = yf.Get(3);
             }
 
-            _testOutputHelper.WriteLine($"Successful: {count}");
+            if (!NearlyEqual(rf, rf2, 1e-5) || !NearlyEqual(vf, vf2, 1e-5))
+            {
+                _testOutputHelper.WriteLine("r0 :" + r0 + " v0:" + v0 + " dt:" + dt + " ecc:" + ecc + "\nrf:" + rf + " vf:" + vf + "\nrf2:" +
+                    rf2 + " vf2:" +
+                    vf2 + "\n");
+            }
 
-            Assert.True(count > NTRIALS * 0.90);
+            rf.ShouldEqual(rf2, 1e-5);
+            vf.ShouldEqual(vf2, 1e-5);
         }
     }
 }


### PR DESCRIPTION
This fixes Solve2 to do the better U3 solve to propagate the state and then adds a single U5 solve to generate the STM.

There's a comment in Shepperd's paper that you don't want to generate higher order recursive fractions from lower order, so do the work to recompute it.

Tests have been fixed to be deterministically random so they won't randomly break.