### PR TITLE
Classic ascent circularization

### DIFF
--- a/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
+++ b/MechJeb2/MechJebModuleAscentBaseAutopilot.cs
@@ -268,9 +268,11 @@ namespace MuMech
                 // TWR launches from equatorial launch sites -- should probably be made optional (or clip it if the correction is too large).
                 Vector3d inclinationCorrection =
                     OrbitalManeuverCalculator.DeltaVToChangeInclination(Orbit, ut, AscentSettings.DesiredInclination);
-                Vector3d smaCorrection = OrbitalManeuverCalculator.DeltaVForSemiMajorAxis(Orbit.PerturbedOrbit(ut, inclinationCorrection), ut,
-                    AscentSettings.DesiredOrbitAltitude + MainBody.Radius);
-                Vector3d dV = inclinationCorrection + smaCorrection;
+                // Circularize on the perturbed orbit rather than fixing the SMA to the desired altitude.  This
+                // avoids errors that creep in when the orbit at this point is inaccurate while still circularizing.
+                Vector3d circularizeCorrection =
+                    OrbitalManeuverCalculator.DeltaVToCircularize(Orbit.PerturbedOrbit(ut, inclinationCorrection), ut);
+                Vector3d dV = inclinationCorrection + circularizeCorrection;
                 Vessel.PlaceManeuverNode(Orbit, dV, ut);
                 _placedCircularizeNode = true;
 


### PR DESCRIPTION
Don't try to set the SMA based on desired altitude, but just circularize at whatever the apoapsis actually is.

We could try to circularize at the precise altitude if the desired altitude < apo, but that could get more costly so I'm going to skip thinking about it (some people will want it, some people probably won't, heuristics will add more edge conditions and buttons and I don't think it is worth it).

closes #1971
closes #1850 (maybe)