### PR TITLE
ODE DenseOutput

### DIFF
--- a/MechJeb2.sln.DotSettings
+++ b/MechJeb2.sln.DotSettings
@@ -71,5 +71,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=rodrigues/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=rtol/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sepratron/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tsit/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=tustin/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ullage/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/MechJebLib/Interpolants/IInterpolant.cs
+++ b/MechJebLib/Interpolants/IInterpolant.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using MechJebLib.Primitives;
+
+namespace MechJebLib.Interpolants
+{
+    public interface IInterpolant : IDisposable
+    {
+        double MaxT { get; }
+        double MinT { get; }
+        Vec    Evaluate(double x);
+    }
+}

--- a/MechJebLib/ODE/AbstractIVP.cs
+++ b/MechJebLib/ODE/AbstractIVP.cs
@@ -75,11 +75,6 @@ namespace MechJebLib.ODE
         public double Hstart { get; set; } = 0.0;
 
         /// <summary>
-        ///     Interpolants are pulled on an evenly spaced grid
-        /// </summary>
-        public int Interpnum { get; set; } = 20;
-
-        /// <summary>
         ///     Throw exception when MaxIter is hit (old PVG optimizer worked better with this set to false).
         /// </summary>
         public bool ThrowOnMaxIter { get; set; } = true;
@@ -107,7 +102,7 @@ namespace MechJebLib.ODE
         /// <param name="events"></param>
         /// <exception cref="ArgumentException"></exception>
         public void Solve(IVPFunc f, Vec y0, Vec yf, double t0, double tf,
-            Hn? interpolant = null,
+            DenseOutput? interpolant = null,
             IReadOnlyList<Event>? events = null)
         {
             try
@@ -145,7 +140,7 @@ namespace MechJebLib.ODE
         }
 
         private void _Solve(IVPFunc f, Vec y0, Vec yf, double t0, double tf,
-            Hn? interpolant,
+            DenseOutput? interpolant,
             IReadOnlyList<Event>? events)
         {
             Status = IVPStatus.Initialized;
@@ -156,15 +151,12 @@ namespace MechJebLib.ODE
 
             T = t0;
             Y.CopyFrom(y0);
-            double niter       = 0;
-            int    interpCount = 1;
+            double niter = 0;
 
             f(Y, T, Dy);
 
             Habs = Hstart > 0 ? Hstart : SelectInitialStep(f, T, Y, Dy, Direction);
             Habs = Clamp(Habs, MinStep, MaxStep);
-
-            interpolant?.Add(T, Y, Dy);
 
             if (events != null)
             {
@@ -247,9 +239,9 @@ namespace MechJebLib.ODE
                         events[i].LastValue = events[i].NewValue;
                 }
 
-                // extract a low fidelity interpolant
-                if (interpolant != null)
-                    interpCount = FillInterpolant(f, t0, tf, interpolant, interpCount);
+                // TODO: look carefully at what we need when an Event fires and terminates a step.
+                // BS3 is almost certainly buggy in the final interpolant step after a terminating event.
+                interpolant?.Append(SnapshotStep());
 
                 // take a step
                 Y.CopyFrom(Ynew);
@@ -275,7 +267,8 @@ namespace MechJebLib.ODE
                 }
             }
 
-            interpolant?.Add(T, Y, Dy);
+            if (t0 == tf)
+                interpolant?.Append(new ConstantNode(T, Y));
 
             Y.CopyTo(yf);
 
@@ -292,36 +285,15 @@ namespace MechJebLib.ODE
             return (up && e.Direction > 0) || (down && e.Direction < 0) || (either && e.Direction == 0);
         }
 
-        private int FillInterpolant(IVPFunc f, double t0, double tf, Hn interpolant, int interpCount)
-        {
-            while (interpCount < Interpnum)
-            {
-                double tinterp = t0 + (tf - t0) * interpCount / Interpnum;
-
-                if (!tinterp.IsWithin(T, Tnew))
-                    break;
-
-                using var yinterp = Vec.Rent(N);
-                using var finterp = Vec.Rent(N);
-
-                InitInterpolant();
-                Interpolate(tinterp, yinterp);
-                f(yinterp, tinterp, finterp);
-                interpolant?.Add(tinterp, yinterp, finterp);
-                interpCount++;
-            }
-
-            return interpCount;
-        }
-
         protected abstract (double, double) Step(IVPFunc f);
 
         protected abstract double SelectInitialStep(IVPFunc f, double t0, Vec y0,
             Vec f0, int direction);
 
-        protected abstract void InitInterpolant();
-        protected abstract void Interpolate(double x, Vec yout);
-        protected abstract void Init();
-        protected abstract void Cleanup();
+        protected abstract void      InitInterpolant();
+        protected abstract DenseNode SnapshotStep();
+        protected abstract void      Interpolate(double x, Vec yout);
+        protected abstract void      Init();
+        protected abstract void      Cleanup();
     }
 }

--- a/MechJebLib/ODE/BS3.cs
+++ b/MechJebLib/ODE/BS3.cs
@@ -5,6 +5,7 @@
 
 using System;
 using MechJebLib.Primitives;
+using MechJebLib.Utils;
 using static MechJebLib.Utils.Statics;
 using static System.Math;
 
@@ -66,6 +67,8 @@ namespace MechJebLib.ODE
             // intentionally left blank
         }
 
+        protected override DenseNode SnapshotStep() => BS3Node.Rent(T, Habs * Direction, Y, Dy, Ynew, Dynew);
+
         protected override void Init()
         {
             base.Init();
@@ -101,5 +104,54 @@ namespace MechJebLib.ODE
         private const double E4 = -0.125;
 
         #endregion
+    }
+
+    internal class BS3Node : DenseNode
+    {
+        private static readonly ObjectPool<BS3Node> _pool = new ObjectPool<BS3Node>(New, Clear);
+
+        public static BS3Node Rent(double t, double h, Vec y, Vec dy, Vec ynew, Vec dynew)
+        {
+            BS3Node node = _pool.Borrow();
+            node.T = t;
+            node.H = h;
+            node.Y = y.Dup();
+            node.N = y.Length;
+            node._dy = dy.Dup();
+            node._ynew = ynew.Dup();
+            node._dynew = dynew.Dup();
+            return node;
+        }
+
+        private BS3Node() { }
+
+        private static BS3Node New() => new BS3Node();
+
+        private static void Clear(BS3Node o)
+        {
+            // ReSharper disable once NullableWarningSuppressionIsUsed
+            o.Y = o._dy = o._ynew = o._dynew = null!;
+            o.N = -1;
+            o.T = 0;
+            o.H = 0;
+        }
+
+        // ReSharper disable NullableWarningSuppressionIsUsed
+        private Vec _dy = null!;
+        private Vec _ynew = null!;
+        private Vec _dynew = null!;
+        // ReSharper restore NullableWarningSuppressionIsUsed
+
+        public override void Evaluate(double x, Vec yout) =>
+            yout.CubicHermiteInterpolant(T, Y, _dy, T + H, _ynew, _dynew, x);
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            _dy.Dispose();
+            _ynew.Dispose();
+            _dynew.Dispose();
+            _pool.Release(this);
+        }
     }
 }

--- a/MechJebLib/ODE/DP5.cs
+++ b/MechJebLib/ODE/DP5.cs
@@ -5,6 +5,7 @@
 
 using System;
 using MechJebLib.Primitives;
+using MechJebLib.Utils;
 using static MechJebLib.Utils.Statics;
 using static System.Math;
 
@@ -62,36 +63,6 @@ namespace MechJebLib.ODE
         private const double E5 = -17253.0 / 339200.0;
         private const double E6 = 22.0 / 525.0;
         private const double E7 = -1.0 / 40.0;
-
-        private const double B10 = 11282082432.0 / 11282082432.0;
-        private const double B11 = -32272833064.0 / 11282082432.0;
-        private const double B12 = 34969693132.0 / 11282082432.0;
-        private const double B13 = -13107642775.0 / 11282082432.0;
-        private const double B14 = 157015080.0 / 11282082432.0;
-
-        private const double B31 = -100 * -1323431896.0 / 32700410799.0;
-        private const double B32 = -100 * 2074956840.0 / 32700410799.0;
-        private const double B33 = -100 * -914128567.0 / 32700410799.0;
-        private const double B34 = -100 * 15701508.0 / 32700410799.0;
-
-        private const double B41 = 25.0 * -889289856.0 / 5641041216.0;
-        private const double B42 = 25.0 * 2460397220.0 / 5641041216.0;
-        private const double B43 = 25.0 * -1518414297.0 / 5641041216.0;
-        private const double B44 = 25.0 * 94209048.0 / 5641041216.0;
-
-        private const double B51 = -2187.0 * -259006536.0 / 199316789632.0;
-        private const double B52 = -2187.0 * 687873124.0 / 199316789632.0;
-        private const double B53 = -2187.0 * -451824525.0 / 199316789632.0;
-        private const double B54 = -2187.0 * 52338360.0 / 199316789632.0;
-
-        private const double B61 = 11.0 * -361440756.0 / 2467955532.0;
-        private const double B62 = 11.0 * 946554244.0 / 2467955532.0;
-        private const double B63 = 11.0 * -661884105.0 / 2467955532.0;
-        private const double B64 = 11.0 * 106151040.0 / 2467955532.0;
-
-        private const double B71 = 44764047.0 / 29380423.0;
-        private const double B72 = -82437520.0 / 29380423.0;
-        private const double B73 = 8293050.0 / 29380423.0;
 
         #endregion
 
@@ -154,6 +125,8 @@ namespace MechJebLib.ODE
             // intentionally left blank
         }
 
+        protected override DenseNode SnapshotStep() => DP5Node.Rent(T, Habs * Direction, Y, _k1, _k3, _k4, _k5, _k6, _k7);
+
         protected override void Init()
         {
             base.Init();
@@ -178,10 +151,45 @@ namespace MechJebLib.ODE
         }
 
         // https://doi.org/10.1016/0898-1221(86)90025-8
-        protected override void Interpolate(double x, Vec yout)
+        protected override void Interpolate(double x, Vec yout) =>
+            DP5Math.Interpolate(x, T, Habs * Direction, Y, _k1, _k3, _k4, _k5, _k6, _k7, yout);
+    }
+
+    internal static class DP5Math
+    {
+        private const double B10 = 11282082432.0 / 11282082432.0;
+        private const double B11 = -32272833064.0 / 11282082432.0;
+        private const double B12 = 34969693132.0 / 11282082432.0;
+        private const double B13 = -13107642775.0 / 11282082432.0;
+        private const double B14 = 157015080.0 / 11282082432.0;
+
+        private const double B31 = -100 * -1323431896.0 / 32700410799.0;
+        private const double B32 = -100 * 2074956840.0 / 32700410799.0;
+        private const double B33 = -100 * -914128567.0 / 32700410799.0;
+        private const double B34 = -100 * 15701508.0 / 32700410799.0;
+
+        private const double B41 = 25.0 * -889289856.0 / 5641041216.0;
+        private const double B42 = 25.0 * 2460397220.0 / 5641041216.0;
+        private const double B43 = 25.0 * -1518414297.0 / 5641041216.0;
+        private const double B44 = 25.0 * 94209048.0 / 5641041216.0;
+
+        private const double B51 = -2187.0 * -259006536.0 / 199316789632.0;
+        private const double B52 = -2187.0 * 687873124.0 / 199316789632.0;
+        private const double B53 = -2187.0 * -451824525.0 / 199316789632.0;
+        private const double B54 = -2187.0 * 52338360.0 / 199316789632.0;
+
+        private const double B61 = 11.0 * -361440756.0 / 2467955532.0;
+        private const double B62 = 11.0 * 946554244.0 / 2467955532.0;
+        private const double B63 = 11.0 * -661884105.0 / 2467955532.0;
+        private const double B64 = 11.0 * 106151040.0 / 2467955532.0;
+
+        private const double B71 = 44764047.0 / 29380423.0;
+        private const double B72 = -82437520.0 / 29380423.0;
+        private const double B73 = 8293050.0 / 29380423.0;
+
+        public static void Interpolate(double x, double t, double h, Vec y, Vec k1, Vec k3, Vec k4, Vec k5, Vec k6, Vec k7, Vec yout)
         {
-            double h  = Habs * Direction;
-            double s  = (x - T) / h;
+            double s  = (x - t) / h;
             double s2 = s * s;
             double s3 = s * s2;
             double s4 = s2 * s2;
@@ -194,7 +202,65 @@ namespace MechJebLib.ODE
             double bs6 = s * (B61 + B62 * s + B63 * s2 + B64 * s3);
             double bs7 = (1.0 - s) * s * (B71 + B72 * s + B73 * s2);
 
-            yout.LinComb6(Y, hs * bs1, _k1, hs * bs3, _k3, hs * bs4, _k4, hs * bs5, _k5, hs * bs6, _k6, hs * bs7, _k7);
+            yout.LinComb6(y, hs * bs1, k1, hs * bs3, k3, hs * bs4, k4, hs * bs5, k5, hs * bs6, k6, hs * bs7, k7);
+        }
+    }
+
+    internal class DP5Node : DenseNode
+    {
+        private static readonly ObjectPool<DP5Node> _pool = new ObjectPool<DP5Node>(New, Clear);
+
+        public static DP5Node Rent(double t, double h, Vec y, Vec k1, Vec k3, Vec k4, Vec k5, Vec k6, Vec k7)
+        {
+            DP5Node node = _pool.Borrow();
+            node.T = t;
+            node.H = h;
+            node.Y = y.Dup();
+            node.N = y.Length;
+            node._k1 = k1.Dup();
+            node._k3 = k3.Dup();
+            node._k4 = k4.Dup();
+            node._k5 = k5.Dup();
+            node._k6 = k6.Dup();
+            node._k7 = k7.Dup();
+            return node;
+        }
+
+        private DP5Node() { }
+
+        private static DP5Node New() => new DP5Node();
+
+        private static void Clear(DP5Node o)
+        {
+            // ReSharper disable once NullableWarningSuppressionIsUsed
+            o.Y = o._k1 = o._k3 = o._k4 = o._k5 = o._k6 = o._k7 = null!;
+            o.N = -1;
+            o.T = 0;
+            o.H = 0;
+        }
+
+        // ReSharper disable NullableWarningSuppressionIsUsed
+        private Vec _k1 = null!;
+        private Vec _k3 = null!;
+        private Vec _k4 = null!;
+        private Vec _k5 = null!;
+        private Vec _k6 = null!;
+        private Vec _k7 = null!;
+        // ReSharper restore NullableWarningSuppressionIsUsed
+
+        public override void Evaluate(double x, Vec yout) =>
+            DP5Math.Interpolate(x, T, H, Y, _k1, _k3, _k4, _k5, _k6, _k7, yout);
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            _k1.Dispose();
+            _k3.Dispose();
+            _k4.Dispose();
+            _k5.Dispose();
+            _k6.Dispose();
+            _k7.Dispose();
+            _pool.Release(this);
         }
     }
 }

--- a/MechJebLib/ODE/DP8.cs
+++ b/MechJebLib/ODE/DP8.cs
@@ -130,38 +130,6 @@ namespace MechJebLib.ODE
         private const double E303 = 0.220588235294117647058823529412e-1;
         private const double E309 = 0.733846688281611857341361741547;
 
-        /*
-        private const double B10 = 11282082432.0 / 11282082432.0;
-        private const double B11 = -32272833064.0 / 11282082432.0;
-        private const double B12 = 34969693132.0 / 11282082432.0;
-        private const double B13 = -13107642775.0 / 11282082432.0;
-        private const double B14 = 157015080.0 / 11282082432.0;
-
-        private const double B31 = -100 * -1323431896.0 / 32700410799.0;
-        private const double B32 = -100 * 2074956840.0 / 32700410799.0;
-        private const double B33 = -100 * -914128567.0 / 32700410799.0;
-        private const double B34 = -100 * 15701508.0 / 32700410799.0;
-
-        private const double B41 = 25.0 * -889289856.0 / 5641041216.0;
-        private const double B42 = 25.0 * 2460397220.0 / 5641041216.0;
-        private const double B43 = 25.0 * -1518414297.0 / 5641041216.0;
-        private const double B44 = 25.0 * 94209048.0 / 5641041216.0;
-
-        private const double B51 = -2187.0 * -259006536.0 / 199316789632.0;
-        private const double B52 = -2187.0 * 687873124.0 / 199316789632.0;
-        private const double B53 = -2187.0 * -451824525.0 / 199316789632.0;
-        private const double B54 = -2187.0 * 52338360.0 / 199316789632.0;
-
-        private const double B61 = 11.0 * -361440756.0 / 2467955532.0;
-        private const double B62 = 11.0 * 946554244.0 / 2467955532.0;
-        private const double B63 = 11.0 * -661884105.0 / 2467955532.0;
-        private const double B64 = 11.0 * 106151040.0 / 2467955532.0;
-
-        private const double B71 = 44764047.0 / 29380423.0;
-        private const double B72 = -82437520.0 / 29380423.0;
-        private const double B73 = 8293050.0 / 29380423.0;
-        */
-
         #endregion
 
         // ReSharper disable NullableWarningSuppressionIsUsed
@@ -229,6 +197,8 @@ namespace MechJebLib.ODE
             // intentionally left blank
         }
 
+        protected override DenseNode SnapshotStep() => throw new NotImplementedException();
+
         protected override void Init()
         {
             base.Init();
@@ -262,41 +232,10 @@ namespace MechJebLib.ODE
             _k12.Dispose();
         }
 
-        // https://doi.org/10.1016/0898-1221(86)90025-8
         protected override void Interpolate(double x, Vec yout)
         {
             throw new NotImplementedException();
-
-            /*
-            double h = Habs * Direction;
-            double s = (x - T) / h;
-            double s2 = s * s;
-            double s3 = s * s2;
-            double s4 = s2 * s2;
-
-            double bs1 = B10 + B11 * s + B12 * s2 + B13 * s3 + B14 * s4;
-            double bs3 = s * (B31 + B32 * s + B33 * s2 + B34 * s3);
-            double bs4 = s * (B41 + B42 * s + B43 * s2 + B44 * s3);
-            double bs5 = s * (B51 + B52 * s + B53 * s2 + B54 * s3);
-            double bs6 = s * (B61 + B62 * s + B63 * s2 + B64 * s3);
-            double bs7 = (1.0 - s) * s * (B71 + B72 * s + B73 * s2);
-
-            for (int i = 0; i < N; i++)
-                yout[i] = Y[i] + h * s * (bs1 * k1[i] + bs3 * k3[i] + bs4 * k4[i] + bs5 * k5[i] + bs6 * k6[i] + bs7 * k7[i]);
-                */
         }
-
-        /*
-         * def _estimate_error_norm(self, K, h, scale):
-           err5 = np.dot(K.T, self.E5) / scale
-           err3 = np.dot(K.T, self.E3) / scale
-           err5_norm_2 = np.linalg.norm(err5)**2
-           err3_norm_2 = np.linalg.norm(err3)**2
-           if err5_norm_2 == 0 and err3_norm_2 == 0:
-           return 0.0
-           denom = err5_norm_2 + 0.01 * err3_norm_2
-           return np.abs(h) * err5_norm_2 / np.sqrt(denom * len(scale))
-         */
 
         protected override double ScaledErrorNorm()
         {

--- a/MechJebLib/ODE/DenseNode.cs
+++ b/MechJebLib/ODE/DenseNode.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using MechJebLib.Primitives;
+
+namespace MechJebLib.ODE
+{
+    public abstract class DenseNode : IDisposable
+    {
+        public double T; // left endpoint
+        public int N;
+        public double H; // signed step (Habs * Direction)
+        // ReSharper disable once NullableWarningSuppressionIsUsed
+        public Vec Y = null!;    // y at T
+
+        public abstract void Evaluate(double t, Vec yout);
+
+        public virtual void Dispose() => Y.Dispose();
+    }
+
+    /// <summary>
+    /// This is a fake "interpolant" for zero-length t0 == tf "integration".
+    /// </summary>
+    public class ConstantNode : DenseNode
+    {
+        public ConstantNode(double t, Vec y)
+        {
+            T = t;
+            Y = y.Dup();
+            N = y.Length;
+            H = 0;
+        }
+
+        public override void Evaluate(double t, Vec yout)
+        {
+            yout.CopyFrom(Y);
+        }
+    }
+}

--- a/MechJebLib/ODE/DenseOutput.cs
+++ b/MechJebLib/ODE/DenseOutput.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using MechJebLib.Interpolants;
+using MechJebLib.Primitives;
+using MechJebLib.Utils;
+using static MechJebLib.Utils.Statics;
+
+namespace MechJebLib.ODE
+{
+    public class DenseOutput : IDisposable, IInterpolant
+    {
+        private static readonly ObjectPool<DenseOutput> _pool = new ObjectPool<DenseOutput>(New, Clear);
+
+        private readonly List<DenseNode> _nodes = new List<DenseNode>();
+        private int _lastIndex = -1;
+        private double _minT = double.NaN;
+        private double _maxT = double.NaN;
+        public double MaxT { get; private set; } = double.NegativeInfinity;
+        public double MinT { get; private set; } = double.PositiveInfinity;
+        public int N = -1;
+        public int Direction;
+
+        public static DenseOutput Rent() => _pool.Borrow();
+
+        private static DenseOutput New() => new DenseOutput();
+
+        private DenseOutput() { }
+
+        private static void Clear(DenseOutput o)
+        {
+            o.N = -1;
+            o._minT = double.NaN;
+            o._maxT = double.NaN;
+            o.MinT = double.PositiveInfinity;
+            o.MaxT = double.NegativeInfinity;
+            o.Direction = 0;
+            o._lastIndex = -1;
+        }
+
+        public void Append(DenseNode n)
+        {
+            _nodes.Add(n);
+            if (N < 1)
+                N = n.N;
+            else if (N != n.N)
+                throw new ArgumentException($"[MechJeb2] DenseOutput.Add(): node lengths do not match {N} != {n.N}");
+            Direction = Math.Sign(n.H);
+            if (Direction * n.T < Direction * _minT || !IsFinite(_minT))
+                _minT = n.T;
+            if (Direction * n.T > Direction * _maxT || !IsFinite(_maxT))
+                _maxT = n.T;
+
+            double min = Direction < 0 ? n.T + n.H : n.T;
+            if (min < MinT)
+                MinT = min;
+            double max = Direction > 0 ? n.T + n.H : n.T;
+            if (max > MaxT)
+                MaxT = max;
+        }
+
+        private int FindIndex(double x)
+        {
+            if (Direction * x < Direction * _minT)
+                return 0;
+            if (Direction * x > Direction * _maxT)
+                return _nodes.Count - 1;
+
+            if (_lastIndex > 0 && Direction * x > Direction * _nodes[_lastIndex].T)
+            {
+                if (Direction * x < Direction * _nodes[_lastIndex + 1].T)
+                    return _lastIndex;
+
+                if (Direction * x >= Direction * _nodes[_lastIndex + 1].T && Direction * x < Direction * _nodes[_lastIndex + 2].T)
+                    return _lastIndex + 1;
+            }
+
+            int lo = 0;
+            int hi = _nodes.Count - 1;
+
+            while (lo <= hi)
+            {
+                int i     = lo + ((hi - lo) >> 1);
+                int order = Direction * x.CompareTo(_nodes[i].T);
+
+                if (order == 0)
+                    return i;
+
+                if (order > 0)
+                    lo = i + 1;
+                else
+                    hi = i - 1;
+            }
+
+            return lo - 1; // lo is the hi value here
+        }
+
+        public Vec Evaluate(double x)
+        {
+            int i = FindIndex(x);
+
+            var yout = Vec.Rent(N);
+
+            _nodes[i].Evaluate(x, yout);
+
+            _lastIndex = i;
+
+            return yout;
+        }
+
+        public void Dispose()
+        {
+            foreach (DenseNode n in _nodes)
+                n.Dispose();
+            _nodes.Clear();
+            _pool.Release(this);
+        }
+    }
+}

--- a/MechJebLib/ODE/Tsit5.cs
+++ b/MechJebLib/ODE/Tsit5.cs
@@ -5,6 +5,7 @@
 
 using System;
 using MechJebLib.Primitives;
+using MechJebLib.Utils;
 using static MechJebLib.Utils.Statics;
 using static System.Math;
 
@@ -55,35 +56,6 @@ namespace MechJebLib.ODE
         private const double E5 = -0.5823571654525552;
         private const double E6 = 0.45808210592918686;
         private const double E7 = -0.015151515151515152;
-
-        private const double R11 = 1.0;
-        private const double R12 = -2.763706197274826;
-        private const double R13 = 2.9132554618219126;
-        private const double R14 = -1.0530884977290216;
-
-        private const double R22 = 0.13169999999999998;
-        private const double R23 = -0.2234;
-        private const double R24 = 0.1017;
-
-        private const double R32 = 3.9302962368947516;
-        private const double R33 = -5.941033872131505;
-        private const double R34 = 2.490627285651253;
-
-        private const double R42 = -12.411077166933676;
-        private const double R43 = 30.33818863028232;
-        private const double R44 = -16.548102889244902;
-
-        private const double R52 = 37.50931341651104;
-        private const double R53 = -88.1789048947664;
-        private const double R54 = 47.37952196281928;
-
-        private const double R62 = -27.896526289197286;
-        private const double R63 = 65.09189467479366;
-        private const double R64 = -34.87065786149661;
-
-        private const double R72 = 1.5;
-        private const double R73 = -4;
-        private const double R74 = 2.5;
 
         #endregion
 
@@ -169,17 +141,48 @@ namespace MechJebLib.ODE
             // intentionally left blank
         }
 
-        protected override void Interpolate(double x, Vec yout)
+        protected override DenseNode SnapshotStep() => Tsit5Node.Rent(T, Habs * Direction, Y, _k1, _k2, _k3, _k4, _k5, _k6, _k7);
+
+        protected override void Interpolate(double x, Vec yout) => Tsit5Math.Interpolate(x, T, Habs * Direction, Y, _k1, _k2, _k3, _k4, _k5, _k6, _k7, yout);
+    }
+
+    internal static class Tsit5Math
+    {
+        private const double R11 = 1.0;
+        private const double R12 = -2.763706197274826;
+        private const double R13 = 2.9132554618219126;
+        private const double R14 = -1.0530884977290216;
+
+        private const double R22 = 0.13169999999999998;
+        private const double R23 = -0.2234;
+        private const double R24 = 0.1017;
+
+        private const double R32 = 3.9302962368947516;
+        private const double R33 = -5.941033872131505;
+        private const double R34 = 2.490627285651253;
+
+        private const double R42 = -12.411077166933676;
+        private const double R43 = 30.33818863028232;
+        private const double R44 = -16.548102889244902;
+
+        private const double R52 = 37.50931341651104;
+        private const double R53 = -88.1789048947664;
+        private const double R54 = 47.37952196281928;
+
+        private const double R62 = -27.896526289197286;
+        private const double R63 = 65.09189467479366;
+        private const double R64 = -34.87065786149661;
+
+        private const double R72 = 1.5;
+        private const double R73 = -4;
+        private const double R74 = 2.5;
+
+        public static void Interpolate(double x, double t, double h, Vec y, Vec k1, Vec k2, Vec k3, Vec k4, Vec k5, Vec k6, Vec k7, Vec yout)
         {
-            double h  = Habs * Direction;
-            double s  = (x - T) / h;
+            double s  = (x - t) / h;
             double s2 = s * s;
             double s3 = s * s2;
 
-            // Tsit5 dense output (SciML convention):
-            //   y(t_n + s·h) = y_n + h · Σᵢ b_iΘ(s) · k_i
-            // The θ factors are baked into b_iΘ, so the leading multiplier is
-            // h alone — not h·s.
             double b1 = s * (R11 + R12 * s + R13 * s2 + R14 * s3);
             double b2 = s2 * (R22 + R23 * s + R24 * s2);
             double b3 = s2 * (R32 + R33 * s + R34 * s2);
@@ -188,9 +191,70 @@ namespace MechJebLib.ODE
             double b6 = s2 * (R62 + R63 * s + R64 * s2);
             double b7 = s2 * (R72 + R73 * s + R74 * s2);
 
-            yout.LinComb7(Y,
-                h * b1, _k1, h * b2, _k2, h * b3, _k3, h * b4, _k4,
-                h * b5, _k5, h * b6, _k6, h * b7, _k7);
+            yout.LinComb7(y,
+                h * b1, k1, h * b2, k2, h * b3, k3, h * b4, k4,
+                h * b5, k5, h * b6, k6, h * b7, k7);
+        }
+    }
+
+    internal class Tsit5Node : DenseNode
+    {
+        private static readonly ObjectPool<Tsit5Node> _pool = new ObjectPool<Tsit5Node>(New, Clear);
+
+        public static Tsit5Node Rent(double t, double h, Vec y, Vec k1, Vec k2, Vec k3, Vec k4, Vec k5, Vec k6, Vec k7)
+        {
+            Tsit5Node node = _pool.Borrow();
+            node.T = t;
+            node.H = h;
+            node.Y = y.Dup();
+            node.N = y.Length;
+            node._k1 = k1.Dup();
+            node._k2 = k2.Dup();
+            node._k3 = k3.Dup();
+            node._k4 = k4.Dup();
+            node._k5 = k5.Dup();
+            node._k6 = k6.Dup();
+            node._k7 = k7.Dup();
+            return node;
+        }
+
+        private Tsit5Node() { }
+
+        private static Tsit5Node New() => new Tsit5Node();
+
+        private static void Clear(Tsit5Node o)
+        {
+            // ReSharper disable once NullableWarningSuppressionIsUsed
+            o.Y = o._k1 = o._k2 = o._k3 = o._k4 = o._k5 = o._k6 = o._k7 = null!;
+            o.N = -1;
+            o.T = 0;
+            o.H = 0;
+        }
+
+        // ReSharper disable NullableWarningSuppressionIsUsed
+        private Vec _k1 = null!;
+        private Vec _k2 = null!;
+        private Vec _k3 = null!;
+        private Vec _k4 = null!;
+        private Vec _k5 = null!;
+        private Vec _k6 = null!;
+        private Vec _k7 = null!;
+        // ReSharper restore NullableWarningSuppressionIsUsed
+
+
+        public override void Evaluate(double x, Vec yout) => Tsit5Math.Interpolate(x, T, H, Y, _k1, _k2, _k3, _k4, _k5, _k6, _k7, yout);
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            _k1.Dispose();
+            _k2.Dispose();
+            _k3.Dispose();
+            _k4.Dispose();
+            _k5.Dispose();
+            _k6.Dispose();
+            _k7.Dispose();
+            _pool.Release(this);
         }
     }
 }

--- a/MechJebLib/PSG/AscentGuesser.cs
+++ b/MechJebLib/PSG/AscentGuesser.cs
@@ -69,14 +69,14 @@ namespace MechJebLib.PSG
         private readonly DP5 _solver = new DP5();
         private readonly List<Event> _events;
 
-        private Hn Integrate(Vec y0, Vec yf, Phase phase, double t0, double tf)
+        private DenseOutput Integrate(Vec y0, Vec yf, Phase phase, double t0, double tf)
         {
             _solver.ThrowOnMaxIter = true;
             _solver.Maxiter = 2000;
             _solver.Rtol = 1e-6;
             _solver.Atol = 1e-6;
             _ode.Phase = phase;
-            var interpolant = Hn.Get(VacuumThrustKernel.N);
+            var interpolant = DenseOutput.Rent();
             if (phase.Coast)
                 _solver.Solve(_ode.dydt, y0, yf, t0, tf, interpolant);
             else
@@ -128,19 +128,19 @@ namespace MechJebLib.PSG
 
                 y0.CopyTo(initial);
 
-                Hn interpolant = Integrate(initial, terminal, phase, t0, t0 + bt);
+                DenseOutput interpolant = Integrate(initial, terminal, phase, t0, t0 + bt);
 
                 if (WillIntraPhaseCoast(phases, p))
                 {
-                    double btActual     = interpolant.MaxTime - interpolant.MinTime;
-                    Hn     interpolant2 = Integrate(initial, terminal, phase, t0, t0 + btActual * 0.75);
-                    solution.AddSegment(interpolant2.MinTime, interpolant2.MaxTime, interpolant2, phase);
+                    double      btActual     = interpolant.MaxT - interpolant.MinT;
+                    interpolant.Dispose();
+                    DenseOutput interpolant2 = Integrate(initial, terminal, phase, t0, t0 + btActual * 0.75);
+                    solution.AddSegment(interpolant2, phase);
                 }
                 else
                 {
-                    solution.AddSegment(interpolant.MinTime, interpolant.MaxTime, interpolant, phase);
+                    solution.AddSegment(interpolant, phase);
                 }
-
                 y0.CopyFrom(terminal);
 
                 t0 = solution.Tmax;

--- a/MechJebLib/PSG/Solution.cs
+++ b/MechJebLib/PSG/Solution.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using MechJebLib.Functions;
+using MechJebLib.Interpolants;
+using MechJebLib.ODE;
 using MechJebLib.Primitives;
 using static MechJebLib.Utils.Statics;
 using static System.Math;
@@ -20,7 +22,7 @@ namespace MechJebLib.PSG
         private readonly Scale _scale;
         private readonly List<double> _tmin = new List<double>();
         private readonly List<double> _tmax = new List<double>();
-        private readonly List<Hn> _interpolants = new List<Hn>();
+        private readonly List<IInterpolant> _interpolants = new List<IInterpolant>();
         public readonly List<Phase> Phases = new List<Phase>();
         private readonly double _mu;
         private readonly double _rbody;
@@ -45,10 +47,10 @@ namespace MechJebLib.PSG
             T0 = problem.T0;
         }
 
-        public void AddSegment(double t0, double tf, Hn interpolant, Phase phase)
+        public void AddSegment(IInterpolant interpolant, Phase phase)
         {
-            _tmin.Add(t0);
-            _tmax.Add(tf);
+            _tmin.Add(interpolant.MinT);
+            _tmax.Add(interpolant.MaxT);
             Phases.Add(phase.DeepCopy());
             _interpolants.Add(interpolant);
         }
@@ -79,14 +81,14 @@ namespace MechJebLib.PSG
         public V3 RBar(double tBar)
         {
             using Vec xRaw = Interpolate(tBar);
-            var      x    = InterpolantLayout.CreateFrom(xRaw);
+            var       x    = InterpolantLayout.CreateFrom(xRaw);
             return x.R;
         }
 
         public V3 RBar(int segment, double tBar)
         {
             using Vec xRaw = Interpolate(segment, tBar);
-            var      x    = InterpolantLayout.CreateFrom(xRaw);
+            var       x    = InterpolantLayout.CreateFrom(xRaw);
             return x.R;
         }
 
@@ -99,14 +101,14 @@ namespace MechJebLib.PSG
         public V3 VBar(double tBar)
         {
             using Vec xRaw = Interpolate(tBar);
-            var      x    = InterpolantLayout.CreateFrom(xRaw);
+            var       x    = InterpolantLayout.CreateFrom(xRaw);
             return x.V;
         }
 
         public V3 VBar(int segment, double tBar)
         {
             using Vec xRaw = Interpolate(segment, tBar);
-            var      x    = InterpolantLayout.CreateFrom(xRaw);
+            var       x    = InterpolantLayout.CreateFrom(xRaw);
             return x.V;
         }
 
@@ -119,14 +121,14 @@ namespace MechJebLib.PSG
         public V3 UBar(double tBar)
         {
             using Vec xRaw = Interpolate(tBar);
-            var      x    = InterpolantLayout.CreateFrom(xRaw);
+            var       x    = InterpolantLayout.CreateFrom(xRaw);
             return x.U;
         }
 
         public V3 UBar(int segment, double tBar)
         {
             using Vec xRaw = Interpolate(segment, tBar);
-            var      x    = InterpolantLayout.CreateFrom(xRaw);
+            var       x    = InterpolantLayout.CreateFrom(xRaw);
             return x.U;
         }
 
@@ -142,14 +144,14 @@ namespace MechJebLib.PSG
         public double MBar(int segment, double tBar)
         {
             using Vec xRaw = Interpolate(segment, tBar);
-            var      x    = InterpolantLayout.CreateFrom(xRaw);
+            var       x    = InterpolantLayout.CreateFrom(xRaw);
             return x.M;
         }
 
         public double MBar(double tBar)
         {
             using Vec xRaw = Interpolate(tBar);
-            var      x    = InterpolantLayout.CreateFrom(xRaw);
+            var       x    = InterpolantLayout.CreateFrom(xRaw);
             return x.M;
         }
 
@@ -172,7 +174,7 @@ namespace MechJebLib.PSG
         public double DVBar(double tBar)
         {
             using Vec xRaw = Interpolate(tBar);
-            var      x    = InterpolantLayout.CreateFrom(xRaw);
+            var       x    = InterpolantLayout.CreateFrom(xRaw);
             return x.Dv;
         }
 
@@ -184,13 +186,13 @@ namespace MechJebLib.PSG
 
         public double DV(double t, int n)
         {
-            double   tbar  = (t - T0) / _timeScale;
-            double   min   = tbar > _tmin[n] ? tbar : _tmin[n];
-            double   max   = _tmax[n];
+            double    tbar  = (t - T0) / _timeScale;
+            double    min   = tbar > _tmin[n] ? tbar : _tmin[n];
+            double    max   = _tmax[n];
             using Vec ddmin = Interpolate(n, min);
-            var      xmin  = InterpolantLayout.CreateFrom(ddmin);
+            var       xmin  = InterpolantLayout.CreateFrom(ddmin);
             using Vec ddmax = Interpolate(n, max);
-            var      xmax  = InterpolantLayout.CreateFrom(ddmax);
+            var       xmax  = InterpolantLayout.CreateFrom(ddmax);
             return Max(xmax.Dv - xmin.Dv, 0) * _velocityScale;
         }
 
@@ -299,8 +301,8 @@ namespace MechJebLib.PSG
             double tBar = (t - T0) / _timeScale;
 
             using Vec xRaw = Interpolate(tBar);
-            var      x    = InterpolantLayout.CreateFrom(xRaw);
-            V3       u0   = x.U.normalized;
+            var       x    = InterpolantLayout.CreateFrom(xRaw);
+            V3        u0   = x.U.normalized;
 
             double thrustPct   = x.U.magnitude;
             int    phase       = IndexForTbar(tBar);
@@ -317,7 +319,7 @@ namespace MechJebLib.PSG
             double tBar = (t - T0) / _timeScale;
 
             using Vec xraw = Interpolate(tBar);
-            var      x    = InterpolantLayout.CreateFrom(xraw);
+            var       x    = InterpolantLayout.CreateFrom(xraw);
             return (x.R * _lengthScale, x.V * _velocityScale);
         }
 
@@ -437,7 +439,9 @@ namespace MechJebLib.PSG
 
         public void Dispose()
         {
-            // FIXME: need to dispose properly
+            foreach (IInterpolant i in _interpolants)
+                i.Dispose();
+            _interpolants.Clear();
         }
     }
 }

--- a/MechJebLib/PSG/SolutionBuilder.cs
+++ b/MechJebLib/PSG/SolutionBuilder.cs
@@ -113,7 +113,7 @@ namespace MechJebLib.PSG
                 }
 
                 double tf = ti + bt;
-                solution.AddSegment(ti, tf, interpolant, _phases[p]);
+                solution.AddSegment(interpolant, _phases[p]);
                 ti = tf;
 
                 dv = solution.DVBar(solution.Tmax);

--- a/MechJebLib/Primitives/H1.cs
+++ b/MechJebLib/Primitives/H1.cs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-PD-hp OR Unlicense OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT OR LGPL-2.1+
  */
 
-using MechJebLib.Functions;
 using MechJebLib.Utils;
 
 namespace MechJebLib.Primitives
@@ -44,7 +43,7 @@ namespace MechJebLib.Primitives
         protected override void Addition(double a, double b, ref double result) => result = a + b;
 
         protected override double Interpolant(double x1, double y1, double yp1, double x2, double y2, double yp2, double x) =>
-            Interpolants.CubicHermiteInterpolant(x1, y1, yp1, x2, y2, yp2, x);
+            Functions.Interpolants.CubicHermiteInterpolant(x1, y1, yp1, x2, y2, yp2, x);
 
         private static void Clear(H1 h) => h.Clear();
     }

--- a/MechJebLib/Primitives/H3.cs
+++ b/MechJebLib/Primitives/H3.cs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-PD-hp OR Unlicense OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT OR LGPL-2.1+
  */
 
-using MechJebLib.Functions;
 using MechJebLib.Utils;
 
 namespace MechJebLib.Primitives
@@ -43,7 +42,7 @@ namespace MechJebLib.Primitives
         protected override void Addition(V3 a, V3 b, ref V3 result) => result = a + b;
 
         protected override V3 Interpolant(double x1, V3 y1, V3 yp1, double x2, V3 y2, V3 yp2, double x) =>
-            Interpolants.CubicHermiteInterpolant(x1, y1, yp1, x2, y2, yp2, x);
+            Functions.Interpolants.CubicHermiteInterpolant(x1, y1, yp1, x2, y2, yp2, x);
 
         private static void Clear(H3 h) => h.Clear();
     }

--- a/MechJebLib/Primitives/HBase.cs
+++ b/MechJebLib/Primitives/HBase.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using MechJebLib.Interpolants;
 using static System.Math;
 
 namespace MechJebLib.Primitives
@@ -14,8 +15,8 @@ namespace MechJebLib.Primitives
         // UnityCompat does no extrapolation outside of MinTime/MaxTime
         public bool UnityCompat;
 
-        public double MinTime = double.MaxValue;
-        public double MaxTime = double.MinValue;
+        public double MinT { get; protected set; } = double.MaxValue;
+        public double MaxT { get; protected set; } = double.MinValue;
 
         protected int LastLo = -1;
 
@@ -24,8 +25,8 @@ namespace MechJebLib.Primitives
         public void Add(double time, T value)
         {
             _list[time] = new HFrame<T>(time, Allocate(value), Allocate(), Allocate(), true);
-            MinTime = Min(MinTime, time);
-            MaxTime = Max(MaxTime, time);
+            MinT = Min(MinT, time);
+            MaxT = Max(MaxT, time);
             RecomputeTangents(_list.IndexOfKey(time));
             LastLo = -1;
         }
@@ -33,8 +34,8 @@ namespace MechJebLib.Primitives
         public void Add(double time, T value, T inTangent, T outTangent)
         {
             _list[time] = new HFrame<T>(time, Allocate(value), Allocate(inTangent), Allocate(outTangent));
-            MinTime = Min(MinTime, time);
-            MaxTime = Max(MaxTime, time);
+            MinT = Min(MinT, time);
+            MaxT = Max(MaxT, time);
             LastLo = -1;
         }
 
@@ -59,10 +60,10 @@ namespace MechJebLib.Primitives
             if (_list.Count <= 1)
                 throw new ApplicationException("FindIndex called on interpolant with less than 2 values.");
 
-            if (value <= MinTime)
+            if (value <= MinT)
                 throw new ApplicationException("FindIndex called value below min value.");
 
-            if (value >= MaxTime)
+            if (value >= MaxT)
                 throw new ApplicationException("FindIndex called value above max value.");
 
             // acceleration for sequential access
@@ -204,24 +205,24 @@ namespace MechJebLib.Primitives
             if (_list.Count == 0)
                 return Allocate();
 
-            if (t <= MinTime)
+            if (t <= MinT)
             {
                 if (UnityCompat)
                     return Allocate(_list.Values[0].Value);
 
                 T ret = Allocate();
-                Multiply(_list.Values[0].InTangent, MinTime - t, ref ret);
+                Multiply(_list.Values[0].InTangent, MinT - t, ref ret);
                 Subtract(_list.Values[0].Value, ret, ref ret);
                 return ret;
             }
 
-            if (t >= MaxTime)
+            if (t >= MaxT)
             {
                 if (UnityCompat)
                     return Allocate(_list.Values[_list.Count - 1].Value);
 
                 T ret = Allocate();
-                Multiply(_list.Values[_list.Count - 1].OutTangent, t - MaxTime, ref ret);
+                Multiply(_list.Values[_list.Count - 1].OutTangent, t - MaxT, ref ret);
                 Addition(_list.Values[_list.Count - 1].Value, ret, ref ret);
                 return ret;
             }
@@ -253,8 +254,8 @@ namespace MechJebLib.Primitives
         public virtual void Clear()
         {
             _list.Clear();
-            MinTime = double.MaxValue;
-            MaxTime = double.MinValue;
+            MinT = double.MaxValue;
+            MaxT = double.MinValue;
             LastLo = -1;
         }
 

--- a/MechJebLib/Primitives/Hn.cs
+++ b/MechJebLib/Primitives/Hn.cs
@@ -4,12 +4,13 @@
  */
 
 using System.Collections.Generic;
+using MechJebLib.Interpolants;
 using MechJebLib.Utils;
 using static System.Math;
 
 namespace MechJebLib.Primitives
 {
-    public class Hn : HBase<Vec>
+    public class Hn : HBase<Vec>, IInterpolant
     {
         public int N;
 
@@ -20,8 +21,8 @@ namespace MechJebLib.Primitives
         public void Add(double time, double[] value, double[] inTangent, double[] outTangent)
         {
             _list[time] = new HFrame<Vec>(time, Allocate(value), Allocate(inTangent), Allocate(outTangent));
-            MinTime = Min(MinTime, time);
-            MaxTime = Max(MaxTime, time);
+            MinT = Min(MinT, time);
+            MaxT = Max(MaxT, time);
             RecomputeTangents(_list.IndexOfKey(time));
             LastLo = -1;
         }
@@ -116,8 +117,8 @@ namespace MechJebLib.Primitives
                 DisposeKeyframe(_list.Values[i]);
             }
 
-            MinTime = double.MaxValue;
-            MaxTime = double.MinValue;
+            MinT = double.MaxValue;
+            MaxT = double.MinValue;
             LastLo = -1;
             _list.Clear();
         }

--- a/MechJebLibTest/ManeuversTests/TwoImpulseTransferTests.cs
+++ b/MechJebLibTest/ManeuversTests/TwoImpulseTransferTests.cs
@@ -8,6 +8,7 @@ using MechJebLib.Functions;
 using MechJebLib.Maneuvers;
 using MechJebLib.Primitives;
 using MechJebLib.TwoBody;
+using MechJebLib.Utils;
 using Xunit;
 using Xunit.Abstractions;
 using static System.Math;
@@ -27,6 +28,8 @@ namespace MechJebLibTest.ManeuversTests
         [Fact]
         private void HohmannTest()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
+
             const int NTRIALS = 50;
 
             var random = new Random();
@@ -74,6 +77,8 @@ namespace MechJebLibTest.ManeuversTests
         [Fact]
         private void GeoTestFixed()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
+
             double mu = 3.986004418e+14;
             var    r1 = new V3(5673188.62234991, 1106269.57811856, 3093900.30098098);
             var    v1 = new V3(-1154.38931594925, 7685.58250511721, -631.330049272638);
@@ -97,6 +102,8 @@ namespace MechJebLibTest.ManeuversTests
         [Fact]
         private void GeoTestFree()
         {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
+
             double mu = 3.986004418e+14;
             var    r1 = new V3(5673188.62234991, 1106269.57811856, 3093900.30098098);
             var    v1 = new V3(-1154.38931594925, 7685.58250511721, -631.330049272638);

--- a/MechJebLibTest/ODETests/BS3Tests.cs
+++ b/MechJebLibTest/ODETests/BS3Tests.cs
@@ -69,7 +69,7 @@ namespace MechJebLibTest.ODETests
             int count1 = random.Next(20, 40);
             int count2 = random.Next(5, 40);
 
-            var solver = new BS3 { Interpnum = count1, Rtol = 1e-5, Atol = 1e-5, Maxiter = 200000 };
+            var solver = new BS3 { Rtol = 1e-5, Atol = 1e-5, Maxiter = 500, ThrowOnMaxIter = true};
             var ode    = new SimpleOscillator(k, m);
             var f      = new Action<Vec, double, Vec>(ode.dydt);
 
@@ -102,10 +102,10 @@ namespace MechJebLibTest.ODETests
             {
                 double t = t0 + dt * i;
                 solver.Solve(f, y0, yf, t0, t);
-                yf[0].ShouldEqual(expected[i], 4e-6);
+                yf[0].ShouldEqual(expected[i], 1e-5);
             }
 
-            using (var interpolant = Hn.Get(SimpleOscillator.N))
+            using (var interpolant = DenseOutput.Rent())
             {
                 solver.Solve(f, y0, yf, t0, tf, interpolant);
 
@@ -122,13 +122,13 @@ namespace MechJebLibTest.ODETests
                     double    t = t0 + dt2 * i;
                     using Vec y = interpolant.Evaluate(t);
 
-                    y[0].ShouldEqual(expected2[i], 2e-2);
+                    y[0].ShouldEqual(expected2[i], 4e-6);
                 }
             }
 
             long start = GC.GetAllocatedBytesForCurrentThread();
 
-            using (var interpolant = Hn.Get(SimpleOscillator.N))
+            using (var interpolant = DenseOutput.Rent())
             {
                 solver.Solve(f, y0, yf, t0, tf, interpolant);
 
@@ -145,7 +145,7 @@ namespace MechJebLibTest.ODETests
                     double    t = t0 + dt2 * i;
                     using Vec y = interpolant.Evaluate(t);
 
-                    y[0].ShouldEqual(expected2[i], 2e-2);
+                    y[0].ShouldEqual(expected2[i], 4e-6);
                 }
             }
 

--- a/MechJebLibTest/ODETests/DP5Tests.cs
+++ b/MechJebLibTest/ODETests/DP5Tests.cs
@@ -69,7 +69,7 @@ namespace MechJebLibTest.ODETests
             int count1 = random.Next(20, 40);
             int count2 = random.Next(5, 40);
 
-            var solver = new DP5 { Interpnum = count1, Rtol = 1e-9, Atol = 0, Maxiter = 2000 };
+            var solver = new DP5 { Rtol = 1e-9, Atol = 0, Maxiter = 400, ThrowOnMaxIter = true };
             var ode    = new SimpleOscillator(k, m);
             var f      = new Action<Vec, double, Vec>(ode.dydt);
 
@@ -102,10 +102,10 @@ namespace MechJebLibTest.ODETests
             {
                 double t = t0 + dt * i;
                 solver.Solve(f, y0, yf, t0, t);
-                yf[0].ShouldEqual(expected[i], 4e-6);
+                yf[0].ShouldEqual(expected[i], 1e-11);
             }
 
-            using (var interpolant = Hn.Get(SimpleOscillator.N))
+            using (var interpolant = DenseOutput.Rent())
             {
                 solver.Solve(f, y0, yf, t0, tf, interpolant);
 
@@ -114,7 +114,7 @@ namespace MechJebLibTest.ODETests
                     double    t = t0 + dt * i;
                     using Vec y = interpolant.Evaluate(t);
 
-                    y[0].ShouldEqual(expected[i], 4e-6);
+                    y[0].ShouldEqual(expected[i], 1e-11);
                 }
 
                 for (int i = 0; i <= count2; i++)
@@ -122,13 +122,13 @@ namespace MechJebLibTest.ODETests
                     double    t = t0 + dt2 * i;
                     using Vec y = interpolant.Evaluate(t);
 
-                    y[0].ShouldEqual(expected2[i], 2e-2);
+                    y[0].ShouldEqual(expected2[i], 1e-11);
                 }
             }
 
             long start = GC.GetAllocatedBytesForCurrentThread();
 
-            using (var interpolant = Hn.Get(SimpleOscillator.N))
+            using (var interpolant = DenseOutput.Rent())
             {
                 solver.Solve(f, y0, yf, t0, tf, interpolant);
 
@@ -137,7 +137,7 @@ namespace MechJebLibTest.ODETests
                     double    t = t0 + dt * i;
                     using Vec y = interpolant.Evaluate(t);
 
-                    y[0].ShouldEqual(expected[i], 4e-6);
+                    y[0].ShouldEqual(expected[i], 1e-11);
                 }
 
                 for (int i = 0; i <= count2; i++)
@@ -145,7 +145,7 @@ namespace MechJebLibTest.ODETests
                     double    t = t0 + dt2 * i;
                     using Vec y = interpolant.Evaluate(t);
 
-                    y[0].ShouldEqual(expected2[i], 2e-2);
+                    y[0].ShouldEqual(expected2[i], 1e-11);
                 }
             }
 

--- a/MechJebLibTest/ODETests/Tsit5Tests.cs
+++ b/MechJebLibTest/ODETests/Tsit5Tests.cs
@@ -69,7 +69,7 @@ namespace MechJebLibTest.ODETests
             int count1 = random.Next(20, 40);
             int count2 = random.Next(5, 40);
 
-            var solver = new Tsit5 { Interpnum = count1, Rtol = 1e-9, Atol = 0, Maxiter = 2000 };
+            var solver = new Tsit5 { Rtol = 1e-9, Atol = 0, Maxiter = 400, ThrowOnMaxIter = true };
             var ode    = new SimpleOscillator(k, m);
             var f      = new Action<Vec, double, Vec>(ode.dydt);
 
@@ -102,10 +102,10 @@ namespace MechJebLibTest.ODETests
             {
                 double t = t0 + dt * i;
                 solver.Solve(f, y0, yf, t0, t);
-                yf[0].ShouldEqual(expected[i], 4e-6);
+                yf[0].ShouldEqual(expected[i], 1e-11);
             }
 
-            using (var interpolant = Hn.Get(SimpleOscillator.N))
+            using (var interpolant = DenseOutput.Rent())
             {
                 solver.Solve(f, y0, yf, t0, tf, interpolant);
 
@@ -114,7 +114,7 @@ namespace MechJebLibTest.ODETests
                     double    t = t0 + dt * i;
                     using Vec y = interpolant.Evaluate(t);
 
-                    y[0].ShouldEqual(expected[i], 4e-6);
+                    y[0].ShouldEqual(expected[i], 1e-11);
                 }
 
                 for (int i = 0; i <= count2; i++)
@@ -122,13 +122,13 @@ namespace MechJebLibTest.ODETests
                     double    t = t0 + dt2 * i;
                     using Vec y = interpolant.Evaluate(t);
 
-                    y[0].ShouldEqual(expected2[i], 2e-2);
+                    y[0].ShouldEqual(expected2[i], 1e-11);
                 }
             }
 
             long start = GC.GetAllocatedBytesForCurrentThread();
 
-            using (var interpolant = Hn.Get(SimpleOscillator.N))
+            using (var interpolant = DenseOutput.Rent())
             {
                 solver.Solve(f, y0, yf, t0, tf, interpolant);
 
@@ -137,7 +137,7 @@ namespace MechJebLibTest.ODETests
                     double    t = t0 + dt * i;
                     using Vec y = interpolant.Evaluate(t);
 
-                    y[0].ShouldEqual(expected[i], 4e-6);
+                    y[0].ShouldEqual(expected[i], 1e-11);
                 }
 
                 for (int i = 0; i <= count2; i++)
@@ -145,7 +145,7 @@ namespace MechJebLibTest.ODETests
                     double    t = t0 + dt2 * i;
                     using Vec y = interpolant.Evaluate(t);
 
-                    y[0].ShouldEqual(expected2[i], 2e-2);
+                    y[0].ShouldEqual(expected2[i], 1e-11);
                 }
             }
 


### PR DESCRIPTION
Finally upgrades the ODE solver to use the actual interpolants from the RK method to create proper DenseOutput instead of cargo culting the Hermite interpolating polynomials I've been using for ages now.