### PR TITLE
Convert ChangeOrbitalElements to use AUL+SQP

### DIFF
--- a/MechJebLib/Maneuvers/ChangeOrbitalElement.cs
+++ b/MechJebLib/Maneuvers/ChangeOrbitalElement.cs
@@ -7,7 +7,6 @@ using System;
 using MechJebLib.Functions;
 using MechJebLib.Primitives;
 using MechJebLib.Utils;
-using static System.Math;
 
 namespace MechJebLib.Maneuvers
 {
@@ -114,14 +113,14 @@ namespace MechJebLib.Maneuvers
                 throw new ArgumentException("bad v in ChangeOrbitalElement");
 
             const double DIFFSTEP = 1e-7;
-            const double EPSX     = 1e-7;
-            const int    MAXITS   = 1000;
+            //const double EPSX     = 1e-10;
+            const int MAXITS = 1000;
 
             const int NVARIABLES             = 2;
             const int NEQUALITYCONSTRAINTS   = 1;
             const int NINEQUALITYCONSTRAINTS = 0;
 
-            double[] x = new double[NVARIABLES];
+            double[] x0 = new double[NVARIABLES];
 
             var scale = Scale.Create(mu, r.magnitude);
 
@@ -130,40 +129,38 @@ namespace MechJebLib.Maneuvers
             p /= scale.LengthScale;
             q /= scale.VelocityScale;
 
-            if (type == Type.ECC)
-            {
-                // changing the ECC is actually a global optimization problem due to basins around parabolic ecc == 1.0
-                double boost = Sign(value - 1.0) * 0.1 + Sqrt(2);
-
-                V3 dv = Simple.DeltaVRelativeToCircularVelocity(1.0, p, q, boost);
-                x[0] = dv.x;
-                x[1] = dv.y;
-            }
-            else
-            {
-                x[0] = 0; // maneuver vy
-                x[1] = 0; // maneuver vy
-            }
+            x0[0] = 0; // maneuver vy
+            x0[1] = 0; // maneuver vy
 
             var args = new Args { P = p, Q = q, Value = type == Type.ECC ? value : value / scale.LengthScale, Type = type };
 
-            alglib.minnlccreate(NVARIABLES, x, out alglib.minnlcstate state);
-            alglib.minnlcsetalgosqp(state);
-            alglib.minnlcsetcond(state, EPSX, MAXITS);
+            // For adjusting ecc, SQP gets hung up on derivatives crossing parabolic orbits,
+            // so use a first pass with AUL, then refine the output of that with SQP.
+            alglib.minnlccreate(NVARIABLES, x0, out alglib.minnlcstate state);
+            alglib.minnlcsetalgoaul2(state, MAXITS);
+            alglib.minnlcsetcond(state, 0, MAXITS);
             alglib.minnlcsetnlc(state, NEQUALITYCONSTRAINTS, NINEQUALITYCONSTRAINTS);
-
-            if (optguard)
-            {
-                alglib.minnlcoptguardsmoothness(state);
-                alglib.minnlcoptguardgradient(state, DIFFSTEP);
-            }
-
+#if DEBUG
+            alglib.minnlcoptguardsmoothness(state);
+            alglib.minnlcoptguardgradient(state, DIFFSTEP);
+#endif
             alglib.minnlcoptimize(state, NLPFunction2, null, args);
-            alglib.minnlcresults(state, out double[] x2, out alglib.minnlcreport rep);
+            alglib.minnlcresults(state, out double[] x1, out alglib.minnlcreport rep1);
 
-            if (rep.terminationtype < 0)
+            alglib.minnlccreate(NVARIABLES, x1, out alglib.minnlcstate state2);
+            alglib.minnlcsetalgosqp(state2);
+            alglib.minnlcsetcond(state2, 0, MAXITS);
+            alglib.minnlcsetnlc(state2, NEQUALITYCONSTRAINTS, NINEQUALITYCONSTRAINTS);
+#if DEBUG
+            alglib.minnlcoptguardsmoothness(state2);
+            alglib.minnlcoptguardgradient(state2, DIFFSTEP);
+#endif
+            alglib.minnlcoptimize(state2, NLPFunction2, null, args);
+            alglib.minnlcresults(state2, out double[] x2, out alglib.minnlcreport rep2);
+
+            if (rep2.terminationtype < 0)
                 throw new Exception(
-                    $"ChangeOrbitalElement.DeltaV({mu}, {r}, {v}, {value}, {type}): SQP solver terminated abnormally: {rep.terminationtype}"
+                    $"ChangeOrbitalElement.DeltaV({mu}, {r}, {v}, {value}, {type}): SQP solver terminated abnormally: {rep2.terminationtype}"
                 );
 
             if (optguard)

--- a/MechJebLibTest/ManeuversTests/ChangeOrbitalElementTests.cs
+++ b/MechJebLibTest/ManeuversTests/ChangeOrbitalElementTests.cs
@@ -4,69 +4,83 @@
  */
 
 using System;
+using System.Collections.Generic;
 using MechJebLib.Functions;
 using MechJebLib.Maneuvers;
 using MechJebLib.Primitives;
+using MechJebLib.Utils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace MechJebLibTest.ManeuversTests
 {
     public class ChangeOrbitalElementTests
     {
-        [Fact]
-        private void ChangeOrbitalElementTest()
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public ChangeOrbitalElementTests(ITestOutputHelper testOutputHelper)
         {
-            const int NTRIALS = 50;
+            _testOutputHelper = testOutputHelper;
+        }
 
-            var random = new Random();
+        public static IEnumerable<object[]> Seeds()
+        {
+            for (int i = 0; i <= 50; i++)
+                yield return new object[] { i };
+        }
 
-            for (int i = 0; i < NTRIALS; i++)
-            {
-                var    r    = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                var    v    = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
-                double newR = random.NextDouble() * r.magnitude;
+        [Theory]
+        [MemberData(nameof(Seeds))]
+        private void ChangeOrbitalElementTest(int seed)
+        {
+            Logger.Register(o => _testOutputHelper.WriteLine((string)o));
 
-                double rscale = random.NextDouble() * 1.5e8 + 1;
-                double vscale = random.NextDouble() * 3e4 + 1;
-                r *= rscale;
-                v *= vscale;
-                newR *= rscale;
-                double mu = rscale * vscale * vscale;
+            var random = new Random(seed);
 
-                V3 dv = ChangeOrbitalElement.ChangePeriapsis(mu, r, v, newR, true);
-                Astro.PeriapsisFromStateVectors(mu, r, v + dv).ShouldEqual(newR, 1e-9);
+            var    r    = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
+            var    v    = new V3(4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2, 4 * random.NextDouble() - 2);
+            double newR = random.NextDouble() * r.magnitude;
 
-                // validate this API works left handed.
-                V3 dv2 = ChangeOrbitalElement.ChangePeriapsis(mu, r.xzy, v.xzy, newR);
-                dv2.ShouldEqual(dv.xzy, 1e-3);
+            double rscale = random.NextDouble() * 1.5e8 + 1;
+            double vscale = random.NextDouble() * 3e4 + 1;
+            r *= rscale;
+            v *= vscale;
+            newR *= rscale;
+            double mu = rscale * vscale * vscale;
 
-                // now test apoapsis changing to elliptical
-                newR = random.NextDouble() * rscale * 1e9 + r.magnitude;
-                V3 dv3 = ChangeOrbitalElement.ChangeApoapsis(mu, r, v, newR, true);
-                Astro.ApoapsisFromStateVectors(mu, r, v + dv3).ShouldEqual(newR, 1e-4);
+            V3 dv = ChangeOrbitalElement.ChangePeriapsis(mu, r, v, newR, true);
+            Astro.PeriapsisFromStateVectors(mu, r, v + dv).ShouldEqual(newR, 1e-9);
 
-                // now test apoapsis changing to hyperbolic
-                newR = -(random.NextDouble() * 1e9 + 1e3) * rscale;
-                V3 dv4 = ChangeOrbitalElement.ChangeApoapsis(mu, r, v, newR, true);
-                Astro.ApoapsisFromStateVectors(mu, r, v + dv4).ShouldEqual(newR, 1e-5);
+            // validate this API works left handed.
+            V3 dv2 = ChangeOrbitalElement.ChangePeriapsis(mu, r.xzy, v.xzy, newR);
+            dv2.ShouldEqual(dv.xzy, 1e-3);
 
-                // now test changing the SMA.
-                newR = random.NextDouble() * 1e3 * rscale;
-                /*
-                mu   = 8657343022269006;
-                r    = new V3(-37559037.128101, -13154072.5832729, -86913972.3215555);
-                v    = new V3(23370.6359939819, 12558.3695536628, 17864.1347044172);
-                newR = 35354091.544774853;
-                */
-                V3 dv5 = ChangeOrbitalElement.ChangeSMA(mu, r, v, newR, true);
-                Astro.SmaFromStateVectors(mu, r, v + dv5).ShouldEqual(newR, 1e-9);
+            // now test apoapsis changing to elliptical
+            newR = random.NextDouble() * rscale * 1e9 + r.magnitude;
+            V3 dv3 = ChangeOrbitalElement.ChangeApoapsis(mu, r, v, newR, true);
+            Astro.ApoapsisFromStateVectors(mu, r, v + dv3).ShouldEqual(newR, 1e-4);
 
-                // now test changing the Ecc
-                double newEcc = random.NextDouble() * 5 + 2.5;
-                V3     dv6    = ChangeOrbitalElement.ChangeECC(mu, r, v, newEcc);
-                (_, double ecc) = Astro.SmaEccFromStateVectors(mu, r, v + dv6);
-                ecc.ShouldEqual(newEcc, 1e-9);
-            }
+            // now test apoapsis changing to hyperbolic
+            newR = -(random.NextDouble() * 1e9 + 1e3) * rscale;
+            V3 dv4 = ChangeOrbitalElement.ChangeApoapsis(mu, r, v, newR, true);
+            Astro.ApoapsisFromStateVectors(mu, r, v + dv4).ShouldEqual(newR, 1e-5);
+
+            // now test changing the SMA.
+            newR = random.NextDouble() * 1e3 * rscale;
+            /*
+            mu   = 8657343022269006;
+            r    = new V3(-37559037.128101, -13154072.5832729, -86913972.3215555);
+            v    = new V3(23370.6359939819, 12558.3695536628, 17864.1347044172);
+            newR = 35354091.544774853;
+            */
+            V3 dv5 = ChangeOrbitalElement.ChangeSMA(mu, r, v, newR, true);
+            Astro.SmaFromStateVectors(mu, r, v + dv5).ShouldEqual(newR, 1e-9);
+
+            // now test changing the Ecc
+            double newEcc = random.NextDouble() * 5 + 2.5;
+            V3     dv6    = ChangeOrbitalElement.ChangeECC(mu, r, v, newEcc);
+            (_, double ecc) = Astro.SmaEccFromStateVectors(mu, r, v + dv6);
+            ecc.ShouldEqual(newEcc, 1e-9);
         }
 
         [Fact]


### PR DESCRIPTION
Turns out the landscape through parabolic orbits for the ecc problem really is C0-smooth, but the SQP solver still gets caught up on the transition.  So presolve with AUL first, then sharpen with SQP, then the special initialization for the ecc problem can be dropped.