### PR TITLE
Turn off atmo cumulative dv on long display

### DIFF
--- a/MechJeb2/MechJebStageStatsHelper.cs
+++ b/MechJeb2/MechJebStageStatsHelper.cs
@@ -423,6 +423,7 @@ namespace MuMech
                     break;
                 case 1:
                     SetAllStageVisibility(true);
+                    stageVisibility[StageData.AtmoCumulativeDeltaV] = false;
                     stageVisibility[StageData.AtmoMaxTWR] = false;
                     stageVisibility[StageData.Thrust] = false;
                     stageVisibility[StageData.StagedMass] = false;


### PR DESCRIPTION
This one is much less useful than vac.