### PR TITLE
FineTuneClosestApproachToCelestial improvements

### DIFF
--- a/MechJeb2/Maneuver/OperationCourseCorrection.cs
+++ b/MechJeb2/Maneuver/OperationCourseCorrection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using JetBrainsAnnotations::JetBrains.Annotations;
 using KSP.Localization;
 using UnityEngine;
+using static System.Math;
 
 namespace MuMech
 {
@@ -14,7 +15,15 @@ namespace MuMech
 
         [UsedImplicitly]
         [Persistent(pass = (int)Pass.GLOBAL)]
-        public EditableDoubleMult CourseCorrectFinalPeA = new EditableDoubleMult(200000, 1000);
+        public EditableDoubleMult Periapsis = new EditableDoubleMult(200000, 1000);
+
+        [UsedImplicitly]
+        [Persistent(pass = (int)Pass.GLOBAL)]
+        public EditableDouble Inclination = new EditableDouble(90);
+
+        [UsedImplicitly]
+        [Persistent(pass = (int)Pass.GLOBAL)]
+        public bool InclinationFlag;
 
         [UsedImplicitly]
         [Persistent(pass = (int)Pass.GLOBAL)]
@@ -23,16 +32,27 @@ namespace MuMech
         public override void DoParametersGUI(Orbit o, double universalTime, MechJebModuleTargetController target)
         {
             if (target.Target is CelestialBody)
-                GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_approach_label1"), CourseCorrectFinalPeA, "km"); //Approximate final periapsis
+            {
+                GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_approach_label1"), Periapsis, "km"); //Approximate final periapsis
+                GuiUtils.ToggledTextBox(ref InclinationFlag, "Inclination", Inclination, "°"); //Inclination
+            }
             else
+            {
                 GuiUtils.SimpleTextBox(Localizer.Format("#MechJeb_approach_label2"), InterceptDistance, "m"); //Closest approach distance
-            GUILayout.Label(Localizer.Format("#MechJeb_approach_label3")); //Schedule the burn to minimize the required ΔV.
+            }
+            GUILayout.Label(Localizer.Format("#MechJeb_approach_label3"));                       //Schedule the burn to minimize the required ΔV.
         }
 
         protected override List<ManeuverParameters> MakeNodesImpl(Orbit o, double ut, MechJebModuleTargetController target)
         {
             if (!target.NormalTargetExists)
                 throw new OperationException(Localizer.Format("#MechJeb_approach_Exception1")); //must select a target for the course correction.
+
+            // NOTE: it looks like this supports (e.g.) starting on a heliocentric course which intersects Jool, and then grabbing
+            // that patch and dropping a course correction on it to fine tune an encounter with Laythe.  Need to at least consider that
+            // use case and how close we need to be to Laythe.  It does not look like it supprorts dropping a maneuver on the helicentric
+            // trajectory to fine tune the Jool trajectory to intersect Laythe.  It is possible that we should demand that a transfer
+            // to Laythe is planned first and a maneuver node dropped in the Jool SOI to keep things simple here.
 
             Orbit correctionPatch = o;
             while (correctionPatch != null)
@@ -60,13 +80,21 @@ namespace MuMech
             }
 
             var targetBody = target.Target as CelestialBody;
-            Vector3d dV = targetBody != null
-                ? OrbitalManeuverCalculator.DeltaVAndTimeForCheapestCourseCorrection(o, ut, target.TargetOrbit, targetBody,
-                    targetBody.Radius + CourseCorrectFinalPeA, out ut)
-                : OrbitalManeuverCalculator.DeltaVAndTimeForCheapestCourseCorrection(o, ut, target.TargetOrbit, InterceptDistance, out ut);
+            // FIXME: add an explicit check that the current course intersects the SOI of the target body
 
+            Vector3d dV;
+            double   dt1 = 0;
+            double   dt2 = 0;
 
-            return new List<ManeuverParameters> { new ManeuverParameters(dV, ut) };
+            if (targetBody is null)
+                dV = OrbitalManeuverCalculator.DeltaVAndTimeForCheapestCourseCorrection(o, ut, target.TargetOrbit, InterceptDistance, out ut);
+            else
+            {
+                double inc = InclinationFlag ? Inclination.Val : double.NaN;
+                (dV, dt1, dt2) = OrbitalManeuverCalculator.DeltaVAndTimeForCourseCorrectionToCelestial(o, ut, targetBody, targetBody.Radius + Periapsis, inc);
+            }
+
+            return new List<ManeuverParameters> { new ManeuverParameters(dV, ut+dt1) };
         }
     }
 }

--- a/MechJeb2/OrbitalManeuverCalculator.cs
+++ b/MechJeb2/OrbitalManeuverCalculator.cs
@@ -7,6 +7,7 @@ using MechJebLibBindings;
 using Smooth.Pools;
 using UnityEngine;
 using static MechJebLib.Utils.Statics;
+using static System.Math;
 
 namespace MuMech
 {
@@ -220,34 +221,26 @@ namespace MuMech
             return dV;
         }
 
-        // This is the entry point for the course-correction to a target orbit which is a celestial
-        public static Vector3d DeltaVAndTimeForCheapestCourseCorrection(Orbit o, double UT, Orbit target, CelestialBody targetBody, double finalPeR,
-            out double burnUT)
+        public static (Vector3d dv, double dt1, double dt2) DeltaVAndTimeForCourseCorrectionToCelestial(Orbit o, double ut, CelestialBody targetBody, double per, double inc=double.NaN)
         {
-            Vector3d collisionDV = DeltaVAndTimeForCheapestCourseCorrection(o, UT, target, out burnUT);
-            Orbit collisionOrbit = o.PerturbedOrbit(burnUT, collisionDV);
-            double collisionUT = collisionOrbit.NextClosestApproachTime(target, burnUT);
-            Vector3d collisionPosition = target.WorldPositionAtUT(collisionUT);
-            Vector3d collisionRelVel = collisionOrbit.WorldOrbitalVelocityAtUT(collisionUT) - target.WorldOrbitalVelocityAtUT(collisionUT);
+            Orbit  target = targetBody.orbit;
+            double mu0    = o.referenceBody.gravParameter;
+            double mu1    = targetBody.gravParameter;
+            double soi    = targetBody.sphereOfInfluence;
+            double tsoi   = o.EndUT - ut;
 
-            double soiEnterUT = collisionUT - targetBody.sphereOfInfluence / collisionRelVel.magnitude;
-            Vector3d soiEnterRelVel = collisionOrbit.WorldOrbitalVelocityAtUT(soiEnterUT) - target.WorldOrbitalVelocityAtUT(soiEnterUT);
+            V3 r0 = o.RightHandedBCIPositionAtUT(ut);
+            V3 v0 = o.RightHandedOrbitalVelocityAtUT(ut);
+            V3 r1 = target.RightHandedBCIPositionAtUT(ut);
+            V3 v1 = target.RightHandedOrbitalVelocityAtUT(ut);
 
-            double E = 0.5 * soiEnterRelVel.sqrMagnitude -
-                       targetBody.gravParameter / targetBody.sphereOfInfluence; //total orbital energy on SoI enter
-            double finalPeSpeed =
-                Math.Sqrt(2 * (E + targetBody.gravParameter / finalPeR)); //conservation of energy gives the orbital speed at finalPeR.
-            double desiredImpactParameter =
-                finalPeR * finalPeSpeed / soiEnterRelVel.magnitude; //conservation of angular momentum gives the required impact parameter
+            //(V3 r0, V3 v0) = o.RightHandedStateVectorsAtUT(ut);
+            //(V3 r1, V3 v1) = target.RightHandedStateVectorsAtUT(ut);
 
-            Vector3d displacementDir = Vector3d.Cross(collisionRelVel, o.OrbitNormal()).normalized;
-            Vector3d interceptTarget = collisionPosition + desiredImpactParameter * displacementDir;
+            var maneuver = new FineTuneClosestApproachToCelestial();
+            (V3 dv, double dt1, double dt2) = maneuver.Maneuver(mu0, r0, v0, mu1, r1, v1, soi, tsoi, Max(per, 0), Deg2Rad(inc));
 
-            (V3 velAfterBurn, _) = Gooding.Solve(o.referenceBody.gravParameter, o.WorldBCIPositionAtUT(burnUT).ToV3(),
-                o.WorldOrbitalVelocityAtUT(burnUT).ToV3(), (interceptTarget - o.referenceBody.position).ToV3(), collisionUT - burnUT, 0);
-
-            Vector3d deltaV = velAfterBurn.ToVector3d() - o.WorldOrbitalVelocityAtUT(burnUT);
-            return deltaV;
+            return (dv.V3ToWorld(), dt1, dt2);
         }
 
         // This is the entry point for the course-correction to a target orbit which is not a celestial

--- a/MechJebLib/Maneuvers/FineTuneClosestApproachToCelestial.cs
+++ b/MechJebLib/Maneuvers/FineTuneClosestApproachToCelestial.cs
@@ -1,0 +1,142 @@
+﻿using MechJebLib.Functions;
+using MechJebLib.Primitives;
+using MechJebLib.TwoBody;
+using MechJebLib.Utils;
+using static System.Math;
+using static MechJebLib.Utils.Statics;
+
+namespace MechJebLib.Maneuvers
+{
+    public class FineTuneClosestApproachToCelestial
+    {
+        private V3 _r0;
+        private V3 _v0;
+        private V3 _r1;
+        private V3 _v1;
+        private double _soi;
+        private double _peR;
+        private double _cosInc;
+        private bool _onlyFeasible;
+
+        private Scale _planetToMoonScale;
+        private Scale _moonScale;
+        private Scale _planetScale;
+
+        private void NLPFunction(double[] x, double[] fi, object? obj)
+        {
+            var    dv  = new V3(x[0], x[1], x[2]);
+            double dt1 = x[3];
+            double dt2 = x[4];
+
+            (V3 r0Burn, V3 v0Burn) = Shepperd.Solve(1.0, dt1, _r0, _v0);
+            (V3 rf0, V3 vf0) = Shepperd.Solve(1.0, dt2, r0Burn, v0Burn + dv);
+            (V3 rf1, V3 vf1) = Shepperd.Solve(1.0, dt1 + dt2, _r1, _v1);
+
+            V3 rsoi = rf0 - rf1;
+            V3 vsoi = vf0 - vf1;
+
+            double per;
+            if (rsoi.magnitude <= 1.1 * _soi)
+                per = Astro.PeriapsisFromStateVectors(1.0, rsoi / _planetToMoonScale.LengthScale, vsoi / _planetToMoonScale.VelocityScale);
+            else
+                per = rsoi.magnitude / _planetToMoonScale.LengthScale;
+
+            fi[0] = _onlyFeasible ? 0 : 0.025 * dv.sqrMagnitude;
+            fi[1] = per - _peR;
+            fi[2] = IsFinite(_cosInc) ? V3.Cross(rsoi, vsoi).normalized.z - _cosInc : 0;
+            fi[3] = rsoi.magnitude - _soi;
+            fi[4] = V3.Dot(rsoi.normalized, vsoi.normalized);
+        }
+
+        public (V3 dv, double dt1, double dt2) Maneuver(double mu0, V3 r0, V3 v0, double mu1, V3 r1, V3 v1, double soi, double tsoi, double peR, double inc=double.NaN)
+        {
+            Print($"FineTuneClosestApproachToCelestial.Maneuver({mu0:G17}, {r0}, {v0}, {mu1:G17}, {r1}, {v1}, {soi:G17}, {tsoi:G17}, {peR:G17}, {inc:G17})");
+            Check.PositiveFinite(mu0);
+            Check.Finite(r0);
+            Check.Finite(v0);
+            Check.PositiveFinite(mu1);
+            Check.Finite(r1);
+            Check.Finite(v1);
+            Check.PositiveFinite(soi);
+            Check.PositiveFinite(peR);
+
+            _planetScale = Scale.Create(mu0, Sqrt(r0.magnitude * r1.magnitude));
+            _moonScale = Scale.Create(mu1, peR);
+            _planetToMoonScale = _planetScale.ConvertTo(_moonScale);
+
+            _soi = soi / _planetScale.LengthScale;
+            _peR = peR / _moonScale.LengthScale;
+            _r0 = r0 / _planetScale.LengthScale;
+            _v0 = v0 / _planetScale.VelocityScale;
+            _r1 = r1 / _planetScale.LengthScale;
+            _v1 = v1 / _planetScale.VelocityScale;
+            _cosInc = Cos(inc);
+
+            const int    NUM_EQUALITY_CONSTRAINTS   = 3;
+            const int    NUM_INEQUALITY_CONSTRAINTS = 2;
+            const double DIFFSTEP                   = 1e-8;
+            const int    MAXITS                     = 500;
+
+            const int NVARIABLES = 5;
+
+            double[] x = new double[NVARIABLES];
+
+            x[4] = tsoi / _planetScale.TimeScale;
+
+            double[] bndl = new double[NVARIABLES];
+            double[] bndu = new double[NVARIABLES];
+
+            for (int i = 0; i < NVARIABLES; i++)
+            {
+                bndu[i] = double.PositiveInfinity;
+                bndl[i] = double.NegativeInfinity;
+            }
+
+            bndl[3] = 0;
+            bndu[3] = tsoi /  _planetScale.TimeScale;
+            bndl[4] = 0;
+            bndl[4] = tsoi / _planetScale.TimeScale;
+
+            // converge once without cost metric to find feasible solution
+            _onlyFeasible = true;
+            alglib.minnlccreatef(x, DIFFSTEP, out alglib.minnlcstate state);
+            alglib.minnlcsetbc(state, bndl, bndu);
+            alglib.minnlcsetalgosqp(state);
+            alglib.minnlcsetcond(state, 0, MAXITS);
+            alglib.minnlcsetnlc(state, NUM_EQUALITY_CONSTRAINTS, NUM_INEQUALITY_CONSTRAINTS);
+            alglib.minnlcoptimize(state, NLPFunction, null, null);
+            alglib.minnlcresults(state, out double[] x2, out alglib.minnlcreport rep);
+
+            double[] fi = new double[NUM_EQUALITY_CONSTRAINTS + NUM_INEQUALITY_CONSTRAINTS + 1];
+
+            Print($"termination type: {rep.terminationtype}");
+            Print($"iterations count: {rep.iterationscount}");
+            Print($"num function evals: {rep.nfev}");
+            NLPFunction(x2, fi, null);
+            Print($"fi[1] = {fi[1]}");
+            Print($"fi[2] = {fi[2]}");
+            Print($"fi[3] = {fi[3]}");
+
+            // converge again to move towards optimal solution
+            _onlyFeasible = false;
+            alglib.minnlccreatef(x2, DIFFSTEP, out alglib.minnlcstate state2);
+            alglib.minnlcsetalgosqp(state2);
+            alglib.minnlcsetcond(state2, 0, MAXITS);
+            alglib.minnlcsetnlc(state2, NUM_EQUALITY_CONSTRAINTS, NUM_INEQUALITY_CONSTRAINTS);
+            alglib.minnlcoptimize(state2, NLPFunction, null, null);
+            alglib.minnlcresults(state2, out double[] x3, out alglib.minnlcreport rep2);
+
+            Print($"termination type: {rep2.terminationtype}");
+            Print($"iterations count: {rep2.iterationscount}");
+            Print($"num function evals: {rep2.nfev}");
+            NLPFunction(x3, fi, null);
+            Print($"fi[1] = {fi[1]}");
+            Print($"fi[2] = {fi[2]}");
+            Print($"fi[3] = {fi[3]}");
+
+            var dv = new V3(x3[0], x3[1], x3[2]);
+
+            return (dv * _planetScale.VelocityScale, x3[3] * _planetScale.TimeScale, x3[4] * _planetScale.TimeScale);
+        }
+    }
+}

--- a/MechJebLib/Primitives/V3.cs
+++ b/MechJebLib/Primitives/V3.cs
@@ -410,7 +410,7 @@ namespace MechJebLib.Primitives
         public string ToString(string? format, IFormatProvider formatProvider)
         {
             if (string.IsNullOrEmpty(format))
-                format = "G";
+                format = "G17";
             return
                 $"[{x.ToString(format, formatProvider)}, {y.ToString(format, formatProvider)}, {z.ToString(format, formatProvider)}]";
         }

--- a/MechJebLibTest/ManeuversTests/FineTuneClosestApproachToCelestialTests.cs
+++ b/MechJebLibTest/ManeuversTests/FineTuneClosestApproachToCelestialTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using MechJebLib.Functions;
+using MechJebLib.Maneuvers;
+using MechJebLib.Primitives;
+using MechJebLib.TwoBody;
+using MechJebLib.Utils;
+using Xunit;
+using Xunit.Abstractions;
+using static MechJebLib.Utils.Statics;
+
+namespace MechJebLibTest.ManeuversTests
+{
+    public class FineTuneClosestApproachToCelestialTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public FineTuneClosestApproachToCelestialTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        public static IEnumerable<object[]> Seeds()
+        {
+            for (int i = 0; i <= 500; i++)
+                yield return new object[] { i };
+        }
+
+        [Theory]
+        [MemberData(nameof(Seeds))]
+        public void RandomLunarTransfers(int seed)
+        {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
+
+            var rng = new Random(seed);
+
+            double soi   = 66167158.6569544;
+            double rmoon = 1737100;
+            double mu0   = 398600435436096;
+            var    r0    = new V3(-6419931.35599855, -1598504.22548976, 1968486.96029449);
+            var    v0    = new V3(-747.608332256415, -9974.07871417746, -3695.67552943825);
+            double mu1   = 4902800066163.8;
+            var    r1    = new V3(4781917.4840911, -344412903.013029, -122488006.928327);
+            var    v1    = new V3(996.891435624119, 120.171877824752, -367.753988404139);
+            double peR   = 0.80 * soi * rng.NextDouble() + rmoon / 10;
+            double inc   = Deg2Rad(120 * rng.NextDouble() + 30); // inclinations <= 30 && >= 150 degrees are not accssible for this test.
+            double tsoi  = 403785.23845505138;                   // time on initial coast to SOI
+
+            Print($"periapsis: {peR - rmoon} inc: {Rad2Deg(inc)}");
+
+            var maneuver = new FineTuneClosestApproachToCelestial();
+
+            (V3 dv, double dt1, double dt2) = maneuver.Maneuver(mu0, r0, v0, mu1, r1, v1, soi, tsoi, peR, inc);
+
+            (V3 r0Burn, V3 v0Burn) = Shepperd.Solve(mu0, dt1, r0, v0);
+            (V3 rf0, V3 vf0) = Shepperd.Solve(mu0, dt2, r0Burn, v0Burn + dv);
+            (V3 rf1, V3 vf1) = Shepperd.Solve(mu0, dt1 + dt2, r1, v1);
+
+            V3 rrel0 = r0 - rf1;
+            V3 vrel0 = v0 - vf1;
+            Print($"starting inc: {Rad2Deg(SafeAcos(V3.Cross(rrel0, vrel0).normalized.z))}");
+
+            V3 rsoi = rf0 - rf1;
+            V3 vsoi = vf0 - vf1;
+
+            (rf1 - rf0).magnitude.ShouldEqual(soi, 1e-4);
+
+            Astro.PeriapsisFromStateVectors(mu1, rsoi, vsoi).ShouldEqual(peR, 1e-4);
+
+            Astro.IncFromStateVectors(rsoi, vsoi).ShouldEqual(inc, 1e-4);
+        }
+    }
+}

--- a/MechJebLibTest/Primitives/V3Tests/StringRepresentationTests.cs
+++ b/MechJebLibTest/Primitives/V3Tests/StringRepresentationTests.cs
@@ -39,14 +39,14 @@ namespace MechJebLibTest.Primitives.V3Tests
         private void ToStringWithLargeValues()
         {
             var v = new V3(1.23456789e100, 2.3456789e150, 3.456789e200);
-            v.ToString().ShouldEqual("[1.23456789E+100, 2.3456789E+150, 3.456789E+200]");
+            v.ToString().ShouldEqual("[1.2345678900000001E+100, 2.3456789E+150, 3.4567890000000002E+200]");
         }
 
         [Fact]
         private void ToStringWithSmallValues()
         {
             var v = new V3(1.23456789e-100, 2.3456789e-150, 3.456789e-200);
-            v.ToString().ShouldEqual("[1.23456789E-100, 2.3456789E-150, 3.456789E-200]");
+            v.ToString().ShouldEqual("[1.2345678900000001E-100, 2.3456789000000001E-150, 3.4567889999999998E-200]");
         }
 
         [Fact]
@@ -201,7 +201,7 @@ namespace MechJebLibTest.Primitives.V3Tests
             var    v      = new V3(1.23e-10, 4.56e20, 7.89e5);
             string result = v.ToString();
 
-            result.ShouldContain("1.23E-10");
+            result.ShouldContain("1.2299999999999999E-10");
             result.ShouldContain("4.56E+20");
             result.ShouldContain("789000");
         }


### PR DESCRIPTION
Allows periapsis and inclination targeting, uses the alglib SQP solver with a much better constructed NLP, and should work considerably better.

Probably needs a re-rewrite to use b-plane targeting, but shipping this since it is an improvement.

Note that low inclinations become increasingly more difficult unless you happen to start in an equatorial orbit.

Box constraints on the burntime haven't been implemented either since the core of the algorithm likely needs to change to b-plane targeting, so this algorithm is still just fundamentally unfinished.

(May also support selecting north-pole or south-pole inclinations at some point in the future, but adding that to this version of the NLP blew up the problem--without b-plane targeting that likely isn't feasible)