### PR TITLE
Drop solids early at % of thrust acceleration of Vessel

### DIFF
--- a/Localization/en-us.cfg
+++ b/Localization/en-us.cfg
@@ -999,7 +999,7 @@ Localization
         #MechJeb_Actiongroup_label1 = Toggle action group
 
         #MechJeb_Ascent_hotStaging = Support hotstaging
-        #MechJeb_Ascent_dropSolids = Drop solids early
+        #MechJeb_Ascent_dropSolids = Drop SRBs at
         #MechJeb_Ascent_label38 = Stage fairings when:
         #MechJeb_Ascent_label39 = dynamic pressure
         #MechJeb_Ascent_label40 = altitude

--- a/MechJeb2/MechJebModuleAscentSettings.cs
+++ b/MechJeb2/MechJebModuleAscentSettings.cs
@@ -362,7 +362,7 @@ namespace MuMech
             Core.Staging.HotStaging = true;
             Core.Staging.HotStagingLeadTime.Val = 2.0;
             Core.Staging.DropSolids = true;
-            Core.Staging.DropSolidsLeadTime.Val = 1.0;
+            Core.Staging.DropSolidsTwrPct.Val = 0.50;
 
             // turn on PSG by default
             AscentType = AscentType.PSG;

--- a/MechJeb2/MechJebModuleStagingController.cs
+++ b/MechJeb2/MechJebModuleStagingController.cs
@@ -48,8 +48,11 @@ namespace MuMech
         [Persistent(pass = (int)(Pass.TYPE | Pass.GLOBAL))]
         public bool DropSolids;
 
+        // fraction of the whole rocket's current TWR that a booster stack must drop to before the solids are
+        // jettisoned early.  Stored as a fraction (0.50 == 50%); the UI text box edits it as a percentage.
+        // (Space shuttle actual value was something close to 37%)
         [Persistent(pass = (int)(Pass.TYPE | Pass.GLOBAL))]
-        public readonly EditableDouble DropSolidsLeadTime = 1.0;
+        public readonly EditableDoubleMult DropSolidsTwrPct = new EditableDoubleMult(0.50, 0.01);
 
         public bool AutostagingOnce;
 
@@ -219,7 +222,7 @@ namespace MuMech
             GUILayout.BeginHorizontal();
             DropSolids = GUILayout.Toggle(DropSolids, CachedLocalizer.Instance.MechJebAscentDropSolids); //"Drop solids early"
             GUILayout.FlexibleSpace();
-            GuiUtils.SimpleTextBox(_sLeadTime, DropSolidsLeadTime, "s", 35); //"lead time"
+            GuiUtils.SimpleTextBox("", DropSolidsTwrPct, "% rocket accel", 35);
             GUILayout.EndHorizontal();
 
             GUILayout.EndVertical();
@@ -246,7 +249,11 @@ namespace MuMech
 
         //internal state:
         private double _lastStageTime;
+        private bool? _shouldDropSolids;
         private bool _countingDown;
+
+        // lazily computed (and cached) once per fixed update, only when first needed
+        private bool _droppingSolids => _shouldDropSolids ??= ShouldDropSolids();
         private double _stageCountdownStart;
         private Vessel _currentActiveVessel;
         private bool _initializedOnce;
@@ -290,6 +297,7 @@ namespace MuMech
 
             UpdateActiveModuleEngines(_allModuleEngines);
             UpdateBurnedResources();
+            _shouldDropSolids = null; // invalidate the cache; _droppingSolids recomputes lazily if needed this update
 
             // don't decouple active or idle engines or tanks
             if (InverseStageDecouplesActiveOrIdleEngineOrTank(Vessel.currentStage - 1, _burnedResources, _activeModuleEngines) &&
@@ -525,10 +533,60 @@ namespace MuMech
             _activeModuleEngines.Slinq().SelectMany(eng => eng.propellants.Slinq()).Select(prop => prop.id).AddTo(_burnedResources);
         }
 
-        // detect if this part is an SRB, will be dropped in the next stage, and we are below the enabled dropSolidsLeadTime
-        private bool IsBurnedOutSrbDecoupledInNextStage(Part p) =>
-            DropSolids && p.IsThrottleLockedEngine() && LastNonZeroDVStageBurnTime() < DropSolidsLeadTime &&
-            p.IsDecoupledInStage(Vessel.currentStage - 1);
+        // detect if this part is an SRB, will be dropped in the next stage, and the boosters being dropped are no
+        // longer pulling their weight (their TWR has fallen to or below the whole rocket's TWR)
+        private bool IsBurnedOutSrbDecoupledInNextStage(Part p) => DropSolids && p.IsThrottleLockedEngine() && p.IsDecoupledInStage(Vessel.currentStage - 1) && _droppingSolids;
+
+        // Drop boosters once the highest-TWR stack that will be decoupled in the next stage has dropped to or below
+        // DropSolidsTwrPct of the whole rocket's current TWR (gravity cancels, so we compare thrust/mass
+        // accelerations directly).  Comparing each booster stack against the whole-rocket TWR is equivalent to
+        // comparing it against the remaining core TWR, since the whole-rocket TWR is the mass-weighted average of
+        // the stacks and the core.
+        private bool ShouldDropSolids()
+        {
+            if (!DropSolids)
+                return false;
+
+            double referenceAccel = VesselState.CurrentThrustAcceleration * DropSolidsTwrPct;
+            double maxStackAccel = 0;
+
+            foreach (PartModule pm in _allDecouplers)
+            {
+                if (pm.part.inverseStage != Vessel.currentStage - 1)
+                    continue;
+                if (!pm.IsUnfiredDecoupler(out Part decoupledPart))
+                    continue;
+
+                double thrust = 0;
+                double mass = 0;
+                SumStackThrustAndMass(decoupledPart, ref thrust, ref mass);
+
+                if (mass <= 0)
+                    continue;
+
+                double accel = thrust / mass;
+                if (accel > maxStackAccel)
+                    maxStackAccel = accel;
+            }
+
+            return maxStackAccel <= referenceAccel;
+        }
+
+        // recursively sum the current thrust and mass of a decoupled subtree (one detached stack)
+        private static void SumStackThrustAndMass(Part p, ref double thrust, ref double mass)
+        {
+            if (p is null)
+                return;
+
+            mass += p.mass + p.GetResourceMass();
+
+            for (int i = 0; i < p.Modules.Count; i++)
+                if (p.Modules[i] is ModuleEngines engine)
+                    thrust += engine.finalThrust;
+
+            for (int i = 0; i < p.children.Count; i++)
+                SumStackThrustAndMass(p.children[i], ref thrust, ref mass);
+        }
 
         //detect if a part is above an active or idle engine in the part tree
         private bool HasActiveOrIdleEngineOrTankDescendant(Part p, List<int> tankResources, List<ModuleEngines> activeModuleEngines)

--- a/MechJebKos/StagingControllerBinding.cs
+++ b/MechJebKos/StagingControllerBinding.cs
@@ -43,8 +43,8 @@ namespace MuMech.MechJebKos
                 "Seconds before burnout to begin hotstaging."));
             AddSuffix("DROPSOLIDS", new SetSuffix<BooleanValue>(() => Module.DropSolids, value => Module.DropSolids = value,
                 "Drop spent solid boosters early."));
-            AddSuffix("DROPSOLIDSLEADTIME", new SetSuffix<ScalarValue>(() => Module.DropSolidsLeadTime.Val, value => Module.DropSolidsLeadTime.Val = value,
-                "Seconds before burnout to drop solids."));
+            AddSuffix("DROPSOLIDSLEADTIME", new SetSuffix<ScalarValue>(() => Module.DropSolidsTwrPct.Val, value => Module.DropSolidsTwrPct.Val = value,
+                "Drop solids at % of rocket thrust acceleration."));
             AddSuffix("AUTOSTAGINGONCE", new Suffix<BooleanValue>(() => Module.AutostagingOnce,
                 "True while a one-shot autostage is pending."));
             AddSuffix("AUTOSTAGEONCE", new NoArgsVoidSuffix(() => Module.AutostageOnce(this),


### PR DESCRIPTION
closes #702

retires the old burntime-left heuristic which everyone pretty much hated.

drops solids when their detached thrust acceleration (or TWR) drops below the thrust acceleration (or TWR) of the pre-detached vessel.

at 100%, detaching the boosters should result in the boosters exactly pacing the remaining core of the rocket.  anything lower than that, and the boosters should fall back.  this should entirely prevent detached boosters from flying past the core.

50% threshold is chosen as something fairly realistic, and in my testing it seemed to "look good".  the exact optimal value is something less than 100% and is difficult to calculate outside of an optimizer simulation.

as the rest of the stack then gains thrust acceleration by no longer having to pull the boosters along, the ratio between the boosters and the core is more than 2:1 after separation, but computing it as whole-vessel-vs-separated-boosters keeps the math very simple.

the shuttle historically used something like ~37%.

and to be clear, the thrust has to drop so that the `accel = thrust / (SRB dry mass+residuals)` has be well under what the core is producing.  so this auto-adjusts for low-thrust cores.  it also means that the % of rated thrust where the boosters detach will be something more like << 5%.  it takes into account that towards the end of the SRBs the mass will be very small, so the burnout TWR at rated thrust will be extraordinarily high, so the thrust needs to drop a lot.  for the shuttle, using a setting of ~37% here, would result in a threshold of around ~1.8% of rated thrust where the SRBs would separate (depending on various assumptions and some historical data).