### PR TITLE
Add RCS Ullage Time to FuelStats

### DIFF
--- a/MechJeb2/MechJebModuleInfoItems.cs
+++ b/MechJeb2/MechJebModuleInfoItems.cs
@@ -755,6 +755,9 @@ namespace MuMech
         public bool showControllableMass = false;
 
         [Persistent(pass = (int)Pass.GLOBAL)]
+        public bool showRcsUllageTime = false;
+
+        [Persistent(pass = (int)Pass.GLOBAL)]
         public bool showTime = true;
 
         [Persistent(pass = (int)Pass.GLOBAL)]

--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -548,7 +548,7 @@ namespace MuMech
             /* prevent unstable ignitions */
             if (LimitToPreventUnstableIgnition && s.mainThrottle > 0.0F && ThrottleLimit > 0.0F)
             {
-                if (VesselState.lowestUllage < 0.95) // needs to match 'unstable' value in RF
+                if (VesselState.lowestUllage < 0.996) // prevent ignition if there is any chance of failure
                 {
                     ScreenMessages.PostScreenMessage(_preventingUnstableIgnitionsMessage);
                     Debug.Log("MechJeb Unstable Ignitions: preventing ignition in state: " + VesselState.lowestUllage);
@@ -903,7 +903,7 @@ namespace MuMech
             if (!Vessel.hasEnabledRCSModules())
                 return;
 
-            bool stableUllage = VesselState.lowestUllage >= 1.0;
+            bool stableUllage = VesselState.lowestUllage >= 0.996;
 
             // ullage may dramatically drop below stable (by as much as to 0.76 in a single tick) so
             // we cannot "detect" low ullage and compensate, but must apply RCS until thrust has come

--- a/MechJeb2/MechJebStageStatsHelper.cs
+++ b/MechJeb2/MechJebStageStatsHelper.cs
@@ -25,7 +25,7 @@ namespace MuMech
 
         private bool showStagedMass, showBurnedMass, showInitialMass, showFinalMass, showThrust, showVacInitialTWR, showAtmoInitialTWR;
         private bool showAtmoMaxTWR, showVacMaxTWR, showAtmoDeltaV, showVacDeltaV, showTime, showISP, showEmpty, showRcs, timeSeconds, liveSLT;
-        private bool showAtmoCumulativeDeltaV, showVacCumulativeDeltaV, showControllableMass;
+        private bool showAtmoCumulativeDeltaV, showVacCumulativeDeltaV, showControllableMass, showRcsUllageTime;
         private int TWRBody;
         private float altSLTScale, machScale;
         private int StageDisplayState { get => infoItems.StageDisplayState; set => infoItems.StageDisplayState = value; }
@@ -51,6 +51,7 @@ namespace MuMech
             showAtmoCumulativeDeltaV = items.showAtmoCumulativeDeltaV;
             showVacCumulativeDeltaV = items.showVacCumulativeDeltaV;
             showControllableMass = items.showControllableMass;
+            showRcsUllageTime = items.showRcsUllageTime;
             showTime = items.showTime;
             showISP = items.showISP;
             showThrust = items.showThrust;
@@ -72,7 +73,7 @@ namespace MuMech
         private enum StageData
         {
             KSPStage, InitialMass, FinalMass, StagedMass, BurnedMass, Thrust, VacInitialTWR, VacMaxTWR, AtmoInitialTWR, AtmoMaxTWR,
-            Isp, AtmoDeltaV, VacDeltaV, Time, AtmoCumulativeDeltaV, VacCumulativeDeltaV, ControllableMass
+            Isp, AtmoDeltaV, VacDeltaV, Time, AtmoCumulativeDeltaV, VacCumulativeDeltaV, ControllableMass, RcsUllageTime,
         }
 
         private static readonly List<StageData> AllStages = new List<StageData>
@@ -89,6 +90,7 @@ namespace MuMech
             StageData.AtmoInitialTWR,
             StageData.AtmoMaxTWR,
             StageData.Isp,
+            StageData.RcsUllageTime,
             StageData.AtmoCumulativeDeltaV,
             StageData.VacCumulativeDeltaV,
             StageData.AtmoDeltaV,
@@ -127,6 +129,7 @@ namespace MuMech
 
             stageHeaderData.Clear();
             stageHeaderData.Add(StageData.KSPStage, "Stage" + SPACING);
+            stageHeaderData.Add(StageData.ControllableMass, "Avionics" + SPACING);
             stageHeaderData.Add(StageData.InitialMass, CachedLocalizer.Instance.MechJebInfoItemsStatsColumn1 + SPACING);
             stageHeaderData.Add(StageData.FinalMass, CachedLocalizer.Instance.MechJebInfoItemsStatsColumn2 + SPACING);
             stageHeaderData.Add(StageData.StagedMass, CachedLocalizer.Instance.MechJebInfoItemsStatsColumn3 + SPACING);
@@ -137,7 +140,7 @@ namespace MuMech
             stageHeaderData.Add(StageData.AtmoInitialTWR, CachedLocalizer.Instance.MechJebInfoItemsStatsColumn7 + SPACING);
             stageHeaderData.Add(StageData.AtmoMaxTWR, CachedLocalizer.Instance.MechJebInfoItemsStatsColumn8 + SPACING);
             stageHeaderData.Add(StageData.Isp, CachedLocalizer.Instance.MechJebInfoItemsStatsColumn9 + SPACING);
-            stageHeaderData.Add(StageData.ControllableMass, "Avionics" + SPACING);
+            stageHeaderData.Add(StageData.RcsUllageTime, "RCS Ullage" + SPACING);
             stageHeaderData.Add(StageData.AtmoDeltaV, (showRcs ? "RCS ∆Vmin" : CachedLocalizer.Instance.MechJebInfoItemsStatsColumn10) + SPACING);
             stageHeaderData.Add(StageData.VacDeltaV, (showRcs ? "RCS ∆Vmax" : CachedLocalizer.Instance.MechJebInfoItemsStatsColumn11) + SPACING);
             stageHeaderData.Add(StageData.AtmoCumulativeDeltaV, "Σ Atmo ∆V" + SPACING);
@@ -205,6 +208,7 @@ namespace MuMech
                 int currentStageIndex = stages.IndexOf(index);
 
                 stageDisplayInfo[StageData.KSPStage].Add($"{stats.AtmoStats[index].KSPStage}   ");
+                if (stageVisibility[StageData.ControllableMass]) stageDisplayInfo[StageData.ControllableMass].Add($"{stats.AtmoStats[index].ControllableMass:F3} t   ");
                 if (stageVisibility[StageData.InitialMass])
                     stageDisplayInfo[StageData.InitialMass].Add($"{stats.AtmoStats[index].StartMass:F3} t   ");
                 if (stageVisibility[StageData.FinalMass]) stageDisplayInfo[StageData.FinalMass].Add($"{stats.AtmoStats[index].EndMass:F3} t   ");
@@ -220,7 +224,9 @@ namespace MuMech
                 if (stageVisibility[StageData.AtmoMaxTWR])
                     stageDisplayInfo[StageData.AtmoMaxTWR].Add($"{_atmoEndTWR(index, geeASL):F2}   ");
                 if (stageVisibility[StageData.Isp]) stageDisplayInfo[StageData.Isp].Add($"{_isp(index):F2}   ");
-                if (stageVisibility[StageData.ControllableMass]) stageDisplayInfo[StageData.ControllableMass].Add($"{stats.AtmoStats[index].ControllableMass:F3} t   ");
+                if (stageVisibility[StageData.RcsUllageTime]) stageDisplayInfo[StageData.RcsUllageTime].Add(timeSeconds
+                    ? $"{stats.AtmoStats[index].RcsUllageTime:F2}s   "
+                    : $"{GuiUtils.TimeToDHMS(stats.AtmoStats[index].RcsUllageTime, 1)}   ");
                 if (stageVisibility[StageData.AtmoDeltaV]) stageDisplayInfo[StageData.AtmoDeltaV].Add($"{_atmoDv(index):F0} m/s   ");
                 if (stageVisibility[StageData.VacDeltaV]) stageDisplayInfo[StageData.VacDeltaV].Add($"{_vacDv(index):F0} m/s   ");
                 if (stageVisibility[StageData.AtmoCumulativeDeltaV])
@@ -395,6 +401,7 @@ namespace MuMech
             stageVisibility[StageData.AtmoCumulativeDeltaV] = showAtmoCumulativeDeltaV;
             stageVisibility[StageData.VacCumulativeDeltaV] = showVacCumulativeDeltaV;
             stageVisibility[StageData.ControllableMass] = showControllableMass;
+            stageVisibility[StageData.RcsUllageTime] = showRcsUllageTime;
         }
 
         private void SaveStageVisibility()
@@ -415,6 +422,7 @@ namespace MuMech
             showAtmoCumulativeDeltaV = infoItems.showAtmoCumulativeDeltaV = stageVisibility[StageData.AtmoCumulativeDeltaV];
             showVacCumulativeDeltaV = infoItems.showVacCumulativeDeltaV = stageVisibility[StageData.VacCumulativeDeltaV];
             showControllableMass = infoItems.showControllableMass = stageVisibility[StageData.ControllableMass];
+            showRcsUllageTime = infoItems.showRcsUllageTime = stageVisibility[StageData.RcsUllageTime];
         }
 
         private void SetVisibility(int state)
@@ -434,6 +442,7 @@ namespace MuMech
                 case 1:
                     SetAllStageVisibility(true);
                     stageVisibility[StageData.ControllableMass] = _isLoadedRP0;
+                    stageVisibility[StageData.RcsUllageTime] = _isLoadedRP0;
                     stageVisibility[StageData.AtmoCumulativeDeltaV] = false;
                     stageVisibility[StageData.AtmoMaxTWR] = false;
                     stageVisibility[StageData.Thrust] = false;
@@ -443,6 +452,7 @@ namespace MuMech
                     break;
                 case 2:
                     SetAllStageVisibility(true);
+                    stageVisibility[StageData.RcsUllageTime] = _isLoadedRP0;
                     stageVisibility[StageData.ControllableMass] = _isLoadedRP0;
                     break;
                 case 3:

--- a/MechJebLib/FuelFlowSimulation/FuelFlowSimulation.cs
+++ b/MechJebLib/FuelFlowSimulation/FuelFlowSimulation.cs
@@ -94,9 +94,27 @@ namespace MechJebLib.FuelFlowSimulation
                 p.UnapplyRCSDrains();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ComputeRcsMinValues(SimVessel vessel) => SimulateRCS(vessel, false);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ComputeRcsMaxValues(SimVessel vessel) => SimulateRCS(vessel, true);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void ComputeRcsUllageTime(SimVessel vessel)
+        {
+            _currentSegment.RcsUllageTime = 0.0;
+
+            if (!vessel.ActiveEngineNeedsUllage()) return;
+
+            // FIXME: read this from RFSettings via reflection
+            double translateAxialCoefficientY = 1.5;
+            // magic calculation that gives time to ullage up to 0.996 guaranteed ignition
+            double a             = vessel.RcsThrust / vessel.Mass;
+            double rcsUllageTime = 0.35 / (translateAxialCoefficientY * a);
+
+            _currentSegment.RcsUllageTime = rcsUllageTime;
+        }
 
         private void SimulateStage(SimVessel vessel)
         {
@@ -106,6 +124,9 @@ namespace MechJebLib.FuelFlowSimulation
 
             GetNextSegment(vessel);
             ComputeRcsMinValues(vessel);
+
+            vessel.UpdateActiveRcs();
+            ComputeRcsUllageTime(vessel);
 
             UpdateResourceDrainsAndResiduals(vessel);
             double currentThrust = vessel.ThrustMagnitude;

--- a/MechJebLib/FuelFlowSimulation/FuelStats.cs
+++ b/MechJebLib/FuelFlowSimulation/FuelStats.cs
@@ -27,6 +27,7 @@ namespace MechJebLib.FuelFlowSimulation
         public double RcsMass;
         public double RcsStartTMR;
         public double RcsEndTMR;
+        public double RcsUllageTime;
         public double ControllableMass;
 
         public double MaxAccel     => EndMass > 0 ? Thrust / EndMass : 0;

--- a/MechJebLib/FuelFlowSimulation/PartModules/SimModuleEngines.cs
+++ b/MechJebLib/FuelFlowSimulation/PartModules/SimModuleEngines.cs
@@ -66,6 +66,7 @@ namespace MechJebLib.FuelFlowSimulation.PartModules
         public bool NoPropellants;
         public bool IsModuleEnginesRf;
         public bool IsUnrestartableDeadEngine;
+        public bool Ullage;
 
         public readonly H1 ThrustCurve = H1.Get(true);
         public readonly H1 ThrottleIspCurve = H1.Get(true);

--- a/MechJebLib/FuelFlowSimulation/SimVessel.cs
+++ b/MechJebLib/FuelFlowSimulation/SimVessel.cs
@@ -218,6 +218,18 @@ namespace MechJebLib.FuelFlowSimulation
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ActiveEngineNeedsUllage()
+        {
+            foreach (SimModuleEngines e in ActiveEngines)
+            {
+                if (e.Ullage)
+                    return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
             foreach (SimPart p in Parts)

--- a/MechJebLibBindings/FuelFlowSimulation/SimVesselBuilder.cs
+++ b/MechJebLibBindings/FuelFlowSimulation/SimVesselBuilder.cs
@@ -24,6 +24,7 @@ namespace MechJebLibBindings.FuelFlowSimulation
 
             private static readonly FieldInfo? _rfSpoolUpTime;
             private static readonly FieldInfo? _rfAutoCutoff;
+            private static readonly FieldInfo? _rfUllage;
             private static readonly FieldInfo? _rp0ControllableMass;
             private static readonly FieldInfo? _rp0MassLimit;
 
@@ -50,7 +51,7 @@ namespace MechJebLibBindings.FuelFlowSimulation
             {
                 _crewMassDelegate = Versioning.version_major == 1 && Versioning.version_minor < 11 ? (CrewMass)CrewMassOld : CrewMassNew;
 
-                if (ReflectionUtils.IsAssemblyLoaded("RealFuels"))
+                if (ReflectionUtils.IsLoadedRealFuels)
                 {
                     _rfSpoolUpTime = ReflectionUtils.GetFieldByReflection("RealFuels", "RealFuels.ModuleEnginesRF", "effectiveSpoolUpTime");
                     if (_rfSpoolUpTime == null)
@@ -63,9 +64,14 @@ namespace MechJebLibBindings.FuelFlowSimulation
                     if (_rfAutoCutoff == null)
                         Debug.Log(
                             "MechJeb BUG: RealFuels loaded, but RealFuels.ModuleEnginesRF has no autoCutoff field, disabling symmetric flameout.");
+
+                    _rfUllage = ReflectionUtils.GetFieldByReflection("RealFuels", "RealFuels.ModuleEnginesRF", "ullage");
+                    if (_rfUllage == null)
+                        Debug.Log(
+                            "MechJeb BUG: RealFuels loaded, but RealFuels.ModuleEnginesRF has no ullage field, disabling RCS Ullage Time calculation.");
                 }
 
-                if (ReflectionUtils.IsAssemblyLoaded("RP0"))
+                if (ReflectionUtils.IsLoadedRP0)
                 {
                     _rp0ControllableMass = ReflectionUtils.GetFieldByReflection("RP0", "RP0.ProceduralAvionics.ModuleProceduralAvionics", "controllableMass");
                     if (_rp0ControllableMass == null)
@@ -293,7 +299,7 @@ namespace MechJebLibBindings.FuelFlowSimulation
                 engine.ModuleSpoolupTime = 0;
                 engine.IsModuleEnginesRf = false;
 
-                if (ReflectionUtils.IsAssemblyLoaded("RealFuels"))
+                if (ReflectionUtils.IsLoadedRealFuels)
                 {
                     engine.IsModuleEnginesRf = _rfType != null && _rfType.IsInstanceOfType(kspEngine);
 
@@ -302,6 +308,9 @@ namespace MechJebLibBindings.FuelFlowSimulation
 
                     if (engine.IsModuleEnginesRf && _rfAutoCutoff?.GetValue(kspEngine) is bool boolVal)
                         engine.AutoCutoff = boolVal;
+
+                    if (engine.IsModuleEnginesRf && _rfUllage?.GetValue(kspEngine) is bool boolVal2)
+                        engine.Ullage = boolVal2;
                 }
 
                 return engine;

--- a/MechJebLibBindings/ReflectionUtils.cs
+++ b/MechJebLibBindings/ReflectionUtils.cs
@@ -16,6 +16,7 @@ namespace MechJebLibBindings
         public static readonly bool IsLoadedRealismOverhaul;
         public static readonly bool IsLoadedPrincipia;
         public static readonly bool IsLoadedFAR;
+        public static readonly bool IsLoadedRP0;
 
         static ReflectionUtils()
         {
@@ -24,6 +25,7 @@ namespace MechJebLibBindings
             IsLoadedPrincipia = IsAssemblyLoaded("principia.ksp_plugin_adapter");
             IsLoadedFAR = IsAssemblyLoaded("FerramAerospaceResearch");
             IsLoadedRealismOverhaul = IsAssemblyLoaded("RealismOverhaul");
+            IsLoadedRP0 = IsAssemblyLoaded("RP0");
         }
 
         public static bool IsAssemblyLoaded(string assemblyName)


### PR DESCRIPTION
Should be accurate amount of time required to go from zero stability to 100% reliable ignition.

Also resets the ignition stability checks in the ThrustController to 0.996 which is what RF rounds off to 100% stable / no failures.

This will make "prevent unstable ignitions" even more incompatible with sounding rockets, but it was already quite incompatible and was turned off by default.