### PR TITLE
kOS: add ThrustController binding

### DIFF
--- a/MechJeb2/DisplayModule.cs
+++ b/MechJeb2/DisplayModule.cs
@@ -8,6 +8,7 @@ namespace MuMech
 {
     public class DisplayModule : ComputerModule
     {
+        // this means Hidden in the drop-down menu because the tech isn't unlocked.
         public bool Hidden;
 
         public Rect WindowPos

--- a/MechJeb2/LandingAutopilot/CourseCorrection.cs
+++ b/MechJeb2/LandingAutopilot/CourseCorrection.cs
@@ -71,7 +71,7 @@ namespace MuMech
                 if (_courseCorrectionBurning)
                 {
                     const double TIME_CONSTANT = 2.0;
-                    Core.Thrust.ThrustForDV(deltaV.magnitude, TIME_CONSTANT);
+                    Core.Thrust.ThrustForDv(deltaV.magnitude, TIME_CONSTANT);
                 }
                 else
                 {

--- a/MechJeb2/MechJebModuleAscentSettingsMenu.cs
+++ b/MechJeb2/MechJebModuleAscentSettingsMenu.cs
@@ -32,7 +32,6 @@ namespace MuMech
             if (_ascentSettings.AscentType == AscentType.PSG)
             {
                 Core.Thrust.LimitThrottle           = false;
-                Core.Thrust.LimitToTerminalVelocity = false;
                 Core.Thrust.ElectricThrottle        = false;
             }
 

--- a/MechJeb2/MechJebModuleNodeExecutor.cs
+++ b/MechJeb2/MechJebModuleNodeExecutor.cs
@@ -288,7 +288,7 @@ namespace MuMech
             if (!RCSOnly)
             {
                 double timeConstant = _dvLeft > 10 || VesselState.minThrustAccel > 0.25 * VesselState.maxThrustAccel ? 0.5 : 2;
-                Core.Thrust.ThrustForDV(_dvLeft, timeConstant);
+                Core.Thrust.ThrustForDv(_dvLeft, timeConstant);
             }
         }
 

--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -11,12 +11,7 @@ namespace MuMech
 {
     public class MechJebModuleThrustController : ComputerModule
     {
-        private static readonly bool _isLoadedRealFuels;
-
-        static MechJebModuleThrustController()
-        {
-            _isLoadedRealFuels = ReflectionUtils.IsAssemblyLoaded("RealFuels");
-        }
+        private static bool _isLoadedRealFuels => ReflectionUtils.IsAssemblyLoaded("RealFuels");
 
         public enum DifferentialThrottleStatus
         {
@@ -35,20 +30,6 @@ namespace MuMech
         public  float TransSpdAct;
         private float _transPrevThrust;
         public  bool  TransKillH = false;
-
-        // The Terminal Velocity limiter is removed to not have to deal with users who
-        // think that seeing the aerodynamic FX means they reached it.
-        // And it s really high since 1.0.x anyway so the Dynamic Pressure limiter is better now
-        //[Persistent(pass = (int)Pass.Global)]
-        public bool LimitToTerminalVelocity = false;
-
-        //[GeneralInfoItem("Limit to terminal velocity", InfoItem.Category.Thrust)]
-        //public void LimitToTerminalVelocityInfoItem()
-        //{
-        //    GUIStyle s = new GUIStyle(GUI.skin.toggle);
-        //    if (limiter == LimitMode.TerminalVelocity) s.onHover.textColor = s.onNormal.textColor = Color.green;
-        //    limitToTerminalVelocity = GUILayout.Toggle(limitToTerminalVelocity, "Limit to terminal velocity", s);
-        //}
 
         [Persistent(pass = (int)Pass.GLOBAL)]
         public bool LimitDynamicPressure;
@@ -223,7 +204,7 @@ namespace MuMech
 
         public enum LimitMode
         {
-            NONE, TERMINAL_VELOCITY, TEMPERATURE, FLAMEOUT, ACCELERATION, THROTTLE, DYNAMIC_PRESSURE, MIN_THROTTLE, ELECTRIC, UNSTABLE_IGNITION,
+            NONE, TEMPERATURE, FLAMEOUT, ACCELERATION, THROTTLE, DYNAMIC_PRESSURE, MIN_THROTTLE, ELECTRIC, UNSTABLE_IGNITION,
             AUTO_RCS_ULLAGE
         }
 
@@ -301,7 +282,7 @@ namespace MuMech
 
         private void SetFlightGlobals(double throttle)
         {
-            if (FlightGlobals.ActiveVessel != null && Vessel == FlightGlobals.ActiveVessel)
+            if (!(FlightGlobals.ActiveVessel is null) && Vessel == FlightGlobals.ActiveVessel)
             {
                 FlightInputHandler.state.mainThrottle = (float)throttle; //so that the on-screen throttle gauge reflects the autopilot throttle
             }
@@ -309,12 +290,12 @@ namespace MuMech
 
         // Call this function to set the throttle for a burn with dV delta-V remaining.
         // timeConstant controls how quickly we throttle down toward the end of the burn.
-        // This function is nice because it will correctly handle engine spool-up/down times.
-        public void ThrustForDV(double dV, double timeConstant)
+        // This function is nice because it will correctly handle engine spool-up/spool-down times.
+        public void ThrustForDv(double dV, double timeConstant)
         {
             timeConstant += VesselState.maxEngineResponseTime;
-            double spooldownDV = VesselState.currentThrustAccel * VesselState.maxEngineResponseTime;
-            double desiredAcceleration = (dV - spooldownDV) / timeConstant;
+            double spooldownDv = VesselState.currentThrustAccel * VesselState.maxEngineResponseTime;
+            double desiredAcceleration = (dV - spooldownDv) / timeConstant;
 
             TargetThrottle = Mathf.Clamp((float)(desiredAcceleration / VesselState.maxThrustAccel), 0.01f, 1.00f);
         }
@@ -370,6 +351,7 @@ namespace MuMech
                 _userCommandingRotationSmoothed--;
             }
 
+            // These are tech-gates (is the window in the drop down?), not normal UI visibility of the window
             if (Core.GetComputerModule<MechJebModuleThrustWindow>().Hidden && Core.GetComputerModule<MechJebModuleAscentMenu>().Hidden) { return; }
 
             if (Tmode != TMode.OFF && VesselState.thrustAvailable > 0)
@@ -453,7 +435,7 @@ namespace MuMech
                 }
             }
 
-            // Only set throttle if a module need it. Otherwise let the user or other mods set it
+            // Only set throttle if a module need it. Otherwise, let the user or other mods set it
             // There is always at least 1 user : the module itself (why ?)
             if (Users.Count > 1)
                 s.mainThrottle = TargetThrottle;
@@ -468,15 +450,6 @@ namespace MuMech
                 if (MaxThrottle < ThrottleLimit)
                 {
                     SetFixedLimit((float)MaxThrottle, LimitMode.THROTTLE);
-                }
-            }
-
-            if (LimitToTerminalVelocity)
-            {
-                float limit = TerminalVelocityThrottle();
-                if (limit < ThrottleLimit)
-                {
-                    SetFixedLimit(limit, LimitMode.TERMINAL_VELOCITY);
                 }
             }
 
@@ -560,9 +533,7 @@ namespace MuMech
             // back on the next tick after disabling.  we save this before applying the throttle limits so that we preserve
             // the requested throttle, and not the limited throttle.
             if (Core.RssMode)
-            {
                 SetFlightGlobals(s.mainThrottle);
-            }
 
             if (double.IsNaN(ThrottleLimit)) ThrottleLimit = 1.0F;
             ThrottleLimit = Mathf.Clamp01(ThrottleLimit);
@@ -603,20 +574,6 @@ namespace MuMech
         public override void OnFixedUpdate() =>
             DifferentialThrottleSuccess =
                 DifferentialThrottle ? ComputeDifferentialThrottle(DifferentialThrottleDemandedTorque) : DifferentialThrottleStatus.SUCCESS;
-
-        //A throttle setting that throttles down when the vertical velocity of the ship exceeds terminal velocity
-        private float TerminalVelocityThrottle()
-        {
-            if (VesselState.altitudeASL > MainBody.RealMaxAtmosphereAltitude()) return 1.0F;
-
-            double velocityRatio = Vector3d.Dot(VesselState.surfaceVelocity, VesselState.up) / VesselState.TerminalVelocity();
-
-            if (velocityRatio < 1.0) return 1.0F; //full throttle if under terminal velocity
-
-            //throttle down quickly as we exceed terminal velocity:
-            const double FALLOFF = 15.0;
-            return Mathf.Clamp((float)(1.0 - FALLOFF * (velocityRatio - 1.0)), 0.0F, 1.0F);
-        }
 
         //A throttle setting that throttles down when the dynamic pressure exceed a set value
         private float MaximumDynamicPressureThrottle()
@@ -754,9 +711,8 @@ namespace MuMech
                     groupIds[partIntake] = grpId;
                     intakes.Add(partIntake);
 
-                    for (int i = 0; i < part.symmetryCounterparts.Count; i++)
+                    foreach (Part sympart in part.symmetryCounterparts)
                     {
-                        Part sympart = part.symmetryCounterparts[i];
                         stack.Push(sympart);
                     }
                 }
@@ -772,9 +728,8 @@ namespace MuMech
             {
                 if (airFlowSoFar < requiredFlow)
                 {
-                    for (int i = 0; i < grp.Count; i++)
+                    foreach (ModuleResourceIntake intake in grp)
                     {
-                        ModuleResourceIntake intake = grp[i];
                         double airFlowThisIntake = data[intake].predictedMassFlow;
                         if (!intake.intakeEnabled)
                         {
@@ -786,9 +741,8 @@ namespace MuMech
                 }
                 else
                 {
-                    for (int j = 0; j < grp.Count; j++)
+                    foreach (ModuleResourceIntake intake in grp)
                     {
-                        ModuleResourceIntake intake = grp[j];
                         if (intake.intakeEnabled)
                         {
                             intake.ToggleAction(param);
@@ -866,23 +820,6 @@ namespace MuMech
                         pm.enablePitch = pm.enableRoll = pm.enableYaw = true;
                     }
                 }
-            }
-        }
-
-        private static void MaxThrust(double[] x, ref double func, double[] grad, object obj)
-        {
-            var el = (List<VesselState.EngineWrapper>)obj;
-
-            func = 0;
-
-            for (int i = 0, j = 0; j < el.Count; j++)
-            {
-                VesselState.EngineWrapper e = el[j];
-                if (e.engine.throttleLocked) continue;
-
-                func    -= el[j].maxVariableForce.y * x[i];
-                grad[i] =  -el[j].maxVariableForce.y;
-                i++;
             }
         }
 
@@ -1011,17 +948,12 @@ namespace MuMech
 
         private void DisableDifferentialThrottle()
         {
-            for (int i = 0; i < Vessel.parts.Count; i++)
+            foreach (Part p in Vessel.parts)
             {
-                Part p = Vessel.parts[i];
-                for (int j = 0; j < p.Modules.Count; j++)
+                foreach (PartModule pm in p.Modules)
                 {
-                    PartModule pm = p.Modules[j];
-                    var engine = pm as ModuleEngines;
-                    if (engine != null)
-                    {
+                    if (pm is ModuleEngines engine)
                         engine.thrustPercentage = 100;
-                    }
                 }
             }
         }

--- a/MechJebKos/Addon.cs
+++ b/MechJebKos/Addon.cs
@@ -25,7 +25,7 @@ namespace MuMech.MechJebKos
     {
         public Addon(SharedObjects shared) : base(shared) => RegisterInitializer(InitializeSuffixes);
 
-        // must never be cached, it can be updated dyanmically
+        // never cached, it can be updated dyanmically
         private MechJebCore? _core => shared.Vessel.GetMasterMechJeb();
 
         public override BooleanValue Available() => !(_core is null);
@@ -33,14 +33,17 @@ namespace MuMech.MechJebKos
         private void InitializeSuffixes()
         {
             var nodeExecutor = new NodeExecutorBinding(() => _core);
-            var staging = new StagingControllerBinding(() => _core);
+            var stagingController = new StagingControllerBinding(() => _core);
+            var thrustController = new ThrustControllerBinding(() => _core);
 
             AddSuffix("RUNNING", new NoArgsSuffix<BooleanValue>(() =>  _core?.running ?? false,
                 "True if MechJeb is present and running on this vessel."));
             AddSuffix("NODEEXECUTOR", new NoArgsSuffix<NodeExecutorBinding>(() => nodeExecutor,
                 "The maneuver node executor."));
-            AddSuffix("STAGINGCONTROLLER", new NoArgsSuffix<StagingControllerBinding>(() => staging,
+            AddSuffix("STAGINGCONTROLLER", new NoArgsSuffix<StagingControllerBinding>(() => stagingController,
                 "The autostaging controller."));
+            AddSuffix("THRUSTCONTROLLER", new NoArgsSuffix<ThrustControllerBinding>(() => thrustController,
+                "The thrust controller (throttle limiters)."));
         }
     }
 }

--- a/MechJebKos/ComputerModuleBinding.cs
+++ b/MechJebKos/ComputerModuleBinding.cs
@@ -5,7 +5,6 @@
 
 using System;
 using kOS.Safe.Encapsulation;
-using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Utilities;
 
@@ -19,7 +18,7 @@ namespace MuMech.MechJebKos
         protected ComputerModuleBinding(Func<MechJebCore?> core)
         {
             _core = core;
-            RegisterInitializer(InitSuffixes);
+            RegisterInitializer(InitializeSuffixes);
         }
 
         // the Module deliberately re-evaluates on every call since the core can update dynamically
@@ -32,21 +31,16 @@ namespace MuMech.MechJebKos
             }
         }
 
-        private void InitSuffixes()
-        {
-            AddSuffix("ENABLED", new SetSuffix<BooleanValue>(() => Module.Enabled, value => SetEnabled(value),
-                "Whether the module is enabled."));
-            InitializeSuffixes();
-        }
-
         protected abstract void InitializeSuffixes();
 
-        protected virtual void SetEnabled(bool enabled)
+        // For modules that do cooperative engage/disengage through the module's Users pool.
+        // (There is no one-size-fits-all)
+        protected void SetUsersEnabled(bool enabled)
         {
             if (enabled)
-                Module.Enable();
+                Module.Users.Add(this);
             else
-                Module.Disable();
+                Module.Users.Remove(this);
         }
     }
 }

--- a/MechJebKos/NodeExecutorBinding.cs
+++ b/MechJebKos/NodeExecutorBinding.cs
@@ -19,6 +19,8 @@ namespace MuMech.MechJebKos
 
         protected override void InitializeSuffixes()
         {
+            AddSuffix("ENABLED", new SetSuffix<BooleanValue>(() => Module.Enabled, value => SetEnabled(value),
+                "Whether node execution is engaged: set true to execute, false to abort."));
             AddSuffix("STATE", new Suffix<StringValue>(() => Module.State.ToString(),
                 "Executor state: WARPALIGN, LEAD, BURN, or IDLE."));
             AddSuffix("MODE", new SetSuffix<StringValue>(() => Module.Mode.ToString(), value => Module.Mode = ParseMode(value),
@@ -39,7 +41,7 @@ namespace MuMech.MechJebKos
         }
 
         // The node executor engages via ExecuteOneNode / Abort rather than the plain Enabled toggle.
-        protected override void SetEnabled(bool enabled)
+        private void SetEnabled(bool enabled)
         {
             if (enabled)
                 Module.ExecuteOneNode(this);

--- a/MechJebKos/README.md
+++ b/MechJebKos/README.md
@@ -1,0 +1,3 @@
+- To build this use the Release-kOS target instead of Release.
+- This is HEAVILY EXPERIMENTAL, I can almost promise I'll break your scripts with API changes.
+- No documentation. For now, you need to be able to read the code and figure out the API yourself.

--- a/MechJebKos/StagingControllerBinding.cs
+++ b/MechJebKos/StagingControllerBinding.cs
@@ -18,6 +18,8 @@ namespace MuMech.MechJebKos
 
         protected override void InitializeSuffixes()
         {
+            AddSuffix("ENABLED", new SetSuffix<BooleanValue>(() => Module.Enabled, value => SetUsersEnabled(value),
+                "Whether continuous autostaging is engaged."));
             AddSuffix("AUTOSTAGEPREDELAY", new SetSuffix<ScalarValue>(() => Module.AutostagePreDelay.Val, value => Module.AutostagePreDelay.Val = value,
                 "Seconds to wait before firing a stage."));
             AddSuffix("AUTOSTAGEPOSTDELAY", new SetSuffix<ScalarValue>(() => Module.AutostagePostDelay.Val, value => Module.AutostagePostDelay.Val = value,
@@ -53,12 +55,5 @@ namespace MuMech.MechJebKos
                 "Stage immediately, bypassing the pre-delay."));
         }
 
-        protected override void SetEnabled(bool enabled)
-        {
-            if (enabled)
-                Module.Users.Add(this);
-            else
-                Module.Users.Remove(this);
-        }
     }
 }

--- a/MechJebKos/ThrustControllerBinding.cs
+++ b/MechJebKos/ThrustControllerBinding.cs
@@ -1,0 +1,74 @@
+/*
+ * Copyright Lamont Granquist, Sebastien Gaggini and the MechJeb contributors
+ * SPDX-License-Identifier: LicenseRef-PD-hp OR Unlicense OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT OR LGPL-2.1+
+ */
+
+using System;
+using kOS.Safe.Encapsulation;
+using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Utilities;
+
+namespace MuMech.MechJebKos
+{
+    // ADDONS:MECHJEB:THRUSTCONTROLLER - the throttle limiters / safety settings on MechJebModuleThrustController.
+    //
+    // Translatron support is omitted in favor of a future Binding around the TranslatronController.
+    // Differential throttle suport is omitted for now.
+    [KOSNomenclature("MechJebThrustController")]
+    public class ThrustControllerBinding : ComputerModuleBinding<MechJebModuleThrustController>
+    {
+        public ThrustControllerBinding(Func<MechJebCore?> core) : base(core) { }
+
+        protected override void InitializeSuffixes()
+        {
+            // NO ENABLED SUFFIX: this one is always-enabled.
+            AddSuffix("LIMITDYNAMICPRESSURE", new SetSuffix<BooleanValue>(() => Module.LimitDynamicPressure, value => Module.LimitDynamicPressure = value,
+                "Toggle to limit throttle to keep dynamic pressure under MAXDYNAMICPRESSURE."));
+            AddSuffix("MAXDYNAMICPRESSURE", new SetSuffix<ScalarValue>(() => Module.MaxDynamicPressure.Val, value => Module.MaxDynamicPressure.Val = value,
+                "Maximum dynamic pressure in Pa."));
+            AddSuffix("LIMITTOPREVENTOVERHEATS", new SetSuffix<BooleanValue>(() => Module.LimitToPreventOverheats, value => Module.LimitToPreventOverheats = value,
+                "Toggle to limit throttle to prevent engine overheats."));
+            AddSuffix("LIMITACCELERATION", new SetSuffix<BooleanValue>(() => Module.LimitAcceleration, value => Module.LimitAcceleration = value,
+                "Toggle to limit throttle to keep acceleration under MAXACCELERATION."));
+            AddSuffix("MAXACCELERATION", new SetSuffix<ScalarValue>(() => Module.MaxAcceleration.Val, value => Module.MaxAcceleration.Val = value,
+                "Maximum acceleration in m/s^2."));
+            AddSuffix("LIMITTHROTTLE", new SetSuffix<BooleanValue>(() => Module.LimitThrottle, value => Module.LimitThrottle = value,
+                "Toggle to limit throttle to at most MAXTHROTTLE."));
+            AddSuffix("MAXTHROTTLE", new SetSuffix<ScalarValue>(() => Module.MaxThrottle.Val, value => Module.MaxThrottle.Val = value,
+                "Maximum throttle as a fraction (0-1)."));
+            AddSuffix("LIMITERMINTHROTTLE", new SetSuffix<BooleanValue>(() => Module.LimiterMinThrottle, value => Module.LimiterMinThrottle = value,
+                "Toggle to keep a limited throttle at or above MINTHROTTLE."));
+            AddSuffix("MINTHROTTLE", new SetSuffix<ScalarValue>(() => Module.MinThrottle.Val, value => Module.MinThrottle.Val = value,
+                "Minimum throttle as a fraction (0-1)."));
+            AddSuffix("LIMITTOPREVENTFLAMEOUT", new SetSuffix<BooleanValue>(() => Module.LimitToPreventFlameout, value => Module.LimitToPreventFlameout = value,
+                "Toggle to limit throttle to prevent air-breathing flameout."));
+            AddSuffix("FLAMEOUTSAFETYPCT", new SetSuffix<ScalarValue>(() => Module.FlameoutSafetyPct.Val, value => Module.FlameoutSafetyPct.Val = value,
+                "Flameout intake-air safety margin, in percent."));
+            AddSuffix("MANAGEINTAKES", new SetSuffix<BooleanValue>(() => Module.ManageIntakes, value => Module.ManageIntakes = value,
+                "Toggle to open and close air intakes automatically."));
+            AddSuffix("LIMITTOPREVENTUNSTABLEIGNITION", new SetSuffix<BooleanValue>(() => Module.LimitToPreventUnstableIgnition,
+                value => Module.LimitToPreventUnstableIgnition = value,
+                "Toggle to kill throttle to prevent unstable (RealFuels) ignitions."));
+            AddSuffix("ELECTRICTHROTTLE", new SetSuffix<BooleanValue>(() => Module.ElectricThrottle, value => Module.ElectricThrottle = value,
+                "Toggle to limit electric-engine throttle by stored charge."));
+            AddSuffix("ELECTRICTHROTTLELO", new SetSuffix<ScalarValue>(() => Module.ElectricThrottleLo.Val, value => Module.ElectricThrottleLo.Val = value,
+                "Charge fraction (0-1) at which electric throttle reaches zero."));
+            AddSuffix("ELECTRICTHROTTLEHI", new SetSuffix<ScalarValue>(() => Module.ElectricThrottleHi.Val, value => Module.ElectricThrottleHi.Val = value,
+                "Charge fraction (0-1) at which electric throttle reaches full."));
+            AddSuffix("AUTORCSULLAGING", new SetSuffix<BooleanValue>(() => Module.AutoRCSUllaging, value => Module.AutoRCSUllaging = value,
+                "Toggle to use RCS to settle propellant (ullage) before ignition."));
+            AddSuffix("SMOOTHTHROTTLE", new SetSuffix<BooleanValue>(() => Module.SmoothThrottle, value => Module.SmoothThrottle = value,
+                "Toggle to smooth throttle changes over time."));
+            AddSuffix("THROTTLESMOOTHINGTIME", new SetSuffix<ScalarValue>(() => Module.ThrottleSmoothingTime, value => Module.ThrottleSmoothingTime = value,
+                "Throttle smoothing time constant in seconds."));
+            AddSuffix("LIMITER", new Suffix<StringValue>(() => Module.Limiter.ToString(),
+                "The currently active throttle limiter (NONE, THROTTLE, DYNAMIC_PRESSURE, ...)."));
+            AddSuffix("THROTTLELIMIT", new Suffix<ScalarValue>(() => Module.ThrottleLimit,
+                "The current applied throttle limit as a fraction (0-1), including transient limits."));
+            AddSuffix("THROTTLEFIXEDLIMIT", new Suffix<ScalarValue>(() => Module.ThrottleFixedLimit,
+                "The current non-transient throttle limit as a fraction (0-1)."));
+            AddSuffix("LASTTHROTTLE", new Suffix<ScalarValue>(() => Module.LastThrottle,
+                "The throttle actually applied last tick, as a fraction (0-1)."));
+        }
+    }
+}


### PR DESCRIPTION
- also sneaks in removal of LimitToTerminalVelocity that has been commented out in the UI for years and was for the pre-1.0 stock souposphere and a bit of other cleanup.