### PR TITLE
More PSG mass constraint related stuff

### DIFF
--- a/MechJeb2/MechJebModuleHoverslamSimulation.cs
+++ b/MechJeb2/MechJebModuleHoverslamSimulation.cs
@@ -282,7 +282,7 @@ namespace MuMech
                         stagingDelay += nextDelay * (deltaStage - 1);
                     }
 
-                    _manager.AddCoast(fuelStats.StartMass * 1000, stagingDelay, fuelStats.KSPStage, mjPhase);
+                    _manager.AddCoast(fuelStats.StartMass * 1000, fuelStats.StartMass * 1000,  stagingDelay, fuelStats.KSPStage, mjPhase);
                 }
 
                 _manager.AddStage(fuelStats.StartMass * 1000, fuelStats.EndMass * 1000, fuelStats.Thrust * 1000, fuelStats.Isp,

--- a/MechJeb2/MechJebModulePSGGlueBall.cs
+++ b/MechJeb2/MechJebModulePSGGlueBall.cs
@@ -273,7 +273,9 @@ namespace MuMech
 
                         bool unguidedCoast = IsUnguided(kspStage);
 
-                        ascentBuilder.AddCoast(fuelStats.StartMass * 1000, mint, maxt, _ascentSettings.CoastStage, mjPhase, unguidedCoast);
+                        double mf = CoastingDuring() ? fuelStats.EndMass * 1000 : fuelStats.StartMass * 1000;
+
+                        ascentBuilder.AddCoast(fuelStats.StartMass * 1000, mf, mint, maxt, _ascentSettings.CoastStage, mjPhase, unguidedCoast);
                     }
                 }
 

--- a/MechJebLib/HoverslamSimulation/HoverslamSimulation.cs
+++ b/MechJebLib/HoverslamSimulation/HoverslamSimulation.cs
@@ -109,7 +109,7 @@ namespace MechJebLib.HoverslamSimulation
             double t0 = 0;
             double tf = t;
 
-            using var coastPhase = Phase.NewCoast(1.0, t0, tf, 0, 0);
+            using var coastPhase = Phase.NewCoast(1.0, 1.0, t0, tf, 0, 0);
             PropagatePhase(ref x, t0, ref tf, coastPhase);
 
             V3 vRel = x.V - V3.Cross(_w, x.R);

--- a/MechJebLib/HoverslamSimulation/HoverslamSimulationManager.cs
+++ b/MechJebLib/HoverslamSimulation/HoverslamSimulationManager.cs
@@ -102,12 +102,12 @@ namespace MechJebLib.HoverslamSimulation
                 return this;
             }
 
-            public HoverslamSimulationManager AddCoast(double m0, double ct, int kspStage, int mjPhase)
+            public HoverslamSimulationManager AddCoast(double m0, double mf, double ct, int kspStage, int mjPhase)
             {
                 if (_debug)
                     DebugPrint($"[MechJebLib.HoverslamSimulationBuilder] AddCoast({m0}, {ct}, {kspStage}, {mjPhase})");
 
-                _phases.Add(Phase.NewCoast(m0, ct, ct, kspStage, mjPhase));
+                _phases.Add(Phase.NewCoast(m0, m0, ct, ct, kspStage, mjPhase));
 
                 return this;
             }

--- a/MechJebLib/PSG/AscentBuilder.cs
+++ b/MechJebLib/PSG/AscentBuilder.cs
@@ -79,10 +79,10 @@ namespace MechJebLib.PSG
                 return this;
             }
 
-            public AscentBuilder AddCoast(double m0, double mint, double maxt, int kspStage, int mjPhase, bool unguided = false, bool massContinuity = false)
+            public AscentBuilder AddCoast(double m0, double mf, double mint, double maxt, int kspStage, int mjPhase, bool unguided = false, bool massContinuity = false)
             {
                 var sb = new StringBuilder();
-                sb.Append($"[MechJebLib.AscentBuilder] AddCoast({m0}, {mint}, {maxt}, {kspStage}, {mjPhase}");
+                sb.Append($"[MechJebLib.AscentBuilder] AddCoast({m0}, {mf}, {mint}, {maxt}, {kspStage}, {mjPhase}");
                 if (unguided)
                     sb.Append(", unguided: true");
                 if (massContinuity)
@@ -90,7 +90,7 @@ namespace MechJebLib.PSG
                 sb.Append(")");
                 DebugPrint(sb.ToString());
 
-                _phases.Add(Phase.NewCoast(m0, mint, maxt, kspStage, mjPhase, unguided, massContinuity));
+                _phases.Add(Phase.NewCoast(m0, mf, mint, maxt, kspStage, mjPhase, unguided, massContinuity));
 
                 return this;
             }

--- a/MechJebLib/PSG/Optimizer.cs
+++ b/MechJebLib/PSG/Optimizer.cs
@@ -342,7 +342,6 @@ namespace MechJebLib.PSG
                     boxConstrained[idx] = true;
             }
 
-            // FIXME: set box path boundaries on control
             for (int p = 0; p < Phases.Count; p++)
             {
                 PhaseProxy thisPhase = _vars[p];
@@ -369,14 +368,28 @@ namespace MechJebLib.PSG
 
                     if (k == 0 && !doingContinuity)
                     {
+                        // pin the initial mass if we aren't carrying over from a prior burn-coast-burn
                         bndu[idx] = bndl[idx] = Phases[p].M0;
-
                         boxConstrained[idx] = true;
+                    }
+                    else if (k == thisPhase.M.Length-1 && !Phases[p].AllowShutdown)
+                    {
+                        // pin the terminal mass if we aren't allowed to shut it down early
+                        bndu[idx] = bndl[idx] = Phases[p].Mf;
+                        boxConstrained[idx] = true;
+                    }
+                    else if (Phases[p].Coast && doingContinuity)
+                    {
+                        // for doingContinuity coasts, we need to allow the mass to be flexible.
+                        bndu[idx] = Phases[p].M0;
+                        bndl[idx] = Phases[p+1].LastAllowShutdownStage ? Sqrt(EPS) : Phases[p+1].Mf;
                     }
                     else
                     {
+                        // constrain everything else within the mass bounds, but allow the
+                        // LastAllowShutdownStage to burn down to effectively zero.
                         bndu[idx] = Phases[p].M0;
-                        bndl[idx] = 0;
+                        bndl[idx] = Phases[p].LastAllowShutdownStage ? Sqrt(EPS) : Phases[p].Mf;
                     }
                 }
             }

--- a/MechJebLib/PSG/Phase.cs
+++ b/MechJebLib/PSG/Phase.cs
@@ -30,11 +30,12 @@ namespace MechJebLib.PSG
         public bool Unguided;
         public bool Normalized;
         public bool Tagged;
+        public bool AllowShutdown;
+        public bool LastAllowShutdownStage;
 
         public int KSPStage;
         public int MJPhase;
 
-        public bool   AllowShutdown => MinT < MaxT;
         public double VacThrust     => Mdot * VexVacuum;
         public double Tau           => Coast ? double.PositiveInfinity : VexVacuum / VacThrust * M0;
         public bool   Coast         => Mdot == 0;
@@ -48,8 +49,32 @@ namespace MechJebLib.PSG
 
         private static Phase New() => new Phase();
 
+        // Runs on every pool Release. The object pool does not reset state on
+        // Borrow, and field initializers only run on a genuinely-new allocation,
+        // so every mutable field must be reset here or it leaks across reuse.
         private static void Clear(Phase phase)
         {
+            phase.M0 = 0;
+            phase.Mf = 0;
+            phase.Bt = 0;
+            phase.MaxT = 0;
+            phase.MinT = 0;
+            phase.VexVacuum = 0;
+            phase.VexCurrent = 0;
+            phase.Mdot = 0;
+            phase.MinThrottle = 0;
+
+            phase.PreciseShutdown = false;
+            phase.TerminalStage = false;
+            phase.MassContinuity = false;
+            phase.Unguided = false;
+            phase.Normalized = false;
+            phase.Tagged = false;
+            phase.AllowShutdown = false;
+            phase.LastAllowShutdownStage = false;
+
+            phase.KSPStage = 0;
+            phase.MJPhase = 0;
         }
 
         public static Phase Rent() => _pool.Borrow();
@@ -110,6 +135,7 @@ namespace MechJebLib.PSG
             Phase phase = Rent();
             phase.Set(m0, thrust, isp, mf, bt, kspStage, mjPhase, ispCurrent);
 
+            phase.AllowShutdown = allowShutdown;
             phase.MinT = allowShutdown ? 0 : bt;
             phase.MaxT = bt / minThrottle;
             phase.Unguided = unguided;
@@ -119,11 +145,12 @@ namespace MechJebLib.PSG
             return phase;
         }
 
-        public static Phase NewCoast(double m0, double minT, double maxT, int kspStage, int mjPhase, bool unguided = false, bool massContinuity = false)
+        public static Phase NewCoast(double m0, double mf, double minT, double maxT, int kspStage, int mjPhase, bool unguided = false, bool massContinuity = false)
         {
             Phase phase = Rent();
-            phase.Set(m0, 0, 0, m0, minT, kspStage, mjPhase);
+            phase.Set(m0, 0, 0, mf, minT, kspStage, mjPhase);
 
+            phase.AllowShutdown = true;
             phase.MinT = minT;
             phase.MaxT = maxT;
             phase.Unguided = unguided;

--- a/MechJebLib/PSG/PhaseCollection.cs
+++ b/MechJebLib/PSG/PhaseCollection.cs
@@ -35,7 +35,8 @@ namespace MechJebLib.PSG
                 return;
 
             Phase phase = this[lastShutdownStage];
-            phase.MaxT = 0.999 * phase.Tau;
+            phase.MaxT = phase.Tau / phase.MinThrottle;
+            phase.LastAllowShutdownStage = true;
             this[lastShutdownStage] = phase;
         }
     }

--- a/MechJebLibTest/HoverslamTests.cs
+++ b/MechJebLibTest/HoverslamTests.cs
@@ -166,7 +166,7 @@ namespace MechJebLibTest
             manager.Initial(r0, v0, t0, mu, w)
                .TargetConditions(height, descentSpeed)
                .AddStage(1631.71526258703, 1478.0574232488, 64000.0164757482, 290.000076251489, 2, 2)
-               .AddCoast(1041.14351191796, 0.5625, 0, 0)
+               .AddCoast(1041.14351191796, 1041.14351191796, 0.5625, 0, 0)
                .AddStage(1041.14351191796, 733.827833241511, 64000.0092904123, 290.000043692936, 0, 0)
                .Reconfigure(hoverslam);
 

--- a/MechJebLibTest/PSGTests/AscentTests/BuggyTests.cs
+++ b/MechJebLibTest/PSGTests/AscentTests/BuggyTests.cs
@@ -48,7 +48,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
                .Initial(r0, v0, u0, t0, mu, rbody)
                .SetTarget(attR, attR, attR, 0.498274048151861, 0, 0, 0, true, false, false)
                .AddStage(23796.5132378765, 3243.62653856172, thrust1, 241.889217870454, 4, 4)
-               .AddCoast(438.273627540912, 0, 450, 3, 3)
+               .AddCoast(438.273627540912, 438.273627540912, 0, 450, 3, 3)
                .AddStage(438.273627540912, 200.596948133534, thrust2, 220.000025355962, 2, 2, true, false)
                .AddStage(124.617032384849, 59.7961198192007, thrust3, 220.000054043093, 1, 1, true, false)
                .AddStage(41.1652332654921, 19.558262410276, thrust4, 220.00004748658, 0, 0, true, false)
@@ -247,7 +247,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
                .SetTarget(PER, 6371000, PER, 0.499303792410538, 0, 0, 0, false, false, false)
                .AddStage(176568.069166482, 33739.9978121645, thrust1, 294.100108674295, 7, 7)
                .AddStage(22640.1444759873, 7657.9646078915, thrust2, 427.000108671115, 4, 4)
-               .AddCoast(529.255624515231, 200, 2000, 1, 0)
+               .AddCoast(529.255624515231, 529.255624515231, 200, 2000, 1, 0)
                .AddStage(529.255624515231, 306.288652498034, thrust3, 279.000106442456, 0, 0, false, false)
                .Build();
 
@@ -263,7 +263,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
                .SetTarget(PER, 6371000, PER, 0.499303792410538, 0, 0, 0, false, false, false)
                .AddStage(176568.069166482, 33739.9978121645, thrust1, 294.100108674295, 7, 7)
                .AddStage(22640.1444759873, 7657.9646078915, thrust2, 427.000108671115, 4, 4)
-               .AddCoast(529.255624515231, 200, 2000, 1, 0)
+               .AddCoast(529.255624515231, 529.255624515231, 200, 2000, 1, 0)
                .AddStage(529.255624515231, 306.288652498034, thrust3, 279.000106442456, 0, 0, true, false)
                .OldSolution(solution)
                .Build();

--- a/MechJebLibTest/PSGTests/AscentTests/KerbinTests.cs
+++ b/MechJebLibTest/PSGTests/AscentTests/KerbinTests.cs
@@ -25,7 +25,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
 
             Ascent ascent = Ascent.Builder()
                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0)
-               .AddCoast(79699.9986022711, 0, 450, 0, 0)
+               .AddCoast(79699.9986022711, 79699.9986022711, 0, 450, 0, 0)
                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0, massContinuity: true)
                .Initial(new V3(365592.912061998, -475862.737003702, -1017.92554628857), new V3(138.749920001822, 106.593409136045, 5.05460467277035E-06), new V3(0.608250428397881, -0.793743408918215, -0.00172494351863861), t0, 3531600000000, 600000)
                .SetTarget(700000, 700000, 700000, 0, 0, 0, 0, false, false, false)
@@ -53,7 +53,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
             Ascent ascent = Ascent.Builder()
                .AerodynamicConstants(0.5, 19.6, 1.22497705725583, 4000, 0, 6797.80562531277, new V3(0, 0, 0.000291570900559802))
                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0)
-               .AddCoast(79699.9986022711, 0, 450, 0, 0)
+               .AddCoast(79699.9986022711, 79699.9986022711, 0, 450, 0, 0)
                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0, massContinuity: true)
                .Initial(new V3(365592.912061998, -475862.737003702, -1017.92554628857), new V3(138.749920001822, 106.593409136045, 5.05460467277035E-06), new V3(0.608250428397881, -0.793743408918215, -0.00172494351863861), t0, 3531600000000, 600000)
                .SetTarget(700000, 700000, 700000, 0, 0, 0, 0, false, false, false)

--- a/MechJebLibTest/PSGTests/AscentTests/RealRocketTests.cs
+++ b/MechJebLibTest/PSGTests/AscentTests/RealRocketTests.cs
@@ -149,7 +149,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
                .AerodynamicConstants(CD, aref, RHO0, Q_ALPHA_MAX, Q_MAX, H0, w)
                .AddStage(FIRST_STAGE_M0, FIRST_STAGE_MF, FIRST_THRUST, FIRST_ISP, 2, 2, allowShutdown: false)
                .AddStage(SECOND_STAGE_M0, SECOND_STAGE_MF, SECOND_THRUST, SECOND_ISP, 1, 1)
-               .AddCoast(SECOND_STAGE_M0, 0, 1300, 1, 1, massContinuity: true)
+               .AddCoast(SECOND_STAGE_M0, SECOND_STAGE_MF, 0, 1300, 1, 1, massContinuity: true)
                .AddStage(SECOND_STAGE_M0, SECOND_STAGE_MF, SECOND_THRUST, SECOND_ISP, 1, 1, massContinuity: true)
                .Initial(r0, v0, r0.normalized, T0, MU, R_BODY)
                .SetTarget(PER_T, APR_T, PER_T, INC_T, LAN_T, ARGP_T, 0, false, true, true)

--- a/MechJebLibTest/PSGTests/AscentTests/TheStandardTests.cs
+++ b/MechJebLibTest/PSGTests/AscentTests/TheStandardTests.cs
@@ -50,7 +50,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
                .SetTarget(PeR, ApR, PeR, incT, 0, 0, 0, true, false, false)
                .AddStage(49119.7842689869, 7114.2513992454, thrust1, 288.000034332275, 3, 3)
                .AddStage(2848.62586760223, 1363.71123994759, thrust2, 270.15767003304, 1, 1)
-               .AddCoast(678.290157913434, 0, 450, 1, 1)
+               .AddCoast(678.290157913434, 678.290157913434, 0, 450, 1, 1)
                .AddStage(678.290157913434, 177.582604389742, thrust3, 230.039271734103, 0, 0, allowShutdown: false)
                .Build();
 
@@ -115,7 +115,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
                .SetTarget(PeR, ApR, PeR, incT, 0, 0, 0, false, false, false)
                .AddStage(49119.7842689869, 7114.2513992454, thrust1, 288.000034332275, 3, 3)
                .AddStage(2848.62586760223, 1363.71123994759, thrust2, 270.15767003304, 1, 1)
-               .AddCoast(678.290157913434, 0, 450, 1, 1)
+               .AddCoast(678.290157913434, 678.290157913434, 0, 450, 1, 1)
                .AddStage(678.290157913434, 177.582604389742, thrust3, 230.039271734103, 0, 0, allowShutdown: false)
                .Build();
 
@@ -187,7 +187,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
                .SetTarget(PeR, ApR, PeR, incT, 0, 0, 0, true, false, false)
                .AddStage(49119.7842689869, 7114.2513992454, thrust1, 288.000034332275, 3, 3)
                .AddStage(2848.62586760223, 1363.71123994759, thrust2, 270.15767003304, 1, 1)
-               .AddCoast(678.290157913434, 0, 450, 1, 1)
+               .AddCoast(678.290157913434, 678.290157913434, 0, 450, 1, 1)
                .AddStage(678.290157913434, 177.582604389742, thrust3, 230.039271734103, 0, 0, true, false)
                .Build();
 

--- a/MechJebLibTest/PSGTests/AscentTests/Titan2Tests.cs
+++ b/MechJebLibTest/PSGTests/AscentTests/Titan2Tests.cs
@@ -460,8 +460,8 @@ namespace MechJebLibTest.PSGTests.AscentTests
             lanf.ShouldEqual(Deg2Rad(270), 1e-2);
 
             Ascent ascent2 = Ascent.Builder()
-               .AddStage(157355.487476332, 40267.56108456338, 2340000, 301.817977905273, 4, 4)
-               .AddStage(32758.6353093992, 6384.144733613521, 456100.006103516, 315.000112652779, 3, 3)
+               .AddStage(157355.487476332, 40267.56108456338, 2340000, 301.817977905273, 4, 4, minThrottle:0)
+               .AddStage(32758.6353093992, 6384.144733613521, 456100.006103516, 315.000112652779, 3, 3, minThrottle:0)
                .Initial(r0, v0, r0.normalized, t0, mu, rbody)
                .SetTarget(PeR, ApR, PeR, incT, Deg2Rad(270), 0, 0, false, false, false)
                .OldSolution(solution)
@@ -538,7 +538,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
 
             Ascent ascent = Ascent.Builder()
                .AddStage(157355.487476332, 40267.56108456338, 2340000, 301.817977905273, 4, 4)
-               .AddCoast(32758.6353093992, 0, 450, 3, 3)
+               .AddCoast(32758.6353093992, 32758.6353093992, 0, 450, 3, 3)
                .AddStage(32758.6353093992, 6384.144733613521, 456100.006103516, 315.000112652779, 3, 3)
                .Initial(r0, v0, r0.normalized, t0, mu, rbody)
                .SetTarget(PeR, ApR, PeR, incT, Deg2Rad(270), 0, 0, false, false, false)
@@ -579,7 +579,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
 
             Ascent ascent2 = Ascent.Builder()
                .AddStage(157355.487476332, 40267.56108456338, 2340000, 301.817977905273, 4, 4)
-               .AddCoast(32758.6353093992, 0, 450, 3, 3)
+               .AddCoast(32758.6353093992, 32758.6353093992, 0, 450, 3, 3)
                .AddStage(32758.6353093992, 6384.144733613521, 456100.006103516, 315.000112652779, 3, 3)
                .Initial(r0, v0, r0.normalized, t0, mu, rbody)
                .SetTarget(PeR, ApR, PeR, incT, Deg2Rad(270), 0, 0, false, false, false)
@@ -607,7 +607,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
 
             Ascent ascent = Ascent.Builder()
                .AddStage(157355.487476332, 40267.56108456338, 2340000, 301.817977905273, 4, 4)
-               .AddCoast(32758.6353093992, 0, 450, 3, 3)
+               .AddCoast(32758.6353093992, 32758.6353093992, 0, 450, 3, 3)
                .AddStage(32758.6353093992, 6384.144733613521, 456100.006103516, 315.000112652779, 3, 3, allowShutdown: false)
                .Initial(r0, v0, r0.normalized, t0, mu, rbody)
                .SetTarget(PeR, ApR, PeR, incT, Deg2Rad(270), 0, 0, false, false, false)
@@ -663,7 +663,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
             Ascent ascent = Ascent.Builder()
                .AddStage(157355.487476332, 40267.56108456338, 2340000, 301.817977905273, 4, 4)
                .AddStage(32758.6353093992, 6384.144733613521, 456100.006103516, 315.000112652779, 3, 3)
-               .AddCoast(32758.6353093992, 0, 450, 3, 3, massContinuity: true)
+               .AddCoast(32758.6353093992, 6384.144733613521, 0, 450, 3, 3, massContinuity: true)
                .AddStage(32758.6353093992, 6384.144733613521, 456100.006103516, 315.000112652779, 3, 3, massContinuity: true)
                .Initial(r0, v0, r0.normalized, t0, mu, rbody)
                .SetTarget(PeR, ApR, PeR, incT, Deg2Rad(270), 0, 0, false, false, false)
@@ -684,12 +684,13 @@ namespace MechJebLibTest.PSGTests.AscentTests
             solution.M(0).ShouldEqual(157355.487476332, 1e-9);
 
             psg.PrimalFeasibility.ShouldBeZero(1e-5);
-            solution.Vgo(0).ShouldEqual(8101.193073142621, 1e-3);
 
             solution.Tgo(solution.T0, 0).ShouldEqual(148.10238013870301, 1e-2);
             //solution.Tgo(solution.T0, 1).ShouldEqual(153.53757758636579, 1e-2);
             //solution.Tgo(solution.T0, 2).ShouldEqual(449.99973855863101, 1e-2);
-            solution.Tgo(solution.T0, 3).ShouldEqual(9.1537185650994335, 1e-2);
+            //solution.Tgo(solution.T0, 3).ShouldEqual(9.1537185650994335, 1e-2);
+
+            solution.Vgo(0).ShouldEqual(8101.193073142621, 1e-3);
 
             solution.U(0).normalized.ShouldEqual(new V3(0.46268355846501641, 0.84975061932167251, 0.25268124126769614), 1e-2);
 
@@ -706,7 +707,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
             Ascent ascent2 = Ascent.Builder()
                .AddStage(157355.487476332, 40267.56108456338, 2340000, 301.817977905273, 4, 4, allowShutdown: false)
                .AddStage(32758.6353093992, 6384.144733613521, 456100.006103516, 315.000112652779, 3, 3)
-               .AddCoast(32758.6353093992, 0, 450, 3, 3, massContinuity: true)
+               .AddCoast(32758.6353093992, 6384.144733613521, 0, 450, 3, 3, massContinuity: true)
                .AddStage(32758.6353093992, 6384.144733613521, 456100.006103516, 315.000112652779, 3, 3, massContinuity: true)
                .Initial(r0, v0, r0.normalized, t0, mu, rbody)
                .SetTarget(PeR, ApR, PeR, incT, Deg2Rad(270), 0, 0, false, false, false)


### PR DESCRIPTION
- better box bounds on the mass
- coasts now take m0+mf for mass continuity constraints
- i don't think we're doing recycling of Phases yet, but since the objectpool is setup, implemented a proper Clear() function