### PR TITLE
Add kOS addon Project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,4 +36,9 @@
     <!-- Linux: KSP_Data sits directly under KspDir -->
     <KspData Condition="'$(OS)' != 'Windows_NT' And !Exists('$(KspDir)/KSP.app')">$(KspDir)/KSP_Data</KspData>
   </PropertyGroup>
+
+  <!-- Derive KosDll from KspDir. -->
+  <PropertyGroup Condition="'$(KosDll)' == ''">
+    <KosDll>$(KspDir)/GameData/kOS/Plugins/kOS.dll</KosDll>
+  </PropertyGroup>
 </Project>

--- a/MechJeb2.sln
+++ b/MechJeb2.sln
@@ -21,10 +21,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "alglib", "alglib\alglib.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MechJebLibBindings", "MechJebLibBindings\MechJebLibBindings.csproj", "{DA770208-1300-4C86-8996-C1790B945999}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MechJebKos", "MechJebKos\MechJebKos.csproj", "{51BD942E-6E68-4F1F-80CA-9B353DD2F8C3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Debug-kOS|Any CPU = Debug-kOS|Any CPU
+		Release-kOS|Any CPU = Release-kOS|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9FC90AE6-C2E4-47F1-A6D1-DB4731A40BE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -47,6 +51,32 @@ Global
 		{DA770208-1300-4C86-8996-C1790B945999}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA770208-1300-4C86-8996-C1790B945999}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA770208-1300-4C86-8996-C1790B945999}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FC90AE6-C2E4-47F1-A6D1-DB4731A40BE3}.Debug-kOS|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FC90AE6-C2E4-47F1-A6D1-DB4731A40BE3}.Debug-kOS|Any CPU.Build.0 = Debug|Any CPU
+		{9FC90AE6-C2E4-47F1-A6D1-DB4731A40BE3}.Release-kOS|Any CPU.ActiveCfg = Release|Any CPU
+		{9FC90AE6-C2E4-47F1-A6D1-DB4731A40BE3}.Release-kOS|Any CPU.Build.0 = Release|Any CPU
+		{D21C9231-4F36-494F-988A-8352CFE7CCCE}.Debug-kOS|Any CPU.ActiveCfg = Debug|Any CPU
+		{D21C9231-4F36-494F-988A-8352CFE7CCCE}.Debug-kOS|Any CPU.Build.0 = Debug|Any CPU
+		{D21C9231-4F36-494F-988A-8352CFE7CCCE}.Release-kOS|Any CPU.ActiveCfg = Release|Any CPU
+		{D21C9231-4F36-494F-988A-8352CFE7CCCE}.Release-kOS|Any CPU.Build.0 = Release|Any CPU
+		{BA86665B-A72E-41FB-858A-C0FF29E05768}.Debug-kOS|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA86665B-A72E-41FB-858A-C0FF29E05768}.Debug-kOS|Any CPU.Build.0 = Debug|Any CPU
+		{BA86665B-A72E-41FB-858A-C0FF29E05768}.Release-kOS|Any CPU.ActiveCfg = Release|Any CPU
+		{BA86665B-A72E-41FB-858A-C0FF29E05768}.Release-kOS|Any CPU.Build.0 = Release|Any CPU
+		{E8CBCDDD-BCFC-4F03-9309-F58395CA4762}.Debug-kOS|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8CBCDDD-BCFC-4F03-9309-F58395CA4762}.Debug-kOS|Any CPU.Build.0 = Debug|Any CPU
+		{E8CBCDDD-BCFC-4F03-9309-F58395CA4762}.Release-kOS|Any CPU.ActiveCfg = Release|Any CPU
+		{E8CBCDDD-BCFC-4F03-9309-F58395CA4762}.Release-kOS|Any CPU.Build.0 = Release|Any CPU
+		{DA770208-1300-4C86-8996-C1790B945999}.Debug-kOS|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA770208-1300-4C86-8996-C1790B945999}.Debug-kOS|Any CPU.Build.0 = Debug|Any CPU
+		{DA770208-1300-4C86-8996-C1790B945999}.Release-kOS|Any CPU.ActiveCfg = Release|Any CPU
+		{DA770208-1300-4C86-8996-C1790B945999}.Release-kOS|Any CPU.Build.0 = Release|Any CPU
+		{51BD942E-6E68-4F1F-80CA-9B353DD2F8C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51BD942E-6E68-4F1F-80CA-9B353DD2F8C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51BD942E-6E68-4F1F-80CA-9B353DD2F8C3}.Debug-kOS|Any CPU.ActiveCfg = Debug|Any CPU
+		{51BD942E-6E68-4F1F-80CA-9B353DD2F8C3}.Debug-kOS|Any CPU.Build.0 = Debug|Any CPU
+		{51BD942E-6E68-4F1F-80CA-9B353DD2F8C3}.Release-kOS|Any CPU.ActiveCfg = Release|Any CPU
+		{51BD942E-6E68-4F1F-80CA-9B353DD2F8C3}.Release-kOS|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MechJebKos/MechJebKos.csproj
+++ b/MechJebKos/MechJebKos.csproj
@@ -1,0 +1,61 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net48</TargetFramework>
+        <RootNamespace>MuMech</RootNamespace>
+        <AssemblyName>MechJebKos</AssemblyName>
+        <LangVersion>8</LangVersion>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <DefineConstants>$(DefineConstants);UNITY_2017_1</DefineConstants>
+        <Prefer32Bit>false</Prefer32Bit>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+        <DefineConstants>$(DefineConstants);ENABLE_PROFILER</DefineConstants>
+        <DebugType>portable</DebugType>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DebugType>None</DebugType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Reference Include="kOS">
+            <HintPath>$(KosDll)</HintPath>
+            <SpecificVersion>False</SpecificVersion>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Assembly-CSharp">
+            <HintPath>$(KspData)/Managed/Assembly-CSharp.dll</HintPath>
+            <SpecificVersion>False</SpecificVersion>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine">
+            <HintPath>$(KspData)/Managed/UnityEngine.dll</HintPath>
+            <SpecificVersion>False</SpecificVersion>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.CoreModule">
+            <HintPath>$(KspData)/Managed/UnityEngine.CoreModule.dll</HintPath>
+            <SpecificVersion>False</SpecificVersion>
+            <Private>False</Private>
+        </Reference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\MechJeb2\MechJeb2.csproj" />
+        <ProjectReference Include="..\MechJebLib\MechJebLib.csproj" />
+        <ProjectReference Include="..\MechJebLibBindings\MechJebLibBindings.csproj" />
+    </ItemGroup>
+
+    <Target Name="MechJebKosCopyBuild" AfterTargets="Build">
+        <ItemGroup>
+            <_MechJebKosArtifacts Include="$(TargetDir)$(TargetName).dll" />
+            <_MechJebKosArtifacts Include="$(TargetDir)$(TargetName).pdb" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
+        </ItemGroup>
+        <MakeDir Directories="$(KspDir)/GameData/MechJeb2/Plugins" />
+        <Copy SourceFiles="@(_MechJebKosArtifacts)"
+              DestinationFolder="$(KspDir)/GameData/MechJeb2/Plugins"
+              SkipUnchangedFiles="true" />
+    </Target>
+
+</Project>

--- a/MechJebKos/MechJebKosAddon.cs
+++ b/MechJebKos/MechJebKosAddon.cs
@@ -1,0 +1,11 @@
+/*
+ * Copyright Lamont Granquist, Sebastien Gaggini and the MechJeb contributors
+ * SPDX-License-Identifier: LicenseRef-PD-hp OR Unlicense OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT OR LGPL-2.1+
+ */
+
+namespace MuMech
+{
+    internal static class MechJebKos
+    {
+    }
+}


### PR DESCRIPTION
This is not built by default with Debug/Release for now.

It needs the Debug-kOS or Relese-kOS build target.

It also needs kOS assemblies in your KSP install.

Does literally nothing at this point.

This will be highly experimental.