### PR TITLE
Fix launch to plane with negative inclination

### DIFF
--- a/MechJebLib/PSG/Terminal/FlightPathAngle3Energy.cs
+++ b/MechJebLib/PSG/Terminal/FlightPathAngle3Energy.cs
@@ -33,7 +33,7 @@ namespace MechJebLib.PSG.Terminal
         {
             double gammaT = _gammaT;
             double rT     = _rT;
-            double incT   = _incT;
+            double incT   = Abs(_incT);
 
             var rf = V3.CopyFromIndices(x, ri);
             var vf = V3.CopyFromIndices(x, vi);

--- a/MechJebLib/PSG/Terminal/FlightPathAngle4.cs
+++ b/MechJebLib/PSG/Terminal/FlightPathAngle4.cs
@@ -41,7 +41,7 @@ namespace MechJebLib.PSG.Terminal
         {
             double gammaT = _gammaT;
             double rT     = _rT;
-            double incT   = _incT;
+            double incT   = Abs(_incT);
             double vT     = _vT;
 
             var rf = V3.CopyFromIndices(x, ri);

--- a/MechJebLib/PSG/Terminal/FlightPathAngle4Energy.cs
+++ b/MechJebLib/PSG/Terminal/FlightPathAngle4Energy.cs
@@ -26,7 +26,7 @@ namespace MechJebLib.PSG.Terminal
             _incT = incT;
             _lanT = lanT;
             _gammaT = gammaT;
-            _iHT = Astro.HunitFromKeplerian(_incT, _lanT);
+            _iHT = Astro.HunitFromKeplerian(Abs(_incT), _lanT);
         }
 
         public ITerminal Rescale(Scale scale)  => new FlightPathAngle4Energy(_gammaT, _rT / scale.LengthScale, _incT, _lanT);

--- a/MechJebLib/PSG/Terminal/FlightPathAngle5.cs
+++ b/MechJebLib/PSG/Terminal/FlightPathAngle5.cs
@@ -30,7 +30,7 @@ namespace MechJebLib.PSG.Terminal
             _lanT = Clamp2Pi(lanT);
             _incT = incT;
 
-            _hT = Astro.HvecFromFlightPathAngle(_rT, _vT, _gammaT, _incT, _lanT);
+            _hT = Astro.HvecFromFlightPathAngle(_rT, _vT, _gammaT, Abs(_incT), _lanT);
         }
 
         public ITerminal Rescale(Scale scale) =>

--- a/MechJebLib/PSG/Terminal/Kepler3.cs
+++ b/MechJebLib/PSG/Terminal/Kepler3.cs
@@ -37,7 +37,7 @@ namespace MechJebLib.PSG.Terminal
         public void Constraints(double[] x, (int, int, int) ri, (int, int, int) vi, double[] f, alglib.sparsematrix j, ref int ci)
         {
             double hTm     = _hTm;
-            double incT    = _incT;
+            double incT    = Abs(_incT);
             double energyT = _energyT;
 
             var rf = V3.CopyFromIndices(x, ri);

--- a/MechJebLib/PSG/Terminal/Kepler4.cs
+++ b/MechJebLib/PSG/Terminal/Kepler4.cs
@@ -6,6 +6,7 @@
 using MechJebLib.Functions;
 using MechJebLib.Primitives;
 using static MechJebLib.Utils.AutoDiff;
+using static System.Math;
 
 namespace MechJebLib.PSG.Terminal
 {
@@ -24,7 +25,7 @@ namespace MechJebLib.PSG.Terminal
             _eccT = eccT;
             _incT = incT;
             _lanT = lanT;
-            _hT = Astro.HvecFromKeplerian(1.0, _smaT, _eccT, _incT, _lanT);
+            _hT = Astro.HvecFromKeplerian(1.0, _smaT, _eccT, Abs(_incT), _lanT);
         }
 
         public ITerminal Rescale(Scale scale)  => new Kepler4(_smaT / scale.LengthScale, _eccT, _incT, _lanT);

--- a/MechJebLib/PSG/Terminal/Kepler5.cs
+++ b/MechJebLib/PSG/Terminal/Kepler5.cs
@@ -6,6 +6,7 @@
 using MechJebLib.Functions;
 using MechJebLib.Primitives;
 using static MechJebLib.Utils.AutoDiff;
+using static System.Math;
 
 namespace MechJebLib.PSG.Terminal
 {
@@ -28,8 +29,8 @@ namespace MechJebLib.PSG.Terminal
             _lanT = lanT;
             _argpT = argpT;
 
-            _hT = Astro.HvecFromKeplerian(1.0, _smaT, _eccT, _incT, _lanT);
-            _eT = Astro.EvecFromKeplerian(_eccT, _incT, _lanT, _argpT);
+            _hT = Astro.HvecFromKeplerian(1.0, _smaT, _eccT, Abs(_incT), _lanT);
+            _eT = Astro.EvecFromKeplerian(_eccT, Abs(_incT), _lanT, _argpT);
         }
 
         public ITerminal Rescale(Scale scale)  => new Kepler5(_smaT / scale.LengthScale, _eccT, _incT, _lanT, _argpT);


### PR DESCRIPTION
Since #2112, the inclination fields in the constraints include the sign, which is used to signal to the initial guesser that the initial launch azimuth should be southwards. When passing this signed inclination to the functions for calculating the angular momentum and eccentricity vectors, this results in those vectors being calculated for an orbit with a LAN 180° offset from the specified orbit.

This PR makes sure that the absolute value of the inclination is taken, anywhere it is used for astrodynamics calculations; the initial guesser is the only place where the inclination with sign is used. Fixes #2184.