### PR TITLE
Move complexity into FixLastShutdownStage()

### DIFF
--- a/MechJebLib/PSG/Optimizer.cs
+++ b/MechJebLib/PSG/Optimizer.cs
@@ -378,18 +378,10 @@ namespace MechJebLib.PSG
                         bndu[idx] = bndl[idx] = Phases[p].Mf;
                         boxConstrained[idx] = true;
                     }
-                    else if (Phases[p].Coast && doingContinuity)
-                    {
-                        // for doingContinuity coasts, we need to allow the mass to be flexible.
-                        bndu[idx] = Phases[p].M0;
-                        bndl[idx] = Phases[p+1].LastAllowShutdownStage ? Sqrt(EPS) : Phases[p+1].Mf;
-                    }
                     else
                     {
-                        // constrain everything else within the mass bounds, but allow the
-                        // LastAllowShutdownStage to burn down to effectively zero.
                         bndu[idx] = Phases[p].M0;
-                        bndl[idx] = Phases[p].LastAllowShutdownStage ? Sqrt(EPS) : Phases[p].Mf;
+                        bndl[idx] = Phases[p].Mf;
                     }
                 }
             }

--- a/MechJebLib/PSG/Phase.cs
+++ b/MechJebLib/PSG/Phase.cs
@@ -31,7 +31,6 @@ namespace MechJebLib.PSG
         public bool Normalized;
         public bool Tagged;
         public bool AllowShutdown;
-        public bool LastAllowShutdownStage;
 
         public int KSPStage;
         public int MJPhase;
@@ -71,7 +70,6 @@ namespace MechJebLib.PSG
             phase.Normalized = false;
             phase.Tagged = false;
             phase.AllowShutdown = false;
-            phase.LastAllowShutdownStage = false;
 
             phase.KSPStage = 0;
             phase.MJPhase = 0;

--- a/MechJebLib/PSG/PhaseCollection.cs
+++ b/MechJebLib/PSG/PhaseCollection.cs
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: LicenseRef-PD-hp OR Unlicense OR CC0-1.0 OR 0BSD OR MIT-0 OR MIT OR LGPL-2.1+
  */
 
+using System;
 using System.Collections.Generic;
+using static MechJebLib.Utils.Statics;
+using static System.Math;
 
 namespace MechJebLib.PSG
 {
@@ -35,9 +38,27 @@ namespace MechJebLib.PSG
                 return;
 
             Phase phase = this[lastShutdownStage];
-            phase.MaxT = phase.Tau / phase.MinThrottle;
-            phase.LastAllowShutdownStage = true;
+            double maxt = phase.Tau / phase.MinThrottle;
+            phase.MaxT = maxt;
+            phase.Mf = Sqrt(EPS);
             this[lastShutdownStage] = phase;
+
+            if (lastShutdownStage > 0 && phase.MassContinuity)
+            {
+                // this is the coast before the massContinuity burn
+                phase = this[lastShutdownStage - 1];
+                phase.Mf = Sqrt(EPS);
+                this[lastShutdownStage-1] = phase;
+
+                if (lastShutdownStage > 1)
+                {
+                    // this is the burn before the massContinuity coast
+                    phase = this[lastShutdownStage - 2];
+                    phase.MaxT = maxt;
+                    phase.Mf = Sqrt(EPS);
+                    this[lastShutdownStage-2] = phase;
+                }
+            }
         }
     }
 }

--- a/MechJebLibTest/PSGTests/AscentTests/KerbinTests.cs
+++ b/MechJebLibTest/PSGTests/AscentTests/KerbinTests.cs
@@ -25,7 +25,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
 
             Ascent ascent = Ascent.Builder()
                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0)
-               .AddCoast(79699.9986022711, 79699.9986022711, 0, 450, 0, 0)
+               .AddCoast(79699.9986022711, 79699.9986022711, 0, 450, 0, 0, massContinuity: true)
                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0, massContinuity: true)
                .Initial(new V3(365592.912061998, -475862.737003702, -1017.92554628857), new V3(138.749920001822, 106.593409136045, 5.05460467277035E-06), new V3(0.608250428397881, -0.793743408918215, -0.00172494351863861), t0, 3531600000000, 600000)
                .SetTarget(700000, 700000, 700000, 0, 0, 0, 0, false, false, false)
@@ -37,8 +37,8 @@ namespace MechJebLibTest.PSGTests.AscentTests
             using Solution solution = psg.Solution ?? throw new Exception("null solution");
 
             psg.PrimalFeasibility.ShouldBeZero(1e-5);
-            solution.Tgo(t0).ShouldEqual(547.31871026658155, 1e-3);
-            solution.Vgo(t0).ShouldEqual(2606.641575481216, 1e-3);
+            solution.Vgo(t0).ShouldEqual(2607.3568524830271, 1e-3);
+            solution.Tgo(t0).ShouldEqual(543.01353889204177, 1e-3);
 
             (V3 rf, V3 vf) = solution.TerminalStateVectors();
         }
@@ -53,7 +53,7 @@ namespace MechJebLibTest.PSGTests.AscentTests
             Ascent ascent = Ascent.Builder()
                .AerodynamicConstants(0.5, 19.6, 1.22497705725583, 4000, 0, 6797.80562531277, new V3(0, 0, 0.000291570900559802))
                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0)
-               .AddCoast(79699.9986022711, 79699.9986022711, 0, 450, 0, 0)
+               .AddCoast(79699.9986022711, 79699.9986022711, 0, 450, 0, 0, massContinuity: true)
                .AddStage(79699.9986022711, 15700.0014199451, 1500000.09246676, 310.000018173591, 0, 0, allowShutdown: true, ispCurrent: 285.387620615011, minThrottle: 0.0, massContinuity: true)
                .Initial(new V3(365592.912061998, -475862.737003702, -1017.92554628857), new V3(138.749920001822, 106.593409136045, 5.05460467277035E-06), new V3(0.608250428397881, -0.793743408918215, -0.00172494351863861), t0, 3531600000000, 600000)
                .SetTarget(700000, 700000, 700000, 0, 0, 0, 0, false, false, false)
@@ -65,8 +65,8 @@ namespace MechJebLibTest.PSGTests.AscentTests
             using Solution solution = psg.Solution ?? throw new Exception("null solution");
 
             psg.PrimalFeasibility.ShouldBeZero(1e-5);
-            solution.Tgo(t0).ShouldEqual(303.81036578362705, 1e-3);
-            solution.Vgo(t0).ShouldEqual(3541.2477099301864, 1e-3);
+            solution.Vgo(t0).ShouldEqual(3556.1291086045085, 1e-3);
+            solution.Tgo(t0).ShouldEqual(288.72123204666434, 1e-3);
 
             (V3 rf, V3 vf) = solution.TerminalStateVectors();
         }

--- a/MechJebLibTest/PSGTests/AscentTests/Titan2Tests.cs
+++ b/MechJebLibTest/PSGTests/AscentTests/Titan2Tests.cs
@@ -686,9 +686,9 @@ namespace MechJebLibTest.PSGTests.AscentTests
             psg.PrimalFeasibility.ShouldBeZero(1e-5);
 
             solution.Tgo(solution.T0, 0).ShouldEqual(148.10238013870301, 1e-2);
-            //solution.Tgo(solution.T0, 1).ShouldEqual(153.53757758636579, 1e-2);
-            //solution.Tgo(solution.T0, 2).ShouldEqual(449.99973855863101, 1e-2);
-            //solution.Tgo(solution.T0, 3).ShouldEqual(9.1537185650994335, 1e-2);
+            solution.Tgo(solution.T0, 1).ShouldEqual(153.53757758636579, 1e-2);
+            solution.Tgo(solution.T0, 2).ShouldEqual(449.99973855863101, 1e-2);
+            solution.Tgo(solution.T0, 3).ShouldEqual(9.1537185650994335, 1e-2);
 
             solution.Vgo(0).ShouldEqual(8101.193073142621, 1e-3);
 


### PR DESCRIPTION
Make the Problem ultimately responsible for messing around with bounds issues caused by sequencing and get that responsibility out of the optimizer.

Fixes an actual test bug in the KerbinTests