### PR TITLE
Remove Launch to Rendezvous

### DIFF
--- a/MechJeb2/CachedLocalizer.cs
+++ b/MechJeb2/CachedLocalizer.cs
@@ -22,7 +22,6 @@ namespace MuMech
             MechJebAscentButton11,
             MechJebAscentButton12,
             MechJebAscentButton13,
-            MechJebAscentButton14,
             MechJebAscentButton15,
             MechJebAscentButton17;
 
@@ -83,7 +82,7 @@ namespace MuMech
             MechJebAscentLaunchingToManualLAN;
 
         [NonSerialized]
-        public string MechJebAscentMsg2, MechJebAscentMsg3;
+        public string MechJebAscentMsg2;
 
         [NonSerialized]
         public string MechJebAscentHotStaging, MechJebAscentDropSolids, MechJebAscentLeadTime;
@@ -180,7 +179,6 @@ namespace MuMech
             MechJebAscentButton11 = Localizer.Format("#MechJeb_Ascent_button11");
             MechJebAscentButton12 = Localizer.Format("#MechJeb_Ascent_button12");
             MechJebAscentButton13 = Localizer.Format("#MechJeb_Ascent_button13");
-            MechJebAscentButton14 = Localizer.Format("#MechJeb_Ascent_button14");
             MechJebAscentButton15 = Localizer.Format("#MechJeb_Ascent_button15");
             MechJebAscentButton17 = Localizer.Format("#MechJeb_Ascent_button17");
 
@@ -264,7 +262,6 @@ namespace MuMech
             MechJebAscentLaunchingToManualLAN = Localizer.Format("#MechJeb_Ascent_LaunchingToManualLAN");
 
             MechJebAscentMsg2       = Localizer.Format("#MechJeb_Ascent_msg2");
-            MechJebAscentMsg3       = Localizer.Format("#MechJeb_Ascent_msg3");
             MechJebAscentHotStaging = Localizer.Format("#MechJeb_Ascent_hotStaging");
             MechJebAscentDropSolids = Localizer.Format("#MechJeb_Ascent_dropSolids");
             MechJebAscentLeadTime   = Localizer.Format("#MechJeb_Ascent_leadTime");

--- a/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
@@ -250,7 +250,6 @@ namespace MuMech
                 if (Vessel.patchedConicSolver.maneuverNodes.Count == 0)
                 {
                     MechJebModuleFlightRecorder recorder                         = Core.GetComputerModule<MechJebModuleFlightRecorder>();
-                    if (recorder != null) AscentSettings.LaunchPhaseAngle.Val    = recorder.PhaseAngleFromMark();
                     if (recorder != null) AscentSettings.LaunchLANDifference.Val = VesselState.orbitLAN - recorder.MarkLAN;
 
                     //finished circularize

--- a/MechJeb2/MechJebModuleAscentMenu.cs
+++ b/MechJeb2/MechJebModuleAscentMenu.cs
@@ -23,12 +23,6 @@ namespace MuMech
             set => _ascentSettings.LaunchingToPlane = value;
         }
 
-        private bool _launchingToRendezvous
-        {
-            get => _ascentSettings.LaunchingToRendezvous;
-            set => _ascentSettings.LaunchingToRendezvous = value;
-        }
-
         private bool _launchingToMatchLan
         {
             get => _ascentSettings.LaunchingToMatchLan;
@@ -43,7 +37,7 @@ namespace MuMech
 
         #endregion
 
-        private bool _launchingWithAnyPlaneControl => _launchingToPlane || _launchingToRendezvous || _launchingToMatchLan || _launchingToLan;
+        private bool _launchingWithAnyPlaneControl => _launchingToPlane || _launchingToMatchLan || _launchingToLan;
 
         private MechJebModuleAscentBaseAutopilot   _autopilot       => Core.Ascent;
         private MechJebModuleAscentSettings        _ascentSettings  => Core.AscentSettings;
@@ -66,7 +60,6 @@ namespace MuMech
         protected override void OnModuleDisabled()
         {
             _launchingToPlane        = false;
-            _launchingToRendezvous   = false;
             _launchingToMatchLan     = false;
             _lastPSGSettingsEnabled  = _psgSettingsMenu.Enabled;
             _lastSettingsMenuEnabled = _settingsMenu.Enabled;
@@ -232,7 +225,7 @@ namespace MuMech
             bool targetExists = Core.Target.NormalTargetExists && Core.Target.TargetOrbit?.referenceBody == VesselState.mainBody;
             if (!_launchingWithAnyPlaneControl && !targetExists)
             {
-                _launchingToPlane = _launchingToRendezvous = _launchingToMatchLan = false;
+                _launchingToPlane = _launchingToMatchLan = false;
                 if (Core.Target.NormalTargetExists)
                     GUILayout.Label(CachedLocalizer.Instance.MechJebAscentWarnInvalidTarget,
                         GuiUtils.OrangeLabel); // Target must be in the same sphere of influence.
@@ -242,17 +235,6 @@ namespace MuMech
 
             if (!_launchingWithAnyPlaneControl)
             {
-                // Launch to Rendezvous
-                if (targetExists && _ascentSettings.AscentType != AscentType.PSG
-                    && GuiUtils.ButtonTextBox(CachedLocalizer.Instance.MechJebAscentButton14, _ascentSettings.LaunchPhaseAngle, "º",
-                        width: 40)) //Launch to rendezvous:
-                {
-                    _launchingToRendezvous = true;
-                    _autopilot.StartCountdown(VesselState.time +
-                        TimeToPhaseAngle(_ascentSettings.LaunchPhaseAngle,
-                            MainBody, VesselState.longitude, Core.Target.TargetOrbit));
-                }
-
                 //Launch into plane of target
                 if (targetExists && GuiUtils.ButtonTextBox(CachedLocalizer.Instance.MechJebAscentButton15, _ascentSettings.LaunchLANDifference, "º",
                         width: LAN_WIDTH)) //Launch into plane of target
@@ -313,7 +295,7 @@ namespace MuMech
             {
                 GUILayout.Label(launchTimer);
                 if (GUILayout.Button(CachedLocalizer.Instance.MechJebAscentButton17)) //Abort
-                    _launchingToPlane = _launchingToRendezvous = _launchingToMatchLan = _launchingToLan = _autopilot.TimedLaunch = false;
+                    _launchingToPlane = _launchingToMatchLan = _launchingToLan = _autopilot.TimedLaunch = false;
             }
 
             _ascentSettings.OverrideWarpToPlane = GUILayout.Toggle(_ascentSettings.OverrideWarpToPlane, "Override Warp to Plane");
@@ -350,7 +332,6 @@ namespace MuMech
                 label30 = $"{CachedLocalizer.Instance.MechJebAscentLabel30}{Core.Glueball.Exception.Message}";
 
             if (_launchingToPlane) launchTimer           = CachedLocalizer.Instance.MechJebAscentMsg2;                 //Launching to target plane
-            else if (_launchingToRendezvous) launchTimer = CachedLocalizer.Instance.MechJebAscentMsg3;                 //Launching to rendezvous
             else if (_launchingToMatchLan) launchTimer   = CachedLocalizer.Instance.MechJebAscentLaunchingToTargetLAN; //Launching to target LAN
             else if (_launchingToLan) launchTimer        = CachedLocalizer.Instance.MechJebAscentLaunchingToManualLAN; //Launching to manual LAN
             else launchTimer                             = string.Empty;
@@ -425,42 +406,6 @@ namespace MuMech
             GUILayout.EndVertical();
 
             base.WindowGUI(windowID);
-        }
-
-        //Computes the time until the phase angle between the launchpad and the target equals the given angle.
-        //The convention used is that phase angle is the angle measured starting at the target and going east until
-        //you get to the launchpad.
-        //The time returned will not be exactly accurate unless the target is in an exactly circular orbit. However,
-        //the time returned will go to exactly zero when the desired phase angle is reached.
-        private static double TimeToPhaseAngle(double phaseAngle, CelestialBody launchBody, double launchLongitude, Orbit target)
-        {
-            double launchpadAngularRate = 360 / launchBody.rotationPeriod;
-            double targetAngularRate    = 360.0 / target.period;
-            if (Vector3d.Dot(-target.GetOrbitNormal().xzy.normalized, launchBody.angularVelocity) < 0)
-                targetAngularRate *= -1; //retrograde target
-
-            Vector3d currentLaunchpadDirection = launchBody.GetSurfaceNVector(0, launchLongitude);
-            Vector3d currentTargetDirection    = target.WorldBCIPositionAtUT(Planetarium.GetUniversalTime());
-            currentTargetDirection = Vector3d.Exclude(launchBody.angularVelocity, currentTargetDirection);
-
-            double currentPhaseAngle = Math.Abs(Vector3d.Angle(currentLaunchpadDirection, currentTargetDirection));
-            if (Vector3d.Dot(Vector3d.Cross(currentTargetDirection, currentLaunchpadDirection), launchBody.angularVelocity) < 0)
-            {
-                currentPhaseAngle = 360 - currentPhaseAngle;
-            }
-
-            double phaseAngleRate = launchpadAngularRate - targetAngularRate;
-
-            double phaseAngleDifference = MuUtils.ClampDegrees360(phaseAngle - currentPhaseAngle);
-
-            if (phaseAngleRate < 0)
-            {
-                phaseAngleRate       *= -1;
-                phaseAngleDifference =  360 - phaseAngleDifference;
-            }
-
-
-            return phaseAngleDifference / phaseAngleRate;
         }
 
         private string PhaseString(Solution solution, double t, int psgPhase)

--- a/MechJeb2/MechJebModuleAscentSettings.cs
+++ b/MechJeb2/MechJebModuleAscentSettings.cs
@@ -144,9 +144,6 @@ namespace MuMech
 
         [Persistent(pass = (int)(Pass.TYPE | Pass.GLOBAL))] public bool LimitQaEnabled = LIMIT_QA_ENABLED_DEFAULT;
 
-        [Persistent(pass = (int)(Pass.TYPE | Pass.GLOBAL))]
-        public readonly EditableDouble LaunchPhaseAngle = LAUNCH_PHASE_ANGLE_DEFAULT;
-
         [Persistent(pass = (int)(Pass.TYPE | Pass.GLOBAL))] public readonly EditableDouble LaunchLANDifference = LAUNCH_LAN_DIFFERENCE;
 
         [Persistent(pass = (int)Pass.GLOBAL)] public readonly EditableInt WarpCountDown = 11;
@@ -252,7 +249,6 @@ namespace MuMech
          */
 
         public bool LaunchingToPlane;
-        public bool LaunchingToRendezvous;
         public bool LaunchingToMatchLan;
         public bool LaunchingToLan;
         public bool OverrideWarpToPlane;
@@ -308,7 +304,6 @@ namespace MuMech
             MinDeltaV.Val             = MIN_DELTAV_DEFAULT;
             MaxCoast.Val              = MAX_COAST_DEFAULT;
             MinCoast.Val              = MIN_COAST_DEFAULT;
-            LaunchPhaseAngle.Val      = LAUNCH_PHASE_ANGLE_DEFAULT;
             LaunchLANDifference.Val   = LAUNCH_LAN_DIFFERENCE;
             PreStageTime.Val          = PRE_STAGE_TIME_DEFAULT;
             OptimizerPauseTime.Val    = OPTIMIZER_PAUSE_TIME_DEFAULT;
@@ -376,7 +371,6 @@ namespace MuMech
         }
 
         private const double LAUNCH_LAN_DIFFERENCE        = 0;
-        private const double LAUNCH_PHASE_ANGLE_DEFAULT   = 0;
         private const double MIN_COAST_DEFAULT            = 0;
         private const double MAX_COAST_DEFAULT            = 450;
         private const double MIN_DELTAV_DEFAULT           = 40;


### PR DESCRIPTION
This only has any hope of working in pure equatorial-to-equatorial and fails for anything else.

While it does actually work fine for the first launches that typical players do to go to the Mun or rendezvous with an equatorial space station, I think it is teaching people a fundamental dead end.

Users should be launching into a phasing orbit in the correct plane, and then doing a rendezvous.

At some point PSG should support direct ascents to rendezvous with the Moon/Mun or a space station.  In the general case this is a legitimately difficult optimization problem to set up.