### PR TITLE
Drop V3 overflow-sensitive normalization

### DIFF
--- a/MechJebLib/Primitives/V3.cs
+++ b/MechJebLib/Primitives/V3.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using MechJebLib.Utils;
 using static MechJebLib.Utils.Statics;
 using static System.Math;
@@ -143,7 +144,6 @@ namespace MechJebLib.Primitives
 
         public static M3 Outer(V3 v1, V3 v2) => new M3(v1 * v2.x, v1 * v2.y, v1 * v2.z);
 
-        // FIXME: precision
         public static V3 Project(V3 vector, V3 onNormal)
         {
             double invC = 1.0 / Math.Max(vector.max_magnitude, onNormal.max_magnitude);
@@ -153,6 +153,7 @@ namespace MechJebLib.Primitives
             V3 onNormalC = onNormal * invC;
 
             double invSqrMag = 1.0 / Dot(onNormalC, onNormalC);
+            if (double.IsPositiveInfinity(invSqrMag)) return zero;
 
             double dot = Dot(vectorC, onNormalC);
             return onNormal * dot * invSqrMag;
@@ -209,12 +210,12 @@ namespace MechJebLib.Primitives
             V3 from_scaled = from / c;
             V3 to_scaled   = to / c;
 
-            double denominator = from_scaled._internal_magnitude * to_scaled._internal_magnitude;
+            double denominator = from_scaled.magnitude * to_scaled.magnitude;
             if (denominator <= 0) return 0;
 
             V3 cross_scaled = Cross(from_scaled, to_scaled);
 
-            double sinAngle = cross_scaled._internal_magnitude / denominator;
+            double sinAngle = cross_scaled.magnitude / denominator;
             double cosAngle = Dot(from_scaled, to_scaled) / denominator;
 
             return Atan2(sinAngle, cosAngle);
@@ -265,25 +266,28 @@ namespace MechJebLib.Primitives
             }
         }
 
-        private double _internal_magnitude => Math.Sqrt(x * x + y * y + z * z);
-
-        private V3 _internal_normalize => this / _internal_magnitude;
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Magnitude(V3 vector) => vector.magnitude;
 
-        public static V3 Normalize(V3 value)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static V3 Normalize(V3 v)
         {
-            double c = value.max_magnitude;
-            return c > 0 ? (value / c)._internal_normalize : zero;
+            double norm = v.magnitude;
+            return norm > 0 ? v / norm : zero;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Normalize()
         {
-            double c = max_magnitude;
-            this = c > 0 ? (this / c)._internal_normalize : zero;
+            double norm = Math.Sqrt(x * x + y * y + z * z);
+            this = norm > 0 ? this / norm : zero;
         }
 
-        public V3 normalized => Normalize(this);
+        public V3 normalized
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Normalize(this);
+        }
 
         public static void OrthoNormalize(ref V3 normal, ref V3 tangent)
         {
@@ -297,16 +301,18 @@ namespace MechJebLib.Primitives
 
         public double magnitude
         {
-            get
-            {
-                double c = max_magnitude;
-                return c > 0 ? Math.Max(c, c * (this / c)._internal_magnitude) : 0;
-            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Math.Sqrt(x * x + y * y + z * z);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double SqrMagnitude(V3 vector) => vector.sqrMagnitude;
 
-        public double sqrMagnitude => x * x + y * y + z * z;
+        public double sqrMagnitude
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => x * x + y * y + z * z;
+        }
 
         public static V3 zero { get; } = new V3(0.0, 0.0, 0.0);
 

--- a/MechJebLibTest/ManeuversTests/TwoImpulseTransferTests.cs
+++ b/MechJebLibTest/ManeuversTests/TwoImpulseTransferTests.cs
@@ -118,9 +118,9 @@ namespace MechJebLibTest.ManeuversTests
 
             dv1.magnitude.ShouldEqual(2484.20137552452, 1e-4);
             dv2.magnitude.ShouldEqual(1793.10206031673, 1e-4);
-            dt1.ShouldEqual(1177.74844650851, 1e-4);
+            dt1.ShouldEqual(1177.74844650851, 1e-3);
             inc.ShouldEqual(Deg2Rad(26.440413305834294), 1e-4);
-            dt2.ShouldEqual(20097.46881536536, 1e-4);
+            dt2.ShouldEqual(20097.46881536536, 1e-3);
         }
     }
 }

--- a/MechJebLibTest/Primitives/V3Tests/CoordinateConversionTests.cs
+++ b/MechJebLibTest/Primitives/V3Tests/CoordinateConversionTests.cs
@@ -204,19 +204,6 @@ namespace MechJebLibTest.Primitives.V3Tests
         }
 
         [Fact]
-        private void CartesianToSphericalRhoOverflow()
-        {
-            const double LARGE = 1.5e154;
-            var          v     = new V3(LARGE, LARGE, LARGE);
-
-            V3 result = v.cart2sph;
-
-            result.x.ShouldEqual(LARGE * Sqrt(3));
-            result.y.ShouldEqual(V3.Angle(new V3(0, 0, 1), new V3(1, 1, 1)));
-            result.z.ShouldEqual(PI / 4);
-        }
-
-        [Fact]
         private void SphericalCartesianRoundTrip()
         {
             var original   = new V3(3, 4, 5);

--- a/MechJebLibTest/Primitives/V3Tests/MagnitudeNormalizationTests.cs
+++ b/MechJebLibTest/Primitives/V3Tests/MagnitudeNormalizationTests.cs
@@ -5,7 +5,6 @@
 
 using MechJebLib.Primitives;
 using Xunit;
-using static MechJebLib.Utils.Statics;
 using static System.Math;
 
 namespace MechJebLibTest.Primitives.V3Tests
@@ -44,17 +43,6 @@ namespace MechJebLibTest.Primitives.V3Tests
         }
 
         [Fact]
-        private void MagnitudeOfVeryLargeVectors()
-        {
-            const double LARGE = 1e190;
-            new V3(LARGE, 0, 0).magnitude.ShouldEqual(LARGE);
-            new V3(LARGE, LARGE, LARGE).magnitude.ShouldEqual(Sqrt(3) * LARGE);
-
-            const double NEAR_MAX = 1e308;
-            new V3(NEAR_MAX, 0, 0).magnitude.ShouldEqual(NEAR_MAX);
-        }
-
-        [Fact]
         private void MagnitudeOfVerySmallVectors()
         {
             const double SMALL = 1e-190;
@@ -63,26 +51,6 @@ namespace MechJebLibTest.Primitives.V3Tests
 
             const double TINY = 1e-300;
             new V3(TINY, 0, 0).magnitude.ShouldEqual(TINY);
-        }
-
-        [Fact]
-        private void MagnitudeAvoidingOverflow()
-        {
-            const double LARGE = 1e200;
-            var          v     = new V3(LARGE, LARGE, LARGE);
-
-            v.magnitude.ShouldEqual(Sqrt(3) * LARGE);
-            Assert.True(IsFinite(v.magnitude));
-        }
-
-        [Fact]
-        private void MagnitudeAvoidingUnderflow()
-        {
-            const double SMALL = 1e-200;
-            var          v     = new V3(SMALL, SMALL, SMALL);
-
-            v.magnitude.ShouldEqual(Sqrt(3) * SMALL);
-            Assert.True(v.magnitude > 0);
         }
 
         [Fact]
@@ -137,42 +105,6 @@ namespace MechJebLibTest.Primitives.V3Tests
         {
             V3.zero.normalized.ShouldEqual(V3.zero);
             new V3(0, 0, 0).normalized.ShouldEqual(V3.zero);
-        }
-
-        [Fact]
-        private void NormalizeVeryLargeVectors()
-        {
-            const double LARGE = 1e190;
-
-            var v = new V3(LARGE, 0, 0);
-
-            v.normalized.ShouldEqual(new V3(1, 0, 0));
-
-            var v2 = new V3(LARGE, LARGE, LARGE);
-            V3  n2 = v2.normalized;
-
-            n2.x.ShouldEqual(1.0 / Sqrt(3));
-            n2.y.ShouldEqual(1.0 / Sqrt(3));
-            n2.z.ShouldEqual(1.0 / Sqrt(3));
-            n2.magnitude.ShouldEqual(1.0);
-        }
-
-        [Fact]
-        private void NormalizeVerySmallVectors()
-        {
-            const double SMALL = 1e-190;
-
-            var v = new V3(SMALL, 0, 0);
-
-            v.normalized.ShouldEqual(new V3(1, 0, 0));
-
-            var v2 = new V3(SMALL, SMALL, SMALL);
-            V3  n2 = v2.normalized;
-
-            n2.x.ShouldEqual(1.0 / Sqrt(3));
-            n2.y.ShouldEqual(1.0 / Sqrt(3));
-            n2.z.ShouldEqual(1.0 / Sqrt(3));
-            n2.magnitude.ShouldEqual(1.0);
         }
 
         [Fact]
@@ -244,20 +176,6 @@ namespace MechJebLibTest.Primitives.V3Tests
             var clamped = V3.ClampMagnitude(v, 0);
 
             clamped.ShouldEqual(V3.zero);
-        }
-
-        [Fact]
-        private void ClampMagnitudeLargeVectors()
-        {
-            const double LARGE = 1e190;
-
-            var v       = new V3(LARGE, LARGE, LARGE);
-            var clamped = V3.ClampMagnitude(v, 1e189);
-
-            clamped.magnitude.ShouldEqual(1e189);
-            Assert.True(IsFinite(clamped.x));
-            Assert.True(IsFinite(clamped.y));
-            Assert.True(IsFinite(clamped.z));
         }
 
         [Fact]

--- a/MechJebLibTest/Primitives/V3Tests/VectorMathOperationTests.cs
+++ b/MechJebLibTest/Primitives/V3Tests/VectorMathOperationTests.cs
@@ -372,17 +372,6 @@ namespace MechJebLibTest.Primitives.V3Tests
         }
 
         [Fact]
-        private void DistanceOverflowWithLargeDifferences()
-        {
-            var a = new V3(1e200, 1e200, 1e200);
-            var b = new V3(-1e200, -1e200, -1e200);
-
-            double distance = V3.Distance(a, b);
-
-            distance.ShouldEqual(Sqrt(3) * 2e200);
-        }
-
-        [Fact]
         private void OrthoNormalizeBasicVectors()
         {
             var normal  = new V3(1, 1, 0);


### PR DESCRIPTION
This actually significantly impacts Hoverslam performance in the flame graphs.