### PR TITLE
Update zh-cn localization: add missing keys and fix untranslated entries

### DIFF
--- a/Localization/zh-cn.cfg
+++ b/Localization/zh-cn.cfg
@@ -2,41 +2,41 @@ Localization
 {
     zh-cn
     {
-        #MechJeb_ModuleAreLocked = 部分模块被禁用，直到你在科技树中解锁相应节点或升级追踪站。
+        #MechJeb_ModuleAreLocked = 部分模块功能关闭直到你解锁科技树的关键性节点和升级追踪站.
         #MechJeb_OnlineManualbutton = 在线手册
 
-        #MechJeb_InstallCheckA_title = MechJeb2 安装不正确
-        #MechJeb_InstallCheckA_msg = MechJeb2 安装不正确，无法正常工作。\n所有 MechJeb2 文件应位于 KSP 中如下目录 \n<KSP>\n\tGameData\n\t\tMechJeb2\n\t\t\tParts\n\t\t\tPlugins\n\n请勿移动 MechJeb2 文件夹中的任何文件。\n\n不正确的路径：\n
+        #MechJeb_InstallCheckA_title = 错误的Mechjeb2安装方式
+        #MechJeb_InstallCheckA_msg = MechJeb2安装不正确，无法正常工作.\nMechJeb2的所有文件都应该放在如下路径中 \n<KSP>\n\tGameData\n\t\tMechJeb2\n\t\t\tParts\n\t\t\tPlugins\n\n不要从MechJeb2文件夹中移动任何文件.\n\n不正确的路径:\n
 
-        #MechJeb_InstallCheckB_title = 冗余的 MechJebMenuToolbar 安装
-        #MechJeb_InstallCheckB_msg = 检测到 MechJebMenuToolbar 已安装，但此版本的 MechJeb2 已内置对 Blizzy78 Toolbar Plugin 的支持。\n请删除此 dll：
+        #MechJeb_InstallCheckB_title = MechJebMenuToolbar的安装是多余的
+        #MechJeb_InstallCheckB_msg = 检测到安装MechJebMenuToolbar, 但此版本的MechJeb2已包含对Blizzy78工具栏插件的支持.\n请把这些dll文件删除:\n
 
-        #MechJeb_MechJebInfo_VABSPH = 由 MechJeb™ 提供姿态控制
+        #MechJeb_MechJebInfo_VABSPH = MechJeb™姿态控制
 
 
-        //ManeuverPlaner
+    //ManeuverPlaner
 
-        #MechJeb_Maneuver_Planner_title = 机动节点规划器
+        #MechJeb_Maneuver_Planner_title = 机动节点规划
 
         #MechJeb_Maneu_Autowarp = 自动加速
 
-        #MechJeb_Maneu_Tolerance = 容差：
+        #MechJeb_Maneu_Tolerance = 误差:
 
-        #MechJeb_Maneu_Lead_time = 预留时间：
+        #MechJeb_Maneu_Lead_time = 预留时间:
 
-        #MechJeb_of = 的
+        #MechJeb_of = /
 
-        #MechJeb_Maneu_STB = 轨道规划
+        #MechJeb_Maneu_STB = 计算燃烧值
 
         #MechJeb_Maneu_TimeSelect1 = 在合适的时间
 
         #MechJeb_Maneu_TimeSelect2 = 在下个远拱点
 
-        #MechJeb_Maneu_TimeSelect3 = 在与目标最近接近时
+        #MechJeb_Maneu_TimeSelect3 = 在离目标最近的距离
 
-        #MechJeb_Maneu_TimeSelect4 = 在赤道升交点
+        #MechJeb_Maneu_TimeSelect4 = 在AN处
 
-        #MechJeb_Maneu_TimeSelect5 = 在赤道降交点
+        #MechJeb_Maneu_TimeSelect5 = 在DN处
 
         #MechJeb_Maneu_TimeSelect6 = 在下个近拱点
 
@@ -46,177 +46,193 @@ Localization
 
         #MechJeb_Maneu_TimeSelect9 = 在固定时间后
 
-        #MechJeb_Maneu_TimeSelect10 = 在这个轨道高度
+        #MechJeb_Maneu_TimeSelect10 = 在这个海拔高度
 
-        #MechJeb_Maneu_TimeSelect11 = 在最近的 AN/DN 点
+        #MechJeb_Maneu_TimeSelect11 = 在最近的AN/DN点
 
-        #MechJeb_Maneu_TimeSelect12 = 在最省燃料的 AN/DN 点
+        #MechJeb_Maneu_TimeSelect12 = 在最省燃料的AN/DN点
 
-        #MechJeb_Maneu_TimeSelect13 = 在与目标最近的 AN/DN 点
+        #MechJeb_Maneu_TimeSelect13 = 在最近的目标AN/DN点
 
-        #MechJeb_Maneu_TimeSelect14 = 在与目标最省燃料的 AN/DN 点
+        #MechJeb_Maneu_TimeSelect14 = 在最节能的目标AN/DN点
 
-        #MechJeb_Maneu_errorMessage = 创建机动节点时发生错误。
+        #MechJeb_Maneu_errorMessage = 创建变轨节点发生错误
 
         #MechJeb_Maneu_Exception1 = 警告：轨道为双曲线，不存在远拱点。
 
         #MechJeb_Maneu_Exception2 = 警告：未选择目标。
 
-        #MechJeb_Maneu_Exception3 = 警告：无法在此高度进行轨道圆化，因为当前轨道无法达到此高度。
+        #MechJeb_Maneu_Exception3 = 警告：不能在此高度进行圆轨，当前轨道无法到达此高度。
 
         #MechJeb_Maneu_Exception4 = 警告：赤道升交点不存在。
 
         #MechJeb_Maneu_Exception5 = 警告：赤道降交点不存在。
 
-        #MechJeb_Maneu_Exception6 = 警告：既不存在升交点也不存在降交点。
+        #MechJeb_Maneu_Exception6 = 警告：既不存在上升节点也不存在下降节点
 
-        #MechJeb_Maneu_Exception7 = 警告：既不存在升交点也不存在降交点。
+        #MechJeb_Maneu_Exception7 = 警告：既不存在上升节点也不存在下降节点。
 
 
         //AdvancedTransfer
         #MechJeb_AdvancedTransfer_title = 高级轨道转移
 
         #MechJeb_adv_modeName1 = 限定时间
-        #MechJeb_adv_modeName2 = 猪排图（Porkchop Plot）
+        #MechJeb_adv_modeName2 = 自动选择
 
-        #MechJeb_adv_Preconditions1 = 初始轨道不得为双曲线
+        #MechJeb_adv_Preconditions1 = 轨道不得为双曲线
 
-        #MechJeb_adv_Preconditions2 = 初始轨道不得脱离<<1>>的引力范围。
+        #MechJeb_adv_Preconditions2 = 初始轨道不能逃脱 <<1>> 的引力范围.
 
-        #MechJeb_adv_Preconditions3 = 必须为行星际转移选择一个目标。
+        #MechJeb_adv_Preconditions3 = 必须为星际转移选择一个目标.
 
-        #MechJeb_adv_Preconditions4 = 从环绕<<1>>的轨道上进行行星际转移是没有意义的。
+        #MechJeb_adv_Preconditions4 = 从环绕<<1>>的轨道上绘制星际转移图是没有意义的
 
-        #MechJeb_adv_Preconditions5 = 请使用双脉冲(霍曼)转移功能转移到绕<<1>>运行的其他天体。
+        #MechJeb_adv_Preconditions5 = 使用经典霍曼转移功能来到达另一个绕<<1>>轨道运行的物体
 
-        #MechJeb_adv_Preconditions6 = 从<<1>>的引力范围内发起的行星际转移，目标必须是围绕<<2>>的母星<<3>>运行的天体。
+        #MechJeb_adv_Preconditions6 = 从<<1>>引力范围内发出的星际间转移必须以<<2>>环绕的母星——<<3>>为目标.
 
-        #MechJeb_adv_Preconditions7 = 请使用双脉冲(霍曼)转移功能来转移到其它绕太阳运行的天体。
+        #MechJeb_adv_Preconditions7 = 使用经典霍曼转移功能来到达另一个绕太阳运行的天体
 
-        #MechJeb_adv_Preconditions8 = 你已经在<<1>>轨道上。
+        #MechJeb_adv_Preconditions8 = 你已经在 <<1>> 轨道上.
 
-        #MechJeb_adv_computing = 计算中：
+        #MechJeb_adv_computing = 计算中:
 
         #MechJeb_adv_reset_button = 重置
-        #MechJeb_adv_captureburn = 包含捕获点火的 ΔV
+        #MechJeb_adv_captureburn = 计算捕获燃烧值
         #MechJeb_adv_periapsis = 近拱点
-        #MechJeb_adv_label1 = 任何时间
-        #MechJeb_adv_label2 = 约束条件选择：
-        #MechJeb_adv_label3 = 出发倒计时
-        #MechJeb_adv_label4 = 转移总时间
-        #MechJeb_adv_label5 = 最晚到达时间
-        #MechJeb_adv_button1 = 最少 ΔV 消耗
-        #MechJeb_adv_button2 = 尽早开始
+        #MechJeb_adv_label1 = 现在任意时间
+        #MechJeb_adv_label2 = 选择:
+        #MechJeb_adv_label3 = 出发日期\u0020
+        #MechJeb_adv_label4 = 转移时间\u0020
+        #MechJeb_adv_label5 = 最长到达时间
+        #MechJeb_adv_button1 = 最少ΔV使用
+        #MechJeb_adv_button2 = 尽可能快
 
         #MechJeb_adv_Exception1 = 计算未完成
         #MechJeb_adv_Exception2 = 开始计算
         #MechJeb_adv_Exception3 = 计算失败
-        #MechJeb_adv_Exception4 = 无效的选择点。
+        #MechJeb_adv_Exception4 = 无效的选择点.
 
         //Hohmann transfer
-        #MechJeb_Hohm_title = 霍曼转移
-        #MechJeb_Hohm_transfer = 转移
-        #MechJeb_Hohm_rendezvous = 交会
-        #MechJeb_Hohm_flyby = 飞掠 / 撞击
-        #MechJeb_Hohm_intercept = 拦截
-        #MechJeb_Hohm_matchOrbit = 匹配轨道
-        #MechJeb_Hohm_arrivalDelay = 到达延迟
-        #MechJeb_Hohm_createArrivalNode = 创建到达节点
-        #MechJeb_Hohm_simpleTransfer = 仅共面
+        #MechJeb_Hohm_title = 双脉冲 (霍曼)转移到目标
+        #MechJeb_Hohm_intercept_only = 仅拦截, 不计算捕获 (撞击/飞掠)
+        #MechJeb_Hohm_simpleTransfer = 简单共面霍曼转移
+        #MechJeb_Hohm_Label1 = 微调目标周期偏移
 
-        #MechJeb_Hohm_Exception1 = 必须为此机动选择一个目标。
-        #MechJeb_Hohm_Exception2 = 机动目标必须在同一引力范围内。
-        #MechJeb_Hohm_Exception3 = 与目标的升交点不存在。
-        #MechJeb_Hohm_Exception4 = 与目标的降交点不存在。
-        #MechJeb_Hohm_Exception5 = 与目标的升交点和降交点都不存在。
+        #MechJeb_Hohm_Exception1 = 必须为霍曼转移选择目标。
+        #MechJeb_Hohm_Exception2 = 进行霍曼转移的目标必须在同一引力范围内
+        #MechJeb_Hohm_Exception3 = 与目标的升交点不存在.
+        #MechJeb_Hohm_Exception4 = 与目标的降交点不存在.
+        #MechJeb_Hohm_Exception5 = 与目标的降交点与升交点都不存在.
 
         //Change Apoapsis
-        #MechJeb_Ap_title = 更改远拱点
-        #MechJeb_Ap_label1 = 新远拱点：
-        #MechJeb_Ap_Exception = 新远拱点不能低于轨道机动点火时的高度 (<<1>>)//(m)
+        #MechJeb_Ap_title = 变更远拱点
+        #MechJeb_Ap_label1 = 新远拱点:
+        #MechJeb_Ap_Exception = 新远拱点不能低于执行高度(<<1>>)//(m)
 
         //Change both Pe and Ap
-        #MechJeb_both_title = 更改远拱点与近拱点
-        #MechJeb_both_label1 = 新近拱点：
-        #MechJeb_both_label2 = 新远拱点：
+        #MechJeb_both_title = 修改远拱点与近拱点
+        #MechJeb_both_label1 = 新近拱点:
+        #MechJeb_both_label2 = 新远拱点:
 
-        #MechJeb_both_Exception1 = 新近拱点不能高于轨道机动点火时的高度 (<<1>>)//(m)
-        #MechJeb_both_Exception2 = 新远拱点不能低于轨道机动点火时的高度
-        #MechJeb_both_Exception3 = 新近拱点不得低于<<1>>的负半径
+        #MechJeb_both_Exception1 = 新近拱点不能低于执行高度(<<1>>)//(m)
+        #MechJeb_both_Exception2 = 新远拱点不能低于执行高度
+        #MechJeb_both_Exception3 = 新近拱点不能低于<<1>>的半径
 
         //Change inclination
-        #MechJeb_inclination_title = 更改轨道倾角
-        #MechJeb_inclination_label = 新轨道倾角：
+        #MechJeb_inclination_title = 修改轨道倾角
+        #MechJeb_inclination_label = 新轨道倾角:
 
         //change longitude of ascending node
-        #MechJeb_AN_title = 更改升交点经度
-        #MechJeb_AN_label = 新升交点经度：
-        #MechJeb_AN_error = 警告：当前轨道倾角<<1>>º 较低（建议大于10º），因此机动可能不准确
+        #MechJeb_AN_title = 修改升交点经度
+        #MechJeb_AN_label = 新升交点经度:
+        #MechJeb_AN_error = 警告：轨道平面的倾角低于<<1>>º (建议 > 10º) 机动节点执行结果可能不够精确
 
         //Change Periapsis
-        #MechJeb_Pe_title = 更改近拱点
-        #MechJeb_Pe_label = 新近拱点：
-        #MechJeb_Pe_Exception1 = 新近拱点不得高于轨道机动点火时的高度
-        #MechJeb_Pe_Exception2 = 新近拱点不得低于<<1>>的负半径
+        #MechJeb_Pe_title = 变更近拱点
+        #MechJeb_Pe_label = 新近拱点:
+        #MechJeb_Pe_Exception1 = 新的近点不能高于执行高度
+        #MechJeb_Pe_Exception2 = 新的近点不能低于<<1>>的半径
 
         //Change Semi-major axis
-        #MechJeb_Sa_title = 更改半长轴
-        #MechJeb_Sa_label = 新半长轴：
-        #MechJeb_Sa_errormsg = 警告：新半长轴非常大，可能导致轨道变为双曲线
-        #MechJeb_Sa_Exception = 新半长轴长度不得小于<<1>>的半径加上两倍轨道机动点火时的高度
+        #MechJeb_Sa_title = 变更半长轴
+        #MechJeb_Sa_label = 新半长轴:
+        #MechJeb_Sa_errormsg = 警告:新的半长轴非常大，可能会导致轨道为双曲线
+        #MechJeb_Sa_Exception = 半长轴不能小于两倍执行高度加上<<1>>的半径的值
 
         //change surface longitude of apsis
-        #MechJeb_la_title = 更改远近拱点的地面投影经度
-        #MechJeb_la_label = 一圈后新的地面投影经度：
+        #MechJeb_la_title = 变更远点地面投影经度
+        #MechJeb_la_label = 后一个轨道的新地面投影经度:
 
         //fine tune closest approach to target
         #MechJeb_approach_title = 微调捕获轨道
-        #MechJeb_approach_label1 = 最终近拱点的大致高度
-        #MechJeb_approach_label2 = 最接近点的距离
-        #MechJeb_approach_label3 = 规划所需最少 ΔV 的点火机动。
-        #MechJeb_approach_Exception1 = 必须选择一个用于轨道修正的目标。
-        #MechJeb_approach_Exception2 = 轨道修正目标必须在同一引力范围内
-        #MechJeb_Approach_errormsg = 警告：修正前的轨道似乎并未靠近目标。计划的轨道修正机动可能很极端。建议先规划机动到近似截获轨道，然后再规划微调捕获轨道。
+        #MechJeb_approach_label1 = 最终近拱点大致高度
+        #MechJeb_approach_label2 = 最接近点距离
+        #MechJeb_approach_label3 = 计划变轨所需的最少ΔV
+        #MechJeb_approach_Exception1 = 必须选择一个目标进行轨道修正.
+        #MechJeb_approach_Exception2 = 进行轨道修正的目标必须在同一引力范围内
+        #MechJeb_Approach_errormsg = 警告:修正之前的轨道似乎离目标有一定距离,轨道修正方案可能比较极端.建议先设定一条比较接近的交会轨道,然后再进行轨道修正.
 
         //intercept target at chosen time
-        #MechJeb_intercept_title = 在选定时间截获目标
-        #MechJeb_intercept_label = 机动后与目标相遇的时间：
-        #MechJeb_intercept_Exception1 = 必须选择要截获的目标。
-        #MechJeb_intercept_Exception2 = 目标必须在同一引力范围内。
+        #MechJeb_intercept_title = 在选定时间拦截目标
+        #MechJeb_intercept_label = 变轨动作后接近所需时间
+        #MechJeb_intercept_Exception1 = 必须选定要拦截的目标.
+        #MechJeb_intercept_Exception2 = 目标必须在同一引力范围内.
 
         //match planes with target
-        #MechJeb_match_planes_title = 匹配目标轨道平面
-        #MechJeb_match_planes_Exception1 = 必须选择要匹配轨道平面的目标。
-        #MechJeb_match_planes_Exception2 = 只能与同一引力范围内的目标匹配轨道平面。
-        #MechJeb_match_planes_Exception3 = 与目标的升交点不存在。
-        #MechJeb_match_planes_Exception4 = 与目标的降交点不存在。
-        #MechJeb_match_planes_Exception5 = 与目标既不存在升交点也不存在降交点。
-        #MechJeb_match_planes_Exception6 = 错误的时间引用。
+        #MechJeb_match_planes_title = 匹配目标轨道
+        #MechJeb_match_planes_Exception1 = 必须选择一个目标来进行轨道匹配.
+        #MechJeb_match_planes_Exception2 = 只能匹配在同一引力范围内的目标.
+        #MechJeb_match_planes_Exception3 = 与目标的升交点不存在.
+        #MechJeb_match_planes_Exception4 = 与目标的降交点不存在.
+        #MechJeb_match_planes_Exception5 = 与目标的降交点与升交点不存在..
+        #MechJeb_match_planes_Exception6 = 错误的时间引用.
 
         //match velocities with target
         #MechJeb_match_v_title = 匹配目标速度
-        #MechJeb_match_v_Exception1 = 必须选择要匹配速度的目标。
-        #MechJeb_match_v_Exception2 = 只能与同一引力范围内的目标匹配速度。
+        #MechJeb_match_v_Exception1 = 必须选择一个目标来进行速度匹配.
+        #MechJeb_match_v_Exception2 = 目标必须在同一引力范围内.
 
         //resonant orbit
-        #MechJeb_resonant_title = 创建共振轨道
-        #MechJeb_resonant_label1 = 将你的轨道周期改为当前轨道周期的<<1>>倍
-        #MechJeb_resonant_label2 = 新的轨道周期比例：
+        #MechJeb_resonant_title = 共振轨道
+        #MechJeb_resonant_label1 = 把你的轨道周期变更当前轨道周期的<<1>>
+        #MechJeb_resonant_label2 = 新的轨道周期 :
 
         //return from a moon
-        #MechJeb_return_title = 从卫星返回
-        #MechJeb_return_label1 = 最终近拱点的大致高度：
-        #MechJeb_return_label2 = 在下一个返回窗口进行机动。
-        #MechJeb_return_errormsg = 警告：建议在近似圆形的轨道上（偏心率小于0.2）计划返回机动。当前轨道的偏心率为<<1>>，因此计划的返回轨道可能不准确。
-        #MechJeb_return_Exception =<<1>>并未绕另一个你可返回的天体运行。
+        #MechJeb_return_title = 从卫星上返回
+        #MechJeb_return_label1 = 最终近拱点大致高度:
+        #MechJeb_return_label2 = 在下一个窗口期返回.
+        #MechJeb_return_errormsg = 警告:建议从接近圆形的轨道(离心率<0.2)开始执行.返回计划是从离心率<<1>>的轨道开始的,可能不准确.
+        #MechJeb_return_Exception = <<1>>并不在你可以返回的天体的轨道上.
+
+        //transfer to another planet
+        #MechJeb_transfer_title = 转移到另一个星球
+        #MechJeb_transfer_Label1 = 计划变轨:
+        #MechJeb_transfer_Label2 = 在下一个转移窗口.
+        #MechJeb_transfer_Label3 = 尽可能快
+        #MechJeb_transfer_Label4 = 使用此模式将使您的保修无效
+
+        #MechJeb_transfer_Exception1 = 必须为星际转移选择一个目标
+
+        #MechJeb_transfer_Exception2 = 在<<1>>的轨道上绘制星际间转移是没有意义的.
+
+        #MechJeb_transfer_Exception3 = 使用经典霍曼转移来与环绕在<<1>>上的物体交会.
+
+        #MechJeb_transfer_Exception4 =  从<<1>>引力范围内发出的星际间转移必须以<<2>>环绕的母星——<<3>>为目标.
+
+        #MechJeb_transfer_errormsg1 = 警告:目标的轨道平面与<<2>>º的轨道平面成<<1>>º角（建议最多30度角）.计划中的星际间转移可能无法正确到达目标
+
+        #MechJeb_transfer_errormsg2 = 警告: 建议从与<<2>>围绕<<3>>的轨道在同一平面的轨道上的<<1>>开始进行星际间转移. 起始环绕<<4>>的轨道是倾角为 <<5>>º对<<6>>的环绕<<7>>的轨道(建议< 10º). 计划中的星际间转移可能无法正确到达目标.
+
+        #MechJeb_transfer_errormsg3 = 警告:建议从接近圆形的轨道(离心率< 0.2)开始进行星际间转移.转移计划是从离心率为<<1>>的轨道开始的，因此可能无法正确与目标回合.
 
         //Circularize
         #MechJeb_Maneu_circularize_title = 圆化轨道
         #MechJeb_Maneu_createNodeBtn01 = 新建节点
         #MechJeb_Maneu_createNodeBtn02 = 更改最后一个
-        #MechJeb_Maneu_createlab1 = 机动节点：
-        #MechJeb_Maneu_createlab2 = 创建新的机动节点：
-        #MechJeb_Maneu_createlab3 = 在上一个机动节点之后
+        #MechJeb_Maneu_createlab1 = 机动节点:
+        #MechJeb_Maneu_createlab2 = 创建新的机动节点:
+        #MechJeb_Maneu_createlab3 = 上个变轨节点之后.
         #MechJeb_Maneu_button1 = 创建节点
         #MechJeb_Maneu_button2 = 创建并执行
         #MechJeb_Maneu_button3 = 移除所有节点
@@ -224,33 +240,115 @@ Localization
         #MechJeb_Maneu_button5 = 执行所有节点
         #MechJeb_Maneu_button6 = 中止节点执行
 
+
+    //Aircraft Approach & Autoland
+        #MechJeb_ApproAndLand_title = 飞机进场 & 着陆
+        #MechJeb_ApproAndLand_label1 = 着陆
+        #MechJeb_ApproAndLand_label2 = 跑道距离:
+        #MechJeb_ApproAndLand_label3 = 导航球显示降落导航点
+        #MechJeb_ApproAndLand_label4 = 进场速度:
+        #MechJeb_ApproAndLand_label5 = 接地速度:
+        #MechJeb_ApproAndLand_label6 = 接地时的将推力反向
+        #MechJeb_ApproAndLand_label7 = 一落地就刹车
+        #MechJeb_ApproAndLand_label8 = 状态:
+        #MechJeb_ApproAndLand_label9 = 导航点距离: <<1>> m
+        #MechJeb_ApproAndLand_label10 = 设定速度: <<1>> m/s
+        #MechJeb_ApproAndLand_label11 = 设定高度: <<1>> m
+        #MechJeb_ApproAndLand_label12 = 设定垂直速度: <<1>> m/s
+        #MechJeb_ApproAndLand_label13 = 设定航向: <<1>>º
+        #MechJeb_ApproAndLand_label14 = 下滑道:
+        #MechJeb_ApproAndLand_MaxRateOfDescent = 最大下降率:
+
+        #MechJeb_ApproAndLand_approachState1 = 向 起始进近点 进发
+        #MechJeb_ApproAndLand_approachState2 = 向 最后进近点 进发
+        #MechJeb_ApproAndLand_approachState3 = 截获下滑道中
+        #MechJeb_ApproAndLand_approachState4 = 向 接地点 进发
+        #MechJeb_ApproAndLand_approachState5 = 等待抬头
+        #MechJeb_ApproAndLand_approachState6 = 抬头中
+        #MechJeb_ApproAndLand_approachState7 = 滑行
+
+        #MechJeb_ApproAndLan_button1 = 自动着陆
+        #MechJeb_ApproAndLan_button2 = 终止
+
+    //Aircraft Autopilot
+        #MechJeb_Aircraftauto_title = 飞机自动驾驶仪
+        #MechJeb_Aircraftauto_button1 = 关闭自动驾驶
+        #MechJeb_Aircraftauto_button2 = 启用自动驾驶
+        #MechJeb_Aircraftauto_button3 = PID
+        #MechJeb_Aircraftauto_button4 = 隐藏PID
+
+        #MechJeb_Aircraftauto_Label1 = 高度保持
+
+        #MechJeb_Aircraftauto_btnset1 = 设置
+
+        #MechJeb_Aircraftauto_Label2 = 垂直速度保持
+
+        #MechJeb_Aircraftauto_btnset2 = 设置
+
+        #MechJeb_Aircraftauto_VS =    V/S ±
+
+        #MechJeb_Aircraftauto_Label3 = 垂直速度限制
+
+        #MechJeb_Aircraftauto_btnset3 = 设置
+
+        #MechJeb_Aircraftauto_Label4 = 航向保持
+
+        #MechJeb_Aircraftauto_btnset4 = 设置
+
+        #MechJeb_Aircraftauto_Label5 = 角度保持
+
+        #MechJeb_Aircraftauto_btnset5 = 设置
+
+        #MechJeb_Aircraftauto_Label6 =     角度限制 ±
+
+        #MechJeb_Aircraftauto_btnset6 = 设置
+
+        #MechJeb_Aircraftauto_Label7 = 速度保持
+
+        #MechJeb_Aircraftauto_btnset7 = 设置
+
+        #MechJeb_Aircraftauto_Label8 = 加速度
+
+        #MecgJeb_Aircraftauto_error1 = 错误:<<1>> 目标:<<2>> 当前:<<3>>
+        #MecgJeb_Aircraftauto_error2 = 错误:<<1>> 目标:<<2>> 当前:<<3>> PID: <<4>>
+
+        #MechJeb_Aircraftauto_Label10 = 滚转
+        #MechJeb_Aircraftauto_Pitch = 俯仰
+
+        #MechJeb_Aircraftauto_Limits = 限制:
+        #MechJeb_Aircraftauto_RollLimit = 滚转
+        #MechJeb_Aircraftauto_YawLimit = 偏航
+        #MechJeb_Aircraftauto_PitchUpLimit = 抬头
+        #MechJeb_Aircraftauto_PitchDownLimit = 低头
+
     //Ascent Guidance
         #MechJeb_Ascent_title = 自动发射
         #MechJeb_Ascent_ascentPathList1 = 经典的上升配置
-        #MechJeb_Ascent_ascentPathList3 = 序列二次规划法（SQP）引导（RSS/RO）
+        #MechJeb_Ascent_ascentPathList2 = Stock-style GravityTurn™
+        #MechJeb_Ascent_ascentPathList3 = Primer Vector Guidance (RSS/RO)
 
-        #MechJeb_Ascent_status1 = 发射前
+        #MechJeb_Ascent_status1 = 准备发射
         #MechJeb_Ascent_status2 = 关闭
-        #MechJeb_Ascent_status3 = 发射前
-        #MechJeb_Ascent_status4 = 飞船未着陆，跳过发射前步骤
-        #MechJeb_Ascent_status5 = 正在收起太阳能电池板
+        #MechJeb_Ascent_status3 = 准备发射
+        #MechJeb_Ascent_status4 = 飞船没有着陆，跳过准备发射
+        #MechJeb_Ascent_status5 = 缩回太阳能电池板
         #MechJeb_Ascent_status6 = 等待点火
-        #MechJeb_Ascent_status7 = 轨道圆化
-        #MechJeb_Ascent_status8 = 滑行到轨道圆化执行点
+        #MechJeb_Ascent_status7 = 圆化轨道
+        #MechJeb_Ascent_status8 = 滑行到圆化轨道执行点
         #MechJeb_Ascent_status18 = 垂直上升
         #MechJeb_Ascent_status19 = 微调中间高度
-        #MechJeb_Ascent_status20 = 开始重力转向
+        #MechJeb_Ascent_status20 = 启用重力转向
         #MechJeb_Ascent_status21 = 微调远拱点
         #MechJeb_Ascent_status22 = 重力转向
         #MechJeb_Ascent_status23 = 滑行到大气层边缘
-        #MechJeb_Ascent_status24 = 保持远拱点
+        #MechJeb_Ascent_status24 = 保持远点
 
-        #MechJeb_NavBallGuidance_btn1 = 隐藏上升时的导航球引导
-        #MechJeb_NavBallGuidance_btn2 = 显示上升时的导航球引导
+        #MechJeb_NavBallGuidance_btn1 = 隐藏发射路径
+        #MechJeb_NavBallGuidance_btn2 = 显示发射路径
 
-        #MechJeb_Ascent_button1 = 解除自动驾驶
-        #MechJeb_Ascent_button2 = 接通自动驾驶
-        #MechJeb_Ascent_button3 = 重置引导（切勿点击！）
+        #MechJeb_Ascent_button1 = 脱离自动驾驶
+        #MechJeb_Ascent_button2 = 自动驾驶
+        #MechJeb_Ascent_button3 = 重置导航(千万不要按)
         #MechJeb_Ascent_button4 = 目标
         #MechJeb_Ascent_button5 = 导航
         #MechJeb_Ascent_button6 = 选项
@@ -261,114 +359,114 @@ Localization
         #MechJeb_Ascent_button11 = 目标
         #MechJeb_Ascent_button12 = 选项
         #MechJeb_Ascent_button13 = 当前
-        #MechJeb_Ascent_button14 = 发射到目标交汇轨道:
-        #MechJeb_Ascent_button15 = 发射到目标轨道平面
-        #MechJeb_Ascent_button16 = 在行星际转移窗口期发射
+        #MechJeb_Ascent_button14 = 发射至目标:
+        #MechJeb_Ascent_button15 = 发射至目标轨道面
+        #MechJeb_Ascent_button16 = 在窗口期发射
         #MechJeb_Ascent_button17 = 终止
-        #MechJeb_Ascent_LaunchToTargetLan = 发射到目标的升交点赤经
-        #MechJeb_Ascent_LaunchToLan = 发射到升交点赤经
+        #MechJeb_Ascent_LaunchToTargetLan = 发射至目标升交点经度
+        #MechJeb_Ascent_LaunchToLan = 发射至升交点经度
 
-        #MechJeb_Ascent_label1 = 目标近拱点：
-        #MechJeb_Ascent_label2 = 目标远拱点：
-        #MechJeb_Ascent_label3 = Ap < Pe：将会在 Pe 处圆化轨道
-        #MechJeb_Ascent_label4 = 目标轨道为双曲线（远拱点为负）
+        #MechJeb_Ascent_label1 = 目标近拱点:
+        #MechJeb_Ascent_label2 = 目标远拱点:
+        #MechJeb_Ascent_label3 = Ap < Pe: 圆化轨道
+        #MechJeb_Ascent_label4 = 双曲线目标轨道 (无远点)
         #MechJeb_Ascent_label5 = 轨道高度
-        #MechJeb_Ascent_label6 = 目标轨道倾角
-        #MechJeb_Ascent_label7 = 目标轨道倾角比当前纬度低<<1>>º
-        #MechJeb_Ascent_label8 = 转弯开始高度：
-        #MechJeb_Ascent_label9 = 转弯开始速度：
-        #MechJeb_Ascent_label10 = 转弯开始俯仰角：
-        #MechJeb_Ascent_label11 = 中间高度：
-        #MechJeb_Ascent_label12 = 保持远拱点时间：
-        #MechJeb_Ascent_label13 = 助推段开始俯仰的起始速度：
-        #MechJeb_Ascent_label14 = 助推段俯仰的速率：
-        #MechJeb_Ascent_label15 = 引导间隔：
-        #MechJeb_Ascent_label16 = 引导间隔限制在 1s 到 30s 之间
+        #MechJeb_Ascent_label6 = 轨道倾角
+        #MechJeb_Ascent_label7 = 倾角 <<1>>º 低于当前纬度
+        #MechJeb_Ascent_label8 = 转向开始高度:
+        #MechJeb_Ascent_label9 = 转向开始速度:
+        #MechJeb_Ascent_label10 = 转向开始俯仰角:
+        #MechJeb_Ascent_label11 = 中等海拔高度:
+        #MechJeb_Ascent_label12 = 保持远拱点时间:
+        #MechJeb_Ascent_label13 = 助推器开始俯仰角:
+        #MechJeb_Ascent_label14 = 助推器俯仰率:
+        #MechJeb_Ascent_label15 = 制导间隔:
+        #MechJeb_Ascent_label16 = 制导间隔被限制在1到30秒之间
         #MechJeb_Ascent_label17 = Qα 限制
-        #MechJeb_Ascent_label18 = Qα 限制不得低于 100 Pa-rad
-        #MechJeb_Ascent_label19 = Qα 限制不得高于 10000 Pa-rad
-        #MechJeb_Ascent_label20 = 建议将 Qα 限制设为 1000 到 4000 Pa-rad
-        #MechJeb_Ascent_label21 = 待修复：g 限制器正在维护
+        #MechJeb_Ascent_label18 = Qα 限制不能低于100 Pa-rad
+        #MechJeb_Ascent_label19 = Qα 限制不能高于10000 Pa-rad
+        #MechJeb_Ascent_label20 = Qα 限制建议设置为 1000到4000 Pa-rad
+        #MechJeb_Ascent_label21 = FIXME: g-limiter正在进行维护
         #MechJeb_Ascent_label22 = 爬升
         #MechJeb_Ascent_label23 = 转向
         #MechJeb_Ascent_label24 = 动压衰减
         #MechJeb_Ascent_label25 = 增益
-        #MechJeb_Ascent_label26 = 引导状态：
-        #MechJeb_Ascent_label27 = 收敛：\u0020
-        #MechJeb_Ascent_label28 = 状态：\u0020
-        #MechJeb_Ascent_label29 = 未更新：
-        #MechJeb_Ascent_label30 = 最后一次失败：
-        #MechJeb_Ascent_label31 = 质量偏差
-        #MechJeb_Ascent_label32 = 推力偏差
-        #MechJeb_Ascent_label33 = 发射倒计时：
-        #MechJeb_Ascent_label34 = 为定时发射选择目标。
-        #MechJeb_Ascent_label35 = 自动驾驶状态：
-        #MechJeb_Ascent_label36 = 控制已禁用（检查AVIONICS）
-        #MechJeb_Ascent_label37 = 警告：如果没有已升级的追踪站，MechJeb 将无法进行轨道圆化。
-        #MechJeb_Ascent_attachAlt = 燃尽高度：
-        #MechJeb_Ascent_warnAttachAltLow = 燃尽高度 < 近拱点：插入到近拱点
-        #MechJeb_Ascent_warnAttachAltHigh = 燃尽高度 > 远拱点：插入到远拱点
+        #MechJeb_Ascent_label26 = 发射状态:
+        #MechJeb_Ascent_label27 = 收敛:\u0020
+        #MechJeb_Ascent_label28 = 状态:\u0020
+        #MechJeb_Ascent_label29 = 延迟:
+        #MechJeb_Ascent_label30 = 上次失败:
+        #MechJeb_Ascent_label31 = 质量下降了
+        #MechJeb_Ascent_label32 = 推力下降了
+        #MechJeb_Ascent_label33 = 发射倒计时:
+        #MechJeb_Ascent_label34 = 选择目标进行定时发射.
+        #MechJeb_Ascent_label35 = 自动驾驶状态:
+        #MechJeb_Ascent_label36 = 控制停用(航空电子设备)
+        #MechJeb_Ascent_label37 = 警告:跟踪站没有升级,MechJeb无法进行圆轨操作.
+        #MechJeb_Ascent_attachAlt = 燃尽高度:
+        #MechJeb_Ascent_warnAttachAltLow = 燃尽点低于Pe：近拱点入轨
+        #MechJeb_Ascent_warnAttachAltHigh = 燃尽点高于Ap：远拱点入轨
 
 
         #MechJeb_Ascent_checkbox1 = 忽略滑行
-        #MechJeb_Ascent_checkbox2 = 滚转角度调整
-        #MechJeb_Ascent_checkbox3 = 将攻角限制为
-        #MechJeb_Ascent_checkbox4 = 校正转向
+        #MechJeb_Ascent_checkbox2 = 角度调整
+        #MechJeb_Ascent_checkbox3 = 迎角限制
+        #MechJeb_Ascent_checkbox4 = 自动纠正航线
         #MechJeb_Ascent_checkbox5 = 自动分级
         #MechJeb_Ascent_checkbox6 = 自动展开太阳能电池板
         #MechJeb_Ascent_checkbox7 = 自动展开天线
         #MechJeb_Ascent_checkbox8 = 自动加速
-        #MechJeb_Ascent_checkbox9 = 跳过轨道圆化
-        #MechJeb_Ascent_checkbox10 = 编辑上升轨迹
+        #MechJeb_Ascent_checkbox9 = 跳过圆轨
+        #MechJeb_Ascent_checkbox10 = 编辑发射轨迹
 
-        #MechJeb_Ascent_msg1 = 正在行星际转移窗口期发射
-        #MechJeb_Ascent_msg2 = 正在发射到目标轨道平面
-        #MechJeb_Ascent_msg3 = 正在发射到目标交汇轨道
-        #MechJeb_Ascent_LaunchingToTargetLAN = 正在发射到目标的升交点赤经
-        #MechJeb_Ascent_LaunchingToManualLAN = 正在发射到设定的升交点赤经
+        #MechJeb_Ascent_msg1 = 在星际间转移窗口期发射
+        #MechJeb_Ascent_msg2 = 发射到目标轨道平面
+        #MechJeb_Ascent_msg3 = 发射到目标
+        #MechJeb_Ascent_LaunchingToTargetLAN = 正在发射至目标升交点经度
+        #MechJeb_Ascent_LaunchingToManualLAN = 正在发射至手动升交点经度
 
     //Attitude Adjustment
-    //CoM->Center of Mass CoL->Center of lift CoT->Center of thrust
+    ///CoM->Center of Mass CoL->Center of lift CoT->Center of thrust
         #MechJeb_AttitudeAdjust_title = 姿态调整
-        #MechJeb_AttitudeAdjust_checkbox1 = RCS 自动模式
-        #MechJeb_AttitudeAdjust_checkbox2 = MJ 姿态控制器
-        #MechJeb_AttitudeAdjust_checkbox3 = Kos 姿态控制器
+        #MechJeb_AttitudeAdjust_checkbox1 = RCS自动模式
+        #MechJeb_AttitudeAdjust_checkbox2 = MJ姿态控制器
+        #MechJeb_AttitudeAdjust_checkbox3 = Kos姿态控制器
         #MechJeb_AttitudeAdjust_checkbox4 = 混合控制器
         #MechJeb_AttitudeAdjust_checkbox5 = 显示数值
-        #MechJeb_AttitudeAdjust_checkbox6 = 可穿透物体显示
-        #MechJeb_AttitudeAdjust_checkbox7 = 显示质心
+        #MechJeb_AttitudeAdjust_checkbox6 = 箭头可穿过物体
+        #MechJeb_AttitudeAdjust_checkbox7 = 显示重心
         #MechJeb_AttitudeAdjust_checkbox8 = 显示升力中心
         #MechJeb_AttitudeAdjust_checkbox9 = 显示推力中心
-        #MechJeb_AttitudeAdjust_checkbox10 = 箭头起点于质心
-        #MechJeb_AttitudeAdjust_checkbox11 = 舱体地面速度（绿色）
-        #MechJeb_AttitudeAdjust_checkbox12 = 舱体轨道速度（红色）
-        #MechJeb_AttitudeAdjust_checkbox13 = 推力方向（紫粉色）
-        #MechJeb_AttitudeAdjust_checkbox14 = 指令舱前向（电光蓝）
-        #MechJeb_AttitudeAdjust_checkbox15 = 设定的姿态（灰色）
-        #MechJeb_AttitudeAdjust_checkbox16 = Debug（品红色）
-        #MechJeb_AttitudeAdjust_checkbox17 = Debug2（淡蓝色）
+        #MechJeb_AttitudeAdjust_checkbox10 = 箭头始点过重心
+        #MechJeb_AttitudeAdjust_checkbox11 = 地面速度方向 (绿色)
+        #MechJeb_AttitudeAdjust_checkbox12 = 轨道速度方向 (红色)
+        #MechJeb_AttitudeAdjust_checkbox13 = 推力方向 (紫粉色)
+        #MechJeb_AttitudeAdjust_checkbox14 = 前进方向 (铁蓝色)
+        #MechJeb_AttitudeAdjust_checkbox15 = 姿态(灰色)
+        #MechJeb_AttitudeAdjust_checkbox16 = Debug (品红色)
+        #MechJeb_AttitudeAdjust_checkbox17 = Debug2 (浅蓝色)
 
 
         #MechJeb_AttitudeAdjust_Label1 = 轴控制\u0020
         #MechJeb_AttitudeAdjust_Label2 = 扭矩
-        #MechJeb_AttitudeAdjust_Label3 = 扭矩反应速度
+        #MechJeb_AttitudeAdjust_Label3 = 扭矩速度
         #MechJeb_AttitudeAdjust_Label4 = 转动惯量 / 扭矩
         #MechJeb_AttitudeAdjust_Label5 = 转动惯量
         #MechJeb_AttitudeAdjust_Label6 = 角速度
         #MechJeb_AttitudeAdjust_Label7 = 角动量
-        #MechJeb_AttitudeAdjust_Label8 = fixedDeltaTime
+        #MechJeb_AttitudeAdjust_Label8 = 修正Delta时间
         #MechJeb_AttitudeAdjust_Label9 = 箭头长度
-        #MechJeb_AttitudeAdjust_Label10 = 球体半径
+        #MechJeb_AttitudeAdjust_Label10 = 球半径
 
     //Custom Window Editor
         #MechJeb_WindowEd_title = 自定义窗口编辑器
-        #MechJeb_WindowEd_Edtitle = 标题：
+        #MechJeb_WindowEd_Edtitle = 标题:
 
         #MechJeb_WindowEd_Presetname1 = 轨道信息
-        #MechJeb_WindowEd_Presetname2 = 地表信息
+        #MechJeb_WindowEd_Presetname2 = 地面信息
         #MechJeb_WindowEd_Presetname3 = 载具信息
-        #MechJeb_WindowEd_Presetname4 = Delta-V 统计
-        #MechJeb_WindowEd_Presetname5 = 上升段统计
+        #MechJeb_WindowEd_Presetname4 = Delta-V 状态
+        #MechJeb_WindowEd_Presetname5 = 发射状态
         #MechJeb_WindowEd_Presetname6 = 交会信息
         #MechJeb_WindowEd_Presetname7 = 着陆信息
         #MechJeb_WindowEd_Presetname8 = 目标轨道信息
@@ -380,112 +478,112 @@ Localization
         #MechJeb_WindowEd_button1 = 新建窗口
         #MechJeb_WindowEd_button2 = 删除窗口
         #MechJeb_WindowEd_button3 = 移除
-        #MechJeb_WindowEd_button4 = 上移
-        #MechJeb_WindowEd_button5 = 下移
+        #MechJeb_WindowEd_button4 = 向上移动
+        #MechJeb_WindowEd_button5 = 向下移动
 
-        #MechJeb_WindowEd_label1 = 显示在：
-        #MechJeb_WindowEd_label2 = 颜色：
-        #MechJeb_WindowEd_label3 = 窗口内容（点击编辑）：
-        #MechJeb_WindowEd_label4 = 点击项目以添加到信息窗口：
-        #MechJeb_WindowEd_label5 = 窗口预设：
+        #MechJeb_WindowEd_label1 = 显示在:
+        #MechJeb_WindowEd_label2 = 颜色:
+        #MechJeb_WindowEd_label3 = 窗口内容(点击编辑):
+        #MechJeb_WindowEd_label4 = 点击项目以添加至信息窗口:
+        #MechJeb_WindowEd_label5 = 预置窗口:
 
 
-        #MechJeb_WindowEd_checkbox1 = 飞行中
-        #MechJeb_WindowEd_checkbox2 = 编辑器
+        #MechJeb_WindowEd_checkbox1 = 飞行界面
+        #MechJeb_WindowEd_checkbox2 = 建造大楼
         #MechJeb_WindowEd_checkbox3 = 叠加
         #MechJeb_WindowEd_checkbox4 = 锁定
-        #MechJeb_WindowEd_checkbox5 = 紧凑
+        #MechJeb_WindowEd_checkbox5 = 精简
         #MechJeb_WindowEd_checkbox6 = 文本
         #MechJeb_WindowEd_checkbox7 = 背景
 
         #MechJeb_WindowEd_CustomInfoWindow_title = 自定义信息窗口
 
-        #MechJeb_WindowEd_CustomInfoWindow_Label1 = 使用自定义窗口编辑器向此窗口添加项目。
-        #MechJeb_WindowEd_CustomInfoWindow_Scrmsg1 = <<1>>窗口的配置已复制到剪贴板。
-        #MechJeb_WindowEd_CustomInfoWindow_Scrmsg2 = 粘贴的文本不是 MechJeb 自定义窗口描述符。
+        #MechJeb_WindowEd_CustomInfoWindow_Label1 = 使用自定义窗口编辑器将项添加到此窗口.
+        #MechJeb_WindowEd_CustomInfoWindow_Scrmsg1 = 将 <<1>> 窗口的配置复制到剪贴板
+        #MechJeb_WindowEd_CustomInfoWindow_Scrmsg2 = 粘贴的文本不是 MechJeb 自定义窗口描述符.
 
     //Docking Autopilot
         #MechJeb_Docking_title = 自动对接
 
-        #MechJeb_Docking_status1 = 以<<1>>m/s 倒退以回避目标侧（横向：<<2>>m/s）
-        #MechJeb_Docking_status2 = 为避免在倒退时撞到目标，以<<1>>m/s 远离对接轴
-        #MechJeb_Docking_status3 = 以<<1>>m/s 移动以进入目标的正确一侧。（横向：<<2>>m/s）
-        #MechJeb_Docking_status4 = 正在以<<1>>m/s 倒退
-        #MechJeb_Docking_status5 = 正在以<<1>>m/s 移动回起始点。
-        #MechJeb_Docking_status6 = 正在以<<1>>/<<2>>m/s 向前对接。
+        #MechJeb_Docking_status1 = 在向目标方向移动前以<<1>>m/s的速度后退(lat: <<2>> m/s)
+        #MechJeb_Docking_status2 = 以<<1>> m/s的速度离开对接轴，以避免后退时击中目标
+        #MechJeb_Docking_status3 = 以小于<<1>> m/s的速度移动到目标的正确一侧.(lat: <<2>> m/s)
+        #MechJeb_Docking_status4 = 以<<1>> m/s后退
+        #MechJeb_Docking_status5 = 以<<1>> m/s的速度向起始点移动.
+        #MechJeb_Docking_status6 = 以<<1>> / <<2>> m/s前进到对接口。
 
-        #MechJeb_Docking_label1 = 选择要对接的目标
-        #MechJeb_Docking_label2 = 警告：你需要选择一个对接端口并基于它来控制飞船。右键点击对接端口并选择“基于此处控制”
-        #MechJeb_Docking_label3 = 警告：目标不是一个对接端口。右键点击对接目标的对接端口并选择“设置为目标”
-        #MechJeb_Docking_label4 = 警告：此飞船未基于对接节点控制。右键点击本飞船上想要的对接节点并选择“基于此处控制”。
+        #MechJeb_Docking_label1 = 选择一个目标来进行对接
+        #MechJeb_Docking_label2 = 警告:你需要以对接口来控制船. 右键单击一个对接口并选择"基于此处控制"
+        #MechJeb_Docking_label3 = 警告: 所选目标不是对接口. 右键单击此目标的对接口然后选择"设置为目标"
+        #MechJeb_Docking_label4 = 警告:该船只不受对接节点的控制. 右键单击一个对接节点并选择"基于此处控制"
         #MechJeb_Docking_label5 = 速度限制
         #MechJeb_Docking_label6 = 起始距离
         #MechJeb_Docking_label7 = 安全距离 <<1>>
-        #MechJeb_Docking_label8 = 目标尺寸 <<1>>
-        #MechJeb_Docking_label9 = 状态：<<1>>
-        #MechJeb_Docking_label10 = X 误差：<<1>>
-        #MechJeb_Docking_label11 = Y 误差：<<1>>
-        #MechJeb_Docking_label12 = Z 误差：<<1>>
-        #MechJeb_Docking_label13 = 距离对接口：<<1>>
-        #MechJeb_Docking_label14 = 距离对接轴：<<1>>
+        #MechJeb_Docking_label8 = 目标大小   <<1>>
+        #MechJeb_Docking_label9 = 状态: <<1>>
+        #MechJeb_Docking_label10 = 误差X: <<1>>
+        #MechJeb_Docking_label11 = 误差Y: <<1>>
+        #MechJeb_Docking_label12 = 误差Z: <<1>>
+        #MechJeb_Docking_label13 = 距离对接口: <<1>>
+        #MechJeb_Docking_label14 = 距离对接轴: <<1>>
 
         #MechJeb_Docking_button = 转储飞船边界框信息
 
-        #MechJeb_Docking_checkbox1 = 启用自动驾驶
+        #MechJeb_Docking_checkbox1 = 启动自动驾驶
         #MechJeb_Docking_checkbox2 = 覆盖安全距离
         #MechJeb_Docking_checkbox3 = 安全距离
         #MechJeb_Docking_checkbox4 = 覆盖起始距离
-        #MechJeb_Docking_checkbox5 = 绘制边界框
-        #MechJeb_Docking_checkbox6 = 滚转角度调整：
+        #MechJeb_Docking_checkbox5 = 绘制飞船边界框
+        #MechJeb_Docking_checkbox6 = 角度调整:
 
     //Flight Recorder
-        #MechJeb_Flightrecord_title = 飞行记录器
+        #MechJeb_Flightrecord_title = 飞行记录仪
         #MechJeb_Flightrecord_Button1_1 = 恢复
         #MechJeb_Flightrecord_Button1_2 = 暂停
         #MechJeb_Flightrecord_Button2_1 = 下行距离
         #MechJeb_Flightrecord_Button2_2 = 时间
-        #MechJeb_Flightrecord_Button3 = 开始记录
-        #MechJeb_Flightrecord_Button4 = 重置刻度
-        #MechJeb_Flightrecord_Button5 = 导出为CSV
+        #MechJeb_Flightrecord_Button3 = 标记
+        #MechJeb_Flightrecord_Button4 = 重置比例
+        #MechJeb_Flightrecord_Button5 = 导出CSV
 
-        #MechJeb_Flightrecord_checkbox1 = 自动缩放
-        #MechJeb_Flightrecord_checkbox2 = 真实大气层
+        #MechJeb_Flightrecord_checkbox1 = 自动调整
+        #MechJeb_Flightrecord_checkbox2 = 真实动力
         #MechJeb_Flightrecord_checkbox3 = 分级
-        #MechJeb_Flightrecord_checkbox4 = 海平面高度
-        #MechJeb_Flightrecord_checkbox5 = 地面高度
+        #MechJeb_Flightrecord_checkbox4 = 高度
+        #MechJeb_Flightrecord_checkbox5 = 实际高度
         #MechJeb_Flightrecord_checkbox6 = 加速度
         #MechJeb_Flightrecord_checkbox7 = 地表速度
         #MechJeb_Flightrecord_checkbox8 = 轨道速度
         #MechJeb_Flightrecord_checkbox9 = 质量
         #MechJeb_Flightrecord_checkbox10 = 动压
-        #MechJeb_Flightrecord_checkbox11 = 攻角（AoA）
-        #MechJeb_Flightrecord_checkbox12 = 侧滑角（AoS）
-        #MechJeb_Flightrecord_checkbox13 = 偏移角（AoD）
+        #MechJeb_Flightrecord_checkbox11 = 攻角
+        #MechJeb_Flightrecord_checkbox12 = 侧滑角
+        #MechJeb_Flightrecord_checkbox13 = 俯角
         #MechJeb_Flightrecord_checkbox14 = 俯仰角
         #MechJeb_Flightrecord_checkbox15 = 重力损耗
         #MechJeb_Flightrecord_checkbox16 = 阻力损耗
         #MechJeb_Flightrecord_checkbox17 = 转向损耗
-        #MechJeb_Flightrecord_checkbox18 = ASL
-        #MechJeb_Flightrecord_checkbox19 = AGL
-        #MechJeb_Flightrecord_checkbox20 = Acc
-        #MechJeb_Flightrecord_checkbox21 = SrfVel
-        #MechJeb_Flightrecord_checkbox22 = ObtVel
-        #MechJeb_Flightrecord_checkbox23 = Mass
-        #MechJeb_Flightrecord_checkbox24 = Q
-        #MechJeb_Flightrecord_checkbox25 = AoA
-        #MechJeb_Flightrecord_checkbox26 = AoS
-        #MechJeb_Flightrecord_checkbox27 = AoD
-        #MechJeb_Flightrecord_checkbox28 = Pitch
-        #MechJeb_Flightrecord_checkbox29 = Gravity Loss
-        #MechJeb_Flightrecord_checkbox30 = Drag Loss
-        #MechJeb_Flightrecord_checkbox31 = Steering Loss
+        #MechJeb_Flightrecord_checkbox18 = 海平面高度
+        #MechJeb_Flightrecord_checkbox19 = 地平面高度
+        #MechJeb_Flightrecord_checkbox20 = 加速度
+        #MechJeb_Flightrecord_checkbox21 = 地面速度
+        #MechJeb_Flightrecord_checkbox22 = 轨道速度
+        #MechJeb_Flightrecord_checkbox23 = 质量
+        #MechJeb_Flightrecord_checkbox24 = 动压
+        #MechJeb_Flightrecord_checkbox25 = 攻角
+        #MechJeb_Flightrecord_checkbox26 = 侧滑角
+        #MechJeb_Flightrecord_checkbox27 = 俯角
+        #MechJeb_Flightrecord_checkbox28 = 俯仰角
+        #MechJeb_Flightrecord_checkbox29 = 重力损耗
+        #MechJeb_Flightrecord_checkbox30 = 阻力损耗
+        #MechJeb_Flightrecord_checkbox31 = 转向损耗
 
-        #MechJeb_Flightrecord_Label1 = 时间：<<1>>
-        #MechJeb_Flightrecord_Label2 = 下行距离：<<1>>
-        #MechJeb_Flightrecord_Label3 = 存储空间：<<1>>%
+        #MechJeb_Flightrecord_Label1 = 时间 <<1>>
+        #MechJeb_Flightrecord_Label2 = 下行距离 <<1>>
+        #MechJeb_Flightrecord_Label3 = 存储: <<1>> %
 
     //Maneuver Node Editor
-        #MechJeb_NodeEd_title = 机动节点编辑器
+        #MechJeb_NodeEd_title = 机动节点编辑
 
         #MechJeb_NodeEd_Snap1 = 近拱点
         #MechJeb_NodeEd_Snap2 = 远拱点
@@ -495,65 +593,65 @@ Localization
         #MechJeb_NodeEd_Snap6 = 赤道降交点
 
         #MechJeb_NodeEd_Label1 = 没有可编辑的机动节点
-        #MechJeb_NodeEd_Label2 = 顺向：
-        #MechJeb_NodeEd_Label3 = 径向+
-        #MechJeb_NodeEd_Label4 = 法线+
-        #MechJeb_NodeEd_Label5 = 设定增量为：
-        #MechJeb_NodeEd_Label6 = 时间平移
-        #MechJeb_NodeEd_Label7 = 容差：
-        #MechJeb_NodeEd_Label8 = 圆锥曲线模式：
-        #MechJeb_NodeEd_Label9 = 当前模式：<<1>>
+        #MechJeb_NodeEd_Label2 = 顺向:
+        #MechJeb_NodeEd_Label3 = 径向+:
+        #MechJeb_NodeEd_Label4 = 法向+:
+        #MechJeb_NodeEd_Label5 = 设置增量为:
+        #MechJeb_NodeEd_Label6 = 位移时间
+        #MechJeb_NodeEd_Label7 = 容差:
+        #MechJeb_NodeEd_Label8 = 二次曲线模式:
+        #MechJeb_NodeEd_Label9 = 当前模式: <<1>>
 
         #MechJeb_NodeEd_button1 = 合并下一个节点
         #MechJeb_NodeEd_button2 = 更新
         #MechJeb_NodeEd_button3 = 对齐节点到
         #MechJeb_NodeEd_button4 = 执行下一个节点
-        #MechJeb_NodeEd_button5 = 执行所有节点
+        #MechJeb_NodeEd_button5 = 执行全部节点
         #MechJeb_NodeEd_button6 = 中止节点执行
-        #MechJeb_NodeEd_button7 = 执行下一个 Principia 节点
+        #MechJeb_NodeEd_button7 = 执行下一个Principia节点
 
         #MechJeb_NodeEd_checkbox1 = 自动加速
 
     //RCS Balancer
-        #MechJeb_RCSBalancer_title = RCS 平衡器
+        #MechJeb_RCSBalancer_title = RCS平衡器
 
-        #MechJeb_RCSBalancer_label1 = 超驱动模式
-        #MechJeb_RCSBalancer_label2 = 超驱动模式在可能时增加 RCS 功率，但会降低燃料效率。
-        #MechJeb_RCSBalancer_label3 = 超驱比例
+        #MechJeb_RCSBalancer_label1 = 超频
+        #MechJeb_RCSBalancer_label2 = 超频可以增加RCS推力,但是更耗费燃料.
+        #MechJeb_RCSBalancer_label3 = 超频比例
         #MechJeb_RCSBalancer_label4 = 扭矩系数
-        #MechJeb_RCSBalancer_label5 = 平移系数
-        #MechJeb_RCSBalancer_label6 = Waste factor
+        #MechJeb_RCSBalancer_label5 = 平动系数
+        #MechJeb_RCSBalancer_label6 = 损耗系数
 
 
-        #MechJeb_RCSBalancer_checkbox1 = Smart translation
+        #MechJeb_RCSBalancer_checkbox1 = 智能算法
         #MechJeb_RCSBalancer_checkbox2 = 高级选项
 
     //Rendezvous Autopilot
         #MechJeb_RZauto_title = 自动交会
 
-        #MechJeb_RZauto_label1 = 选择要交会的目标。
-        #MechJeb_RZauto_label2 = 交会目标必须在同一引力范围内。
+        #MechJeb_RZauto_label1 = 选择要与之交会的目标
+        #MechJeb_RZauto_label2 = 交会目标必须处在同一引力范围内.
         #MechJeb_RZauto_label3 = 交会目标
-        #MechJeb_RZauto_label4 = 期望最终交会距离：
-        #MechJeb_RZauto_label5 = 最大相位轨道数：
-        #MechJeb_RZauto_label6 = 最大相位轨道数至少为5个。
-        #MechJeb_RZauto_label7 = 状态：<<1>>
-        #MechJeb_RZauto_label8 = 接近时最大速度：
+        #MechJeb_RZauto_label4 = 交会距离:
+        #MechJeb_RZauto_label5 = 相位轨道最大个数:
+        #MechJeb_RZauto_label6 = 相位轨道的最大值必须至少为5个.
+        #MechJeb_RZauto_label7 = 状态: <<1>>
+        #MechJeb_RZauto_label8 = 最大接近速度:
 
         #MechJeb_RZauto_checkbox1 = 自动加速
 
-        #MechJeb_RZauto_button1 = 接通自动驾驶
-        #MechJeb_RZauto_button2 = 解除自动驾驶
+        #MechJeb_RZauto_button1 = 自动驾驶
+        #MechJeb_RZauto_button2 = 取消自动
 
         #MechJeb_RZauto_statu1 = 成功对接
-        #MechJeb_RZauto_statu2 = 距离目标<<1>>m：匹配速度中。
-        #MechJeb_RZauto_statu3 = 计划在最接近处匹配速度。
-        #MechJeb_RZauto_statu4 = 接近目标：绘制交会轨迹
-        #MechJeb_RZauto_statu5 = 在交会轨迹上。计划在最接近处匹配速度。
-        #MechJeb_RZauto_statu6 = 正在规划霍曼转移以在<<1>>个相位轨道后与目标交会。
-        #MechJeb_RZauto_statu7 = 下一个交会窗口将相隔<<1>>个轨道，超过最大值<<2>>。通过在<<3>>m 建立新相位轨道来增加相位速率
-        #MechJeb_RZauto_statu8 = 轨道圆化中。
-        #MechJeb_RZauto_statu9 = 匹配轨道平面。
+        #MechJeb_RZauto_statu2 = <<1>>m内: 匹配速度中.
+        #MechJeb_RZauto_statu3 = 准备在最接近目标时匹配速度.
+        #MechJeb_RZauto_statu4 = 接近目标:绘制交会轨道
+        #MechJeb_RZauto_statu5 = 交会作业.计划在最接近目标时匹配速度.
+        #MechJeb_RZauto_statu6 = 计划<<1>>个相位轨道后进行霍曼转移交会.
+        #MechJeb_RZauto_statu7 = 下一个交会窗口将在 <<1>>个轨道外,超过了<<2>>个相位轨道的最大值. 通过在<<3>>m建立新的相位轨道来增加相位率
+        #MechJeb_RZauto_statu8 = 圆轨中.
+        #MechJeb_RZauto_statu9 = 匹配轨道中.
 
     //Rendezvous Planner
         #MechJeb_RZplan_title = 交会规划
@@ -576,7 +674,7 @@ Localization
         #MechJeb_RZplan_label4 = 目标轨道
         #MechJeb_RZplan_label5 = 当前轨道
         #MechJeb_RZplan_label6 = 相对轨道倾角
-        #MechJeb_RZplan_label7 = 到达最接近点的倒计时
+        #MechJeb_RZplan_label7 = 到达最接近点剩余时间
         #MechJeb_RZplan_label8 = 最接近点的距离
         #MechJeb_RZplan_label9 = 容差:
 
@@ -615,7 +713,7 @@ Localization
 
         #MechJeb_ScriptMod_checkbox1 = 隐藏添加动作
 
-        #MechJeb_ScriptMod_actions1 = Time
+        #MechJeb_ScriptMod_actions1 = 时间
             #MechJeb_ScriptMod_actions1_1 = 计时器
             #MechJeb_ScriptMod_actions1_2 = 暂停
             #MechJeb_ScriptMod_actions1_3 = 等待至
@@ -664,16 +762,16 @@ Localization
     //Settings
         #MechJeb_Settings_title = 设置
 
-        #MechJeb_Settings_label1 = 当前皮肤：<<1>>
-        #MechJeb_Settings_label2 = 界面缩放比例：（默认为1）
+        #MechJeb_Settings_label1 = 当前皮肤: <<1>>
+        #MechJeb_Settings_label2 = UI比例:
 
         #MechJeb_Settings_checkbox1 = 用箭头替换下拉菜单
-        #MechJeb_Settings_checkbox2 = 在加速时激活 SAS
+        #MechJeb_Settings_checkbox2 = 加速时激活SAS
 
         #MechJeb_Settings_button1 = \n恢复出厂默认设置\n
-        #MechJeb_Settings_button2 = 使用 MechJeb 1 界面皮肤
-        #MechJeb_Settings_button3 = 使用 MechJeb 2 界面皮肤
-        #MechJeb_Settings_button4 = 使用 MJ2 紧凑界面皮肤
+        #MechJeb_Settings_button2 = 使用MechJeb界面皮肤1
+        #MechJeb_Settings_button3 = 使用MechJeb界面皮肤2
+        #MechJeb_Settings_button4 = 使用MJ2紧凑型界面皮肤
 
     //Smart A.S.S. or Smart A.C.S.
         #MechJeb_SmartASS_title = 智能姿态控制
@@ -715,7 +813,7 @@ Localization
         #MechJeb_SmartASS_button33 = 上
         #MechJeb_SmartASS_button34 = 关
         #MechJeb_SmartASS_button35 = 姿态稳定
-        #MechJeb_SmartASS_button36 = 接地那
+        #MechJeb_SmartASS_button36 = 节点
         #MechJeb_SmartASS_button37 = 地面
         #MechJeb_SmartASS_button38 = 顺向
         #MechJeb_SmartASS_button39 = 逆向
@@ -747,92 +845,92 @@ Localization
 
         #MechJeb_SmartASS_checkbox1 = 自动关闭智能姿态控制
         #MechJeb_SmartASS_checkbox2 = 自动关闭智能姿态控制
-        #MechJeb_SmartASS_checkbox3 = 滚转角度调整 :
+        #MechJeb_SmartASS_checkbox3 = 角度调整 :
 
     //SmartRcs
-        #MechJeb_SmartRcs_title = 智能 RCS
+        #MechJeb_SmartRcs_title = 智能RCS
 
-        #MechJeb_SmartRcs_button1 = 关闭
+        #MechJeb_SmartRcs_button1 = 关
         #MechJeb_SmartRcs_button2 = 消除相对速度
         #MechJeb_SmartRcs_button3 = 自动
 
         #MechJeb_SmartRcs_label1 = 选择一个目标
 
-        #MechJeb_SmartRcs_checkbox1 = 自动禁用 SmartRcs
-        #MechJeb_SmartRcs_checkbox2 = 引擎关闭时使用 RCS 进行推力控制
-        #MechJeb_SmartRcs_checkbox3 = 使用 RCS 旋转
+        #MechJeb_SmartRcs_checkbox1 = 自动关闭智能RCS
+        #MechJeb_SmartRcs_checkbox2 = 引擎关闭时使用RCS
+        #MechJeb_SmartRcs_checkbox3 = 使用RCS进行旋转
 
     //Landing Guidance
         #MechJeb_LandingGuidance_title = 自动着陆
         #MechJeb_LandingGuidance_label1 = 目标点坐标
-        #MechJeb_LandingGuidance_label2 = 自动驾驶：
-        #MechJeb_LandingGuidance_label3 = 触地速度：
-        #MechJeb_LandingGuidance_label4 = 分级限制：
-        #MechJeb_LandingGuidance_label5 = 分级限制：
-        #MechJeb_LandingGuidance_label6 = 当前状态：
-        #MechJeb_LandingGuidance_label7 = 当前步骤：
-        #MechJeb_LandingGuidance_label8 = 当前模式：
-        #MechJeb_LandingGuidance_label9 = 着陆预测：
-        #MechJeb_LandingGuidance_Label10 = 目标差异 =
-        #MechJeb_LandingGuidance_Label11 = \n最大阻力：
-        #MechJeb_LandingGuidance_Label12 = \n所需 Δv：
-        #MechJeb_LandingGuidance_Label13 = \n着陆时间：
-        #MechJeb_LandingGuidance_Label14 = 大气刹车后的预测轨道：
-        #MechJeb_LandingGuidance_Label15 = 双曲线，偏心率 =
-        #MechJeb_LandingGuidance_Label16 = 最大阻力：<<1>>g
-        #MechJeb_LandingGuidance_Label17 = \n于<<1>>后脱离大气层
-        #MechJeb_LandingGuidance_Label18_1 = 轨道没有再入阶段：\n
+        #MechJeb_LandingGuidance_label2 = 自动驾驶:
+        #MechJeb_LandingGuidance_label3 = 着陆速度:
+        #MechJeb_LandingGuidance_label4 = 分级限制:
+        #MechJeb_LandingGuidance_label5 = 分级限制:
+        #MechJeb_LandingGuidance_label6 = 当前状态:
+        #MechJeb_LandingGuidance_label7 = 步骤:
+        #MechJeb_LandingGuidance_label8 = 模式
+        #MechJeb_LandingGuidance_label9 = 着陆点预测:
+        #MechJeb_LandingGuidance_Label10 = 目标点距离 =
+        #MechJeb_LandingGuidance_Label11 = \n最大阻力:
+        #MechJeb_LandingGuidance_Label12 = \n需要的Delta-v:
+        #MechJeb_LandingGuidance_Label13 = \n着陆时间:
+        #MechJeb_LandingGuidance_Label14 = 大气刹车后的预计轨道:
+        #MechJeb_LandingGuidance_Label15 = 双曲率,离心率 =
+        #MechJeb_LandingGuidance_Label16 = 最大阻力:<<1>> g
+        #MechJeb_LandingGuidance_Label17 = \n脱离大气:<<1>>
+        #MechJeb_LandingGuidance_Label18_1 = 轨道没有再入阶段:\n
         #MechJeb_LandingGuidance_Label18_2 = m 大气高度
-        #MechJeb_LandingGuidance_Label18_3 = m 地面
-        #MechJeb_LandingGuidance_Label19 = 模拟再入超时。
+        #MechJeb_LandingGuidance_Label18_3 = m 地面高度
+        #MechJeb_LandingGuidance_Label19 = 模拟再入超时.
 
         #MechJeb_LandingGuidance_checkbox1 = 自动加速
-        #MechJeb_LandingGuidance_checkbox2 = 放下起落架
+        #MechJeb_LandingGuidance_checkbox2 = 展开着陆架
         #MechJeb_LandingGuidance_checkbox3 = 展开降落伞
-        #MechJeb_LandingGuidance_checkbox4 = 使用 RCS 微调
-        #MechJeb_LandingGuidance_checkbox5 = 显示着陆预测
-        #MechJeb_LandingGuidance_checkbox6 = 显示大气刹车节点
+        #MechJeb_LandingGuidance_checkbox4 = 使用RCS微调
+        #MechJeb_LandingGuidance_checkbox5 = 显示预测着陆点
+        #MechJeb_LandingGuidance_checkbox6 = 显示大气刹车点
         #MechJeb_LandingGuidance_checkbox7 = 显示轨迹
-        #MechJeb_LandingGuidance_checkbox8 = 世界轨迹
-        #MechJeb_LandingGuidance_checkbox9 = 相机轨迹（持续开发中）
+        #MechJeb_LandingGuidance_checkbox8 = 全球轨迹
+        #MechJeb_LandingGuidance_checkbox9 = 相机轨迹(在做了)
 
-        #MechJeb_LandingGuidance_button1 = 输入目标坐标：
-        #MechJeb_LandingGuidance_button2 = 在地图上选择目标
-        #MechJeb_LandingGuidance_button3 = 中止自动着陆
+        #MechJeb_LandingGuidance_button1 = 输入坐标点:
+        #MechJeb_LandingGuidance_button2 = 在地面上选择坐标
+        #MechJeb_LandingGuidance_button3 = 终止自动着陆
         #MechJeb_LandingGuidance_button4 = 降落在目标点
         #MechJeb_LandingGuidance_button5 = 降落在任意点
 
-        #MechJeb_LandingGuidance_Status1 = 向制动燃烧节点滑行
-        #MechJeb_LandingGuidance_Status2 = 轨道修正 ΔV：<<1>>m/s
-        #MechJeb_LandingGuidance_Status3 = 正在执行约<<1>>m/s 的轨道修正
-        #MechJeb_LandingGuidance_Status4 = 正在加速到制动燃烧节点。
-        #MechJeb_LandingGuidance_Status5 = 制动中。
-        #MechJeb_LandingGuidance_Status6 = 制动中：目标速度 =<<1>>m/s
-        #MechJeb_LandingGuidance_Status7 = 执行高轨离轨机动
-        #MechJeb_LandingGuidance_Status8 = 移动到高轨离轨机动节点
-        #MechJeb_LandingGuidance_Status9 = 最终下降路径：距地面<<1>>m
-        #MechJeb_LandingGuidance_Status10 = 在执行最终下降前清除水平速度
-        #MechJeb_LandingGuidance_Status11 = 执行低轨离轨机动
-        #MechJeb_LandingGuidance_Status12 = 移动到低轨离轨点执行点
-        #MechJeb_LandingGuidance_Status13 = 离轨燃烧完成：等待合适时机以开始制动
-        #MechJeb_LandingGuidance_Status14 = 执行约<<1>>m/s 的低轨平面变换
-        #MechJeb_LandingGuidance_Status15 = 前往低轨平面变换点
-        #MechJeb_LandingGuidance_Status16 = 正在执行离轨燃烧。
+        #MechJeb_LandingGuidance_Status1 = 正在滑行至减速点
+        #MechJeb_LandingGuidance_Status2 = 航向修正 DV: <<1>> m/s
+        #MechJeb_LandingGuidance_Status3 = 正在进行约为 <<1>> m/s 的轨迹修正
+        #MechJeb_LandingGuidance_Status4 = 时间加速至执行减速节点.
+        #MechJeb_LandingGuidance_Status5 = 正在减速
+        #MechJeb_LandingGuidance_Status6 = 正在减速: 目标速度 = <<1>> m/s
+        #MechJeb_LandingGuidance_Status7 = 正在执行高空离轨点火
+        #MechJeb_LandingGuidance_Status8 = 正在移至高空离轨点火点
+        #MechJeb_LandingGuidance_Status9 = 最终下降: 距离地面 <<1>>m
+        #MechJeb_LandingGuidance_Status10 = 在最终下降前消除水平速度
+        #MechJeb_LandingGuidance_Status11 = 正在执行低空离轨点火
+        #MechJeb_LandingGuidance_Status12 = 正在移至低空离轨点火点
+        #MechJeb_LandingGuidance_Status13 = 离轨燃烧完成: 正在等待正确的时机减速
+        #MechJeb_LandingGuidance_Status14 = 正在改变轨道倾角，DV: <<1>> m/s
+        #MechJeb_LandingGuidance_Status15 = 正在移动至改变倾角点
+        #MechJeb_LandingGuidance_Status16 = 正在进行离轨燃烧.
 
     //Translatron
 
-        #MechJeb_Translatron_title = 速度控制
+        #MechJeb_Translatron_title = 平动控制
         #MechJeb_Translatron_off = 关闭
-        #MechJeb_Translatron_KEEP_OBT = 轨道\n速度
-        #MechJeb_Translatron_KEEP_SURF = 地面\n速度
-        #MechJeb_Translatron_KEEP_VERT = 垂直\n速度
+        #MechJeb_Translatron_KEEP_OBT = 轨道\n保持
+        #MechJeb_Translatron_KEEP_SURF = 地面\n保持
+        #MechJeb_Translatron_KEEP_VERT = 速度\n保持
         #MechJeb_Trans_kill_h = 消除水平速度
         #MechJeb_Trans_spd = 速度
         #MechJeb_Trans_auto = 自动
         #MechJeb_Trans_spd_act = 执行
-        #MechJeb_Trans_current_spd = 设定速度
-        #MechJeb_Trans_NOPANIC = 取消紧急控制
-        #MechJeb_Trans_PANIC = 紧急控制
+        #MechJeb_Trans_current_spd = 当前速度
+        #MechJeb_Trans_NOPANIC = 不要慌!
+        #MechJeb_Trans_PANIC = 恐慌!!!
 
     //Utilities
         #MechJeb_Utilities_title = 实用工具
@@ -856,59 +954,59 @@ Localization
         #MechJeb_WarpHelper_Combobox_text1 = 近拱点
         #MechJeb_WarpHelper_Combobox_text2 = 远拱点
         #MechJeb_WarpHelper_Combobox_text3 = 机动节点
-        #MechJeb_WarpHelper_Combobox_text4 = 引力范围转换时
+        #MechJeb_WarpHelper_Combobox_text4 = 引力范围过渡
         #MechJeb_WarpHelper_Combobox_text5 = 时间
         #MechJeb_WarpHelper_Combobox_text6 = 相位角
-        #MechJeb_WarpHelper_Combobox_text7 = 极限点火时
-        #MechJeb_WarpHelper_Combobox_text8 = 进入大气时
+        #MechJeb_WarpHelper_Combobox_text7 = 最佳点火时机
+        #MechJeb_WarpHelper_Combobox_text8 = 大气再入
 
-        #MechJeb_WarpHelper_label1 = 加速到：\u0020
-        #MechJeb_WarpHelper_label2 = 加速持续：\u0020
+        #MechJeb_WarpHelper_label1 = 加速至:\u0020
+        #MechJeb_WarpHelper_label2 = 加速于:\u0020
         #MechJeb_WarpHelper_label3 = 你需要选定一个目标
-        #MechJeb_WarpHelper_label4 = 相位角：
-        #MechJeb_WarpHelper_label5 = 预留时间：\u0020
-        #MechJeb_WarpHelper_label6 = 正在加速到：\u0020
+        #MechJeb_WarpHelper_label4 = 相位角:
+        #MechJeb_WarpHelper_label5 = 预留时间:\u0020
+        #MechJeb_WarpHelper_label6 = 加速至\u0020
 
         #MechJeb_WarpHelper_checkbox1 = 快速加速
 
-        #MechJeb_WarpHelper_scrmsg = MJ： 加速已暂停 - 在加速助手菜单中恢复
+        #MechJeb_WarpHelper_scrmsg = MJ : 加速暂停-在加速助手菜单中恢复
 
-        #MechJeb_WarpHelper_button1 = 停止
+        #MechJeb_WarpHelper_button1 = 终止
         #MechJeb_WarpHelper_button2 = 加速
-        #MechJeb_WarpHelper_button3 = 恢复 MJ 加速
-        #MechJeb_WarpHelper_button4 = 暂停 MJ 加速
+        #MechJeb_WarpHelper_button3 = 恢复MJ加速
+        #MechJeb_WarpHelper_button4 = 暂停MJ加速
 
     //InfoItems
 
-        #MechJeb_InfoItems_label1 = 分级统计
-        #MechJeb_InfoItems_label2 = 相对目标角速度：(N/A)
-        #MechJeb_InfoItems_label3 = 相对目标角速度：
-        #MechJeb_InfoItems_label4 = 从目标分离：(N/A)
-        #MechJeb_InfoItems_label5 = 从目标分离：
+        #MechJeb_InfoItems_label1 = 分级状态
+        #MechJeb_InfoItems_label2 = 目标相对角速度: (N/A)
+        #MechJeb_InfoItems_label3 = 目标相对角速度:
+        #MechJeb_InfoItems_label4 = 从目标分离: (N/A)
+        #MechJeb_InfoItems_label5 = 从目标分离:
         #MechJeb_InfoItems_label6 = 行星相位角
         #MechJeb_InfoItems_label7 = 卫星相位角
 
-        #MechJeb_InfoItems_button1 = 简短统计
-        #MechJeb_InfoItems_button2 = 详细统计
+        #MechJeb_InfoItems_button1 = 短统计
+        #MechJeb_InfoItems_button2 = 长统计
         #MechJeb_InfoItems_button3 = 完整统计
         #MechJeb_InfoItems_button4 = 自定义
-        #MechJeb_InfoItems_button5 = 实时 推重比
-        #MechJeb_InfoItems_button6 = 0海拔推重比
+        #MechJeb_InfoItems_button5 = 实时海平面推重比
+        #MechJeb_InfoItems_button6 = 0海拔推力
 
         #MechJeb_InfoItems_showEmpty = 显示所有分级
-        #MechJeb_InfoItems_hideEmpty = 隐藏空的分级
+        #MechJeb_InfoItems_hideEmpty = 隐藏空分级
 
         #MechJeb_InfoItems_UnlimitedText = 无限制
         #MechJeb_InfoItems_velocityNA = 目标相对速度: (N/A)
-        #MechJeb_InfoItems_velocity = 目标相对速度: 
-        #MechJeb_InfoItems_CopytoClipboard = 复制纬度、经度和海拔至剪贴板
+        #MechJeb_InfoItems_velocity = 目标相对速度:
+        #MechJeb_InfoItems_CopytoClipboard = 复制 纬度/经度/海拔 至剪贴板
 
         #MechJeb_InfoItems_VesselSituation1 = 飞越<<1>>
         #MechJeb_InfoItems_VesselSituation2 = <<1>>的高层大气
         #MechJeb_InfoItems_VesselSituation3 = <<1>>的近地太空
-        #MechJeb_InfoItems_VesselSituation4 = <<1>>的远地太空）
-        #MechJeb_InfoItems_VesselSituation5 = 的地面上    //如 “Kerbin 的地表”
-        #MechJeb_InfoItems_VesselSituation6 = 的海面上    //如 “Kerbin 的海洋”
+        #MechJeb_InfoItems_VesselSituation4 = <<1>>的远地太空
+        #MechJeb_InfoItems_VesselSituation5 = 的地面上
+        #MechJeb_InfoItems_VesselSituation6 = 的海面上
 
         #MechJeb_InfoItems_StatsColumn0 = 分级
         #MechJeb_InfoItems_StatsColumn1 = 初始质量
@@ -923,34 +1021,34 @@ Localization
         #MechJeb_InfoItems_StatsColumn10 = 大气内 ΔV
         #MechJeb_InfoItems_StatsColumn11 = 真空 ΔV
         #MechJeb_InfoItems_StatsColumn12 = 燃烧时间
-        #MechJeb_InfoItems_StatsColumn13 = 推力
+        #MechJeb_InfoItems_StatsColumn13 = 最大推力
 
 
-    //Ascent Path Editor
-        #MechJeb_AscentPathEd_title = 上升轨迹编辑器
-        #MechJeb_AscentPathEd_nopath = 轨迹为空？？？！！！
-        #MechJeb_AscentPathEd_auto = 自动确定转向开始高度
-        #MechJeb_AscentPathEd_label1 = 高度：\u0020
-        #MechJeb_AscentPathEd_label2 = 速度：\u0020
+        //Ascent Path Editor
+        #MechJeb_AscentPathEd_title = 发射轨迹编辑器
+        #MechJeb_AscentPathEd_nopath = 轨迹不存在!!!
+        #MechJeb_AscentPathEd_auto = 自动确定转向高度
+        #MechJeb_AscentPathEd_label1 = 高度:\u0020
+        #MechJeb_AscentPathEd_label2 = 速度:\u0020
         #MechJeb_AscentPathEd_label3 = 转向开始高度
-        #MechJeb_AscentPathEd_label4 = 或当速度为
-        #MechJeb_AscentPathEd_label5 = 转向结束高度：
-        #MechJeb_AscentPathEd_label6 = 转向开始高度：
-        #MechJeb_AscentPathEd_label7 = 转向开始速度：
-        #MechJeb_AscentPathEd_label8 = 转向结束高度：
-        #MechJeb_AscentPathEd_label9 = 最终飞行路径角：
-        #MechJeb_AscentPathEd_label10 = 转弯形状：
-    //AttitudeController
+        #MechJeb_AscentPathEd_label4 = 或抵达速度
+        #MechJeb_AscentPathEd_label5 = 转向结束高度:
+        #MechJeb_AscentPathEd_label6 = 转向开始高度:
+        #MechJeb_AscentPathEd_label7 = 转向开始速度:
+        #MechJeb_AscentPathEd_label8 = 转向结束高度:
+        #MechJeb_AscentPathEd_label9 = 轨迹最终角度:
+        #MechJeb_AscentPathEd_label10 = 轨迹转向程度:
+        //AttitudeController
         #MechJeb_AttitudeController_checkbox1 = \u0020自动调节
         #MechJeb_AttitudeController_checkbox2 = \u0020低通滤波
 
-        #MechJeb_AttitudeController_label1 = 更大的飞船适合更大的 Tf
-        #MechJeb_AttitudeController_label2 = Tf (s)
+        #MechJeb_AttitudeController_label1 = 大型飞船建议使用较大的Tf值
+        #MechJeb_AttitudeController_label2 = Tf（秒）
         #MechJeb_AttitudeController_label3 = P
         #MechJeb_AttitudeController_label4 = Y
         #MechJeb_AttitudeController_label5 = R
         #MechJeb_AttitudeController_label6 = Tf
-        #MechJeb_AttitudeController_label7 = Tf 范围
+        #MechJeb_AttitudeController_label7 = Tf范围
         #MechJeb_AttitudeController_label8 = 最小
         #MechJeb_AttitudeController_label9 = 最大
         #MechJeb_AttitudeController_label11 = 最大相对角速度
@@ -958,34 +1056,34 @@ Localization
         #MechJeb_AttitudeController_label13 = Ki
         #MechJeb_AttitudeController_label14 = Kd
         #MechJeb_AttitudeController_label15 = 误差
-        #MechJeb_AttitudeController_label16 = 比例（P）作用
-        #MechJeb_AttitudeController_label17 = 微分（D）作用
-        #MechJeb_AttitudeController_label18 = 积分（I）作用
-        #MechJeb_AttitudeController_label19 = PID 动作
+        #MechJeb_AttitudeController_label16 = 比例作用.
+        #MechJeb_AttitudeController_label17 = 微分作用.
+        #MechJeb_AttitudeController_label18 = 积分作用.
+        #MechJeb_AttitudeController_label19 = PID动作
         #MechJeb_AttitudeController_label20 = 惯性
 
-        #MechJeb_AttitudeController_PIDF = PID 因子
-        #MechJeb_AttitudeController_PIDFactor1 = 死区 =
+        #MechJeb_AttitudeController_PIDF = PID参数
+        #MechJeb_AttitudeController_PIDFactor1 = 死域 =
 
         //New Adding
-        #MechJeb_Ascent_checkbox11 = 限制 Q 到
+        #MechJeb_Ascent_checkbox11 = 动压限制
         #MechJeb_Ascent_checkbox12 = 防止引擎过热
         #MechJeb_Ascent_checkbox13 = 防止喷气引擎熄火
         #MechJeb_Ascent_checkbox14 = 防止不稳定状态点火
-        #MechJeb_Ascent_checkbox15 = 使用 RCS 执行沉底操作
-        #MechJeb_Ascent_checkbox16 = 限制加速度到
-        #MechJeb_Ascent_checkbox17 = 限制节流阀到
-        #MechJeb_Ascent_checkbox18 = 保持节流阀不低于
+        #MechJeb_Ascent_checkbox15 = 使用RCS执行沉底操作
+        #MechJeb_Ascent_checkbox16 = 加速度限制
+        #MechJeb_Ascent_checkbox17 = 节流阀限制
+        #MechJeb_Ascent_checkbox18 = 限制节流阀一直超过
         #MechJeb_Ascent_checkbox19 = 差速节流阀
-        #MechJeb_Ascent_checkbox20 = 电力限制   Lo
-        #MechJeb_Ascent_srcmsg1 = <color=orange>[MechJeb]：为防止不稳定点火而关闭节流阀</color>
+        #MechJeb_Ascent_checkbox20 = 电力限制 Lo
+        #MechJeb_Ascent_srcmsg1 = <color=orange>[MechJeb]: 关闭节流阀，防止不稳定状态点火</color>
 
-        #MechJeb_HybridController_checkbox1 = useInertia
-        #MechJeb_HybridController_checkbox2 = RollControlRange
+        #MechJeb_HybridController_checkbox1 = 使用惯性
+        #MechJeb_HybridController_checkbox2 = 滚动控制范围
 
-        #MechJeb_HybridController_label1 = MaxStoppingTime
-        #MechJeb_HybridController_label2 = 执行
-        #MechJeb_HybridController_label3 = φ 向量
+        #MechJeb_HybridController_label1 = 最大停机时间
+        #MechJeb_HybridController_label2 = 启动
+        #MechJeb_HybridController_label3 = φ向量
         #MechJeb_HybridController_label4 = 目标扭矩
         #MechJeb_HybridController_label5 = 控制扭矩
         #MechJeb_HybridController_label6 = 惯性
@@ -993,57 +1091,57 @@ Localization
         #MechJeb_Actiongroup_label1 = 切换动作组
 
         #MechJeb_Ascent_hotStaging = 允许热分级
-        #MechJeb_Ascent_dropSolids = 提前抛弃固推
-        #MechJeb_Ascent_label38 = 分离整流罩当：
+        #MechJeb_Ascent_dropSolids = 提前抛弃固推 \n (RO里面有的固推 \n 在燃料即将用完时 \n 推力会很低，不抛浪费dv \n ——译者注)
+        #MechJeb_Ascent_label38 = 分离整流罩当:
         #MechJeb_Ascent_label39 = 动压
         #MechJeb_Ascent_label40 = 高度
         #MechJeb_Ascent_label41 = 空气热通量
-        #MechJeb_Ascent_label42 = 在分级#时停止
+        #MechJeb_Ascent_label42 = 在分级# 时停止
         #MechJeb_Ascent_leadTime = 预留时间
-        #MechJeb_Ascent_label44 = 夹具自动分离力度
+        #MechJeb_Ascent_label44 = 夹具自动分离推力大小
         #MechJeb_Ascent_status9 = 关闭自动分级
-        #MechJeb_Ascent_status10 = 仅会对下一个分级执行自动分级
-        #MechJeb_Ascent_status11 = 在分级#时停止自动分级
+        #MechJeb_Ascent_status10 = 只会对下一级进行自动分级.
+        #MechJeb_Ascent_status11 = 在分级 #处停止自动分级
         #MechJeb_Ascent_status12 = 等待点火
-        #MechJeb_Ascent_status13 = 垂直上升 还差<<1>>m/s
-        #MechJeb_Ascent_status14 = 重力转向 还差<<1>>° 到稳定引导
-        #MechJeb_Ascent_status15 = 俯仰程序 还差<<1>>° 到稳定引导
-        #MechJeb_Ascent_status16 = 警告：不稳定的引导
-        #MechJeb_Ascent_status17 = 稳定的引导
+        #MechJeb_Ascent_status13 = 垂直上升 <<1>>m/s
+        #MechJeb_Ascent_status14 = 重力转向<<1>>°
+        #MechJeb_Ascent_status15 = 俯仰角变化程序<<1>>°
+        #MechJeb_Ascent_status16 = 警告:不稳定的导向
+        #MechJeb_Ascent_status17 = 稳定的导向
 
-        //ASL = above sea level && AoA = Angle Of Attack && AoS = Angle Of Sideslip && AoD = Angle of Displacement
+        //TWR=Thrust to Weight Ratio
         #MechJeb_NodeBurnTime = 节点执行时间
         #MechJeb_TimeToNode = 到达节点时间
         #MechJeb_NodedV = 节点所需ΔV
         #MechJeb_SurfaceTWR = 地面推重比
-        #MechJeb_LocalTWR = 当地推重比
+        #MechJeb_LocalTWR = 局部推重比
         #MechJeb_ThrottleTWR = 节流阀推重比
-        #MechJeb_AtmosphericPressurePa = 大气压强（Pa）
+        #MechJeb_AtmosphericPressurePa = 大气压强(Pa)
         #MechJeb_AtmosphericPressure = 大气压强
         #MechJeb_Coordinates = 坐标
         #MechJeb_MeanAnomaly = 平近点角
         #MechJeb_Orbit = 轨道
         #MechJeb_TargetOrbit = 目标轨道
         #MechJeb_OrbitWithInc = 轨道
-        #MechJeb_OrbitWithInc_desc = 包含倾角的轨道形状
+        #MechJeb_OrbitWithInc_desc = 轨道样式 带倾角.
         #MechJeb_TargetOrbitWithInc = 目标轨道
-        #MechJeb_TargetOrbitWithInc_desc = 包含倾角的目标轨道形状
+        #MechJeb_TargetOrbitWithInc_desc = 目标轨道 带倾角.
         #MechJeb_OrbitalEnergy = 轨道能量
         #MechJeb_OrbitalEnergy_desc = 比轨道能量
         #MechJeb_PotentialEnergy = 势能
-        #MechJeb_PotentialEnergy_desc = 比势能
+        #MechJeb_PotentialEnergy_desc = 比位能
         #MechJeb_KineticEnergy = 动能
         #MechJeb_KineticEnergy_desc = 比动能
-        #MechJeb_TimeToImpact = 撞击倒计时
+        #MechJeb_TimeToImpact = 撞击时间
         #MechJeb_SuicideBurnCountdown = 极限点火倒计时
-        #MechJeb_RCSthrust = RCS 推力
-        #MechJeb_RCSTranslationEfficiency = RCS 平动效率
+        #MechJeb_RCSthrust = RCS推力
+        #MechJeb_RCSTranslationEfficiency = RCS转换效率
         #MechJeb_RCSdV = RCS ΔV
         #MechJeb_AngularVelocity = 角速度
         #MechJeb_CurrentAcceleration = 当前加速度
         #MechJeb_CurrentThrust = 当前推力
-        #MechJeb_TimeToSoIWwitch = 引力范围切换倒计时
-        #MechJeb_SurfaceGravity = 表面重力
+        #MechJeb_TimeToSoIWwitch = 引力捕获时间
+        #MechJeb_SurfaceGravity = 地面重力
         #MechJeb_EscapeVelocity = 逃逸速度
         #MechJeb_VesselName = 航天器名称
         #MechJeb_VesselType = 航天器类型
@@ -1051,168 +1149,166 @@ Localization
         #MechJeb_MaxVesselMass = 航天器最大质量
         #MechJeb_DryMass = 干质量
         #MechJeb_LiquidFuelandOxidizerMass = 液体燃料和氧化剂质量
-        #MechJeb_MonopropellantMass = 单组分推进剂质量
+        #MechJeb_MonopropellantMass = 单组元推进剂质量
         #MechJeb_TotalElectricCharge = 总电量
         #MechJeb_MaxThrust = 最大推力
         #MechJeb_MinThrust = 最小推力
         #MechJeb_MaxAcceleration = 最大加速度
         #MechJeb_MinAcceleration = 最小加速度
-        #MechJeb_Gforce = G 力
+        #MechJeb_Gforce = G-力
         #MechJeb_PartCount = 部件数
         #MechJeb_MaxPartCount = 最大部件数
         #MechJeb_PartCountDivideMaxParts = 部件数 / 最大部件数
-        #MechJeb_StrutCount = 支结构数
-        #MechJeb_FuelLinesCount = 燃料管线数
+        #MechJeb_StrutCount = 结构数
+        #MechJeb_FuelLinesCount = 燃油管数
         #MechJeb_VesselCost = 航天器成本
         #MechJeb_CrewCount = 乘员数
         #MechJeb_CrewCapacity = 乘员容量
-        #MechJeb_DistanceToTarget = 与目标距离
-        #MechJeb_HeadingToTarget = 朝向目标的航向
+        #MechJeb_DistanceToTarget = 目标距离
+        #MechJeb_HeadingToTarget = 驶向目标
         #MechJeb_RelativeVelocity = 相对速度
-        #MechJeb_TimeToClosestApproach = 到达最接近点的倒计时
-        #MechJeb_ClosestApproachDistance = 最接近点的距离
-        #MechJeb_RelativeVelocityAtClosestApproach = 最接近点的相对速度
+        #MechJeb_TimeToClosestApproach = 到达最接近点时间
+        #MechJeb_ClosestApproachDistance = 最接近点距离
+        #MechJeb_RelativeVelocityAtClosestApproach = 最接近点相对速度
         #MechJeb_PeriapsisInTargetSoI = 目标引力范围的近拱点高度
-        #MechJeb_TargetCaptureDV = 被目标捕获所需 ΔV
+        #MechJeb_TargetCaptureDV = 被目标捕获所需ΔV
         #MechJeb_TargetApoapsis = 目标远拱点高度
         #MechJeb_TargetPeriapsis = 目标近拱点高度
         #MechJeb_TargetInclination = 目标轨道倾角
         #MechJeb_TargetOrbitPeriod = 目标轨道周期
         #MechJeb_TargetOrbitSpeed = 目标轨道速度
-        #MechJeb_TargetTimeToAp = 目标到远拱点时间
-        #MechJeb_TargetTimeToPe = 目标到近拱点时间
-        #MechJeb_TargetTimeToAN = 目标到升交点时间
-        #MechJeb_TargetTimeToDN = 目标到降交点时间
+        #MechJeb_TargetTimeToAp = 目标到达Ap的时间
+        #MechJeb_TargetTimeToPe = 目标到达Pe的时间
+		#MechJeb_TargetTimeToAN = 目标到达AN的时间
+        #MechJeb_TargetTimeToDN = 目标到达DN的时间
         #MechJeb_TargetMeanAnomaly = 目标平近点角
-        #MechJeb_TargetTrueLongitude = 目标真实经度
+        #MechJeb_TargetTrueLongitude = 目标真经度
         #MechJeb_TargetLAN = 目标升交点经度
-        #MechJeb_TargetLDN = 目标降交点经度
-        #MechJeb_TargetAoP = 目标近心点幅角
-        #MechJeb_TargetEccentricity = 目标偏心率
-        #MechJeb_TargetSMA = 目标半长轴
+        #MechJeb_TargetAoP = 目标近点幅角
+        #MechJeb_TargetEccentricity = 目标离心率
+        #MechJeb_TargetSMA = 目标轨道半长轴
         #MechJeb_AtmosphericDrag = 大气阻力
-        #MechJeb_SynodicPeriod = 朔望周期
-        #MechJeb_PhaseAngleToTarget = 到目标的相位角
+        #MechJeb_SynodicPeriod = 会合周期
+        #MechJeb_PhaseAngleToTarget = 目标相位角
         #MechJeb_TargetPlanetPhaseAngle = 目标行星相位角
         #MechJeb_RelativeInclination = 相对倾角
-        #MechJeb_TimeToAN = 到升交点时间
-        #MechJeb_TimeToDN = 到降交点时间
-        #MechJeb_TimeToEquatorialAN = 到赤道升交点时间
-        #MechJeb_TimeToEquatorialDN = 到赤道降交点时间
+        #MechJeb_TimeToAN = 到达AN时间
+        #MechJeb_TimeToDN = 到达DN时间
+        #MechJeb_TimeToEquatorialAN = 到达赤道AN时间
+        #MechJeb_TimeToEquatorialDN = 到达赤道DN时间
         #MechJeb_CircularOrbitSpeed = 沿圆形轨道飞行速度
-        #MechJeb_StageDv_vac = 当前分级 ΔV（真空）
-
-        #MechJeb_StageDV_atmo = 当前分级 ΔV（大气）
-        #MechJeb_StageDV_atmo_vac = 当前分级 ΔV（大气，真空）
-        #MechJeb_StageTimeFullThrottle = 分级时间（满节流阀）
-        #MechJeb_StageTimeCurrentThrottle = 分级时间（当前节流阀）
-        #MechJeb_StageTimeHover = 分级时间（悬停）
-        #MechJeb_TotalDV_vacuum = 总 ΔV（真空）
-        #MechJeb_TotalDV_atmo = 总 ΔV（大气）
-        #MechJeb_TotalDV_atmo_vac = 总 ΔV（大气，真空）
-        #MechJeb_SurfaceBiome = 地表生态群落
+        #MechJeb_StageDv_vac = 分级 ΔV (真空)
+        #MechJeb_StageDV_atmo = 分级 ΔV (大气)
+        #MechJeb_StageDV_atmo_vac = 分级 ΔV (大气, 真空)
+        #MechJeb_StageTimeFullThrottle = 分级时间 (满节流阀)
+        #MechJeb_StageTimeCurrentThrottle = 分级时间(当前节流阀)
+        #MechJeb_StageTimeHover = 分级时间(hover)
+        #MechJeb_TotalDV_vacuum = 总ΔV (真空)
+        #MechJeb_TotalDV_atmo = 总ΔV (大气)
+        #MechJeb_TotalDV_atmo_vac = 总ΔV (大气, 真空)
+        #MechJeb_SurfaceBiome = 表面生态群落
         #MechJeb_CurrentBiome = 当前生态群落
         #MechJeb_SteeringError = 转向误差
         #MechJeb_MarkUT = 系统时间标记
         #MechJeb_TimeSinceMark = 自标记后时间
-        #MechJeb_DVExpended = 已消耗 ΔV
+        #MechJeb_DVExpended = ΔV消耗
         #MechJeb_DragLosses = 阻力损失
         #MechJeb_GravityLosses = 重力损失
         #MechJeb_SteeringLosses = 转向损失
-        #MechJeb_PhaseAngleFromMark = 自标记的相位角
-        #MechJeb_MarkLAN = 标记 LAN
-        #MechJeb_MarkLatitude = 标记纬度
-        #MechJeb_MarkLongitude = 标记经度
-        #MechJeb_MarkAltitudeASL = 标记海平面高度
-        #MechJeb_MarkBody = 标记天体
-        #MechJeb_DistanceFromMark = 到标记的距离
-        #MechJeb_DownrangeDistance = 下行距离
-        #MechJeb_MaxDragGees = 最大阻力 G 力
+        #MechJeb_PhaseAngleFromMark = 相位角标记
+        #MechJeb_MarkLAN = 标记升交点经度
+        #MechJeb_MarkLatitude = 纬度标记
+        #MechJeb_MarkLongitude = 经度标记
+        #MechJeb_MarkAltitudeASL = 海平面高度标记
+        #MechJeb_MarkBody = 天体标记
+        #MechJeb_DistanceFromMark = 距离标记
+        #MechJeb_DownrangeDistance = 下行距离高度
+        #MechJeb_MaxDragGees = 最大阻力
         #MechJeb_ParachuteControlInfo = 降落伞控制信息
-        #MechJeb_ChuteMultiplier = 降落伞倍数：<<1>>
-        #MechJeb_MultiplierQuality = \n倍数：<<1>>%
-        #MechJeb_Usingpredictions = \n使用<<1>>预测
-        #MechJeb_SimDragScalar = 模拟阻力系数
-        #MechJeb_SimLiftScalar = 模拟升力系数
-        #MechJeb_SimDynaPressPa = 模拟动压（Pa）
-        #MechJeb_SimsimMach = 模拟马赫数
-        #MechJeb_SimSpdOfSnd = 模拟声速
+        #MechJeb_ChuteMultiplier = 降落伞乘数: <<1>>
+        #MechJeb_MultiplierQuality = \n乘数质量: <<1>>%
+        #MechJeb_Usingpredictions = \n使用 <<1>> 预测
+        #MechJeb_SimDragScalar = 阻力模拟
+        #MechJeb_SimLiftScalar = 升力模拟
+        #MechJeb_SimDynaPressPa = 动压模拟
+        #MechJeb_SimsimMach = 马赫数模拟
+        #MechJeb_SimSpdOfSnd = 音速模拟
         #MechJeb_LandingSim = 着陆模拟
-        #MechJeb_DVincludecosinelosses = ΔV 包含余弦损失
+        #MechJeb_DVincludecosinelosses = ΔV包括余弦损失
         #MechJeb_NodeBurnLength = 节点点火时间
         #MechJeb_NodeBurnCountdown = 节点点火倒计时
-        #MechJeb_SpeedIntAcc = 速度积分加速度
-        #MechJeb_Traction = 抓地力
+        #MechJeb_SpeedIntAcc = 速度积分精度
+        #MechJeb_Traction = 牵引
         #MechJeb_Headingerror = 航向误差
-        #MechJeb_Speederror = 速度误差
+        #MechJeb_Speederror = 速率误差
         #MechJeb_Autostagingstatus = 自动分级状态
         #MechJeb_Targetcoordinates = 目标坐标
-        #MechJeb_pickingPositionMsg = 点击以在<<1>>的表面上选择目标点。\n（离开地图视图以取消。）
-        #MechJeb_Pickpositiontarget = 选择位置目标
-        #MechJeb_UniversalTime = 世界时
+        #MechJeb_pickingPositionMsg = 在 <<1>>的表面上单击选择一个目标坐标.\n(离开地图视角取消.)
+        #MechJeb_Pickpositiontarget = 选择目标位置
+        #MechJeb_UniversalTime = 国际标准时间
         #MechJeb_LocalGravity = 当地重力
         #MechJeb_OrbitalSpeed = 轨道速度
-        #MechJeb_SurfaceSpeed = 表面速度
+        #MechJeb_SurfaceSpeed = 地面速度
         #MechJeb_VerticalSpeed = 垂直速度
         #MechJeb_SurfaceHorizontalSpeed = 地面水平速度
         #MechJeb_OrbitHorizontalSpeed = 轨道水平速度
         #MechJeb_Heading = 航向
-        #MechJeb_Pitch = 俯仰
-        #MechJeb_Roll = 横滚
-        #MechJeb_Altitude_ASL = 高度（海平面）
-        #MechJeb_Altitude_true = 高度（地面）
-        #MechJeb_SurfaceAltitudeASL = 地表海平面高度
-        #MechJeb_Apoapsis = 远拱点
-        #MechJeb_Periapsis = 近拱点
+        #MechJeb_Pitch = 俯仰角
+        #MechJeb_Roll = 滚转角
+        #MechJeb_Altitude_ASL = 高度(海平面高度)
+        #MechJeb_Altitude_true = 高度(实际)
+        #MechJeb_SurfaceAltitudeASL = 地面海拔
+        #MechJeb_Apoapsis = 远点
+        #MechJeb_Periapsis = 近点
         #MechJeb_OrbitalPeriod = 轨道周期
-        #MechJeb_TimeToApoapsis = 到达远拱点时间
-        #MechJeb_TimeToPeriapsis = 到达近拱点时间
+        #MechJeb_TimeToApoapsis = 到达远供点时间
+        #MechJeb_TimeToPeriapsis = 到达近供点时间
         #MechJeb_LAN = 升交点经度
-        #MechJeb_ArgumentOfPeriapsis = 近心点幅角
+        #MechJeb_ArgumentOfPeriapsis = 近点幅角
         #MechJeb_Inclination = 轨道倾角
-        #MechJeb_Eccentricity = 偏心率
+        #MechJeb_Eccentricity = 离心率
         #MechJeb_SemiMajorAxis = 半长轴
         #MechJeb_Latitude = 纬度
         #MechJeb_Longitude = 经度
         #MechJeb_AngleOfAttack = 攻角
         #MechJeb_AngleOfSideslip = 侧滑角
-        #MechJeb_DisplacementAngle = 偏移角
-        #MechJeb_Mach = 马赫数
+        #MechJeb_DisplacementAngle = 位移角
+        #MechJeb_Mach = 马赫
         #MechJeb_SpeedOfSound = 音速
         #MechJeb_DragCoefficient = 阻力系数
         #MechJeb_AtmosphereDensity = 大气密度
         #MechJeb_MaxDynamicPressure = 最大动压
         #MechJeb_DynamicPressure = 动压
-        #MechJeb_IntakeAir = 进气量
-        #MechJeb_IntakeAirAllIntakes = 进气量（所有进气口打开）
-        #MechJeb_IntakeAirNeeded = 所需进气量
-        #MechJeb_intakeAirAtMax = 所需进气量（最大）
-        #MechJeb_AngleToPrograde = 到顺向的角度
-        #MechJeb_AerothermalFlux = 气动热通量
+        #MechJeb_IntakeAir = 进气
+        #MechJeb_IntakeAirAllIntakes = 进气(所有进气口均开启)
+        #MechJeb_IntakeAirNeeded = 需要进气量
+        #MechJeb_intakeAirAtMax = 需要进气量(最大)
+        #MechJeb_AngleToPrograde = 前进角
+        #MechJeb_AerothermalFlux = 飞行热通量
         #MechJeb_TerminalVelocity = 终端速度
-        #MechJeb_Altitude_bottom = 高度（底部）
+        #MechJeb_Altitude_bottom = 高度(底部)
         #MechJeb_PureDrag = 净阻力
         #MechJeb_PureLift = 净升力
-        #MechJeb_Toggle_Ascent_Navball_Guidance = 切换上升时的导航球引导
+        #MechJeb_Toggle_Ascent_Navball_Guidance = 开关发射导航球指引
         #MechJeb_ToggleAntennas = 开关天线
         #MechJeb_Autodeployantennas = 自动展开天线
-        #MechJeb_AntennasEXTENDED = 切换天线状态（当前已展开）
-        #MechJeb_AntennasRETRACTED = 切换天线状态（当前已收起）
-        #MechJeb_AntennasToggle = 切换天线状态
-        #MechJeb_StageStatsAll = 分级统计（全部）
-        #MechJeb_DockingGuidance_velocity = 对接引导：速度
-        #MechJeb_DockingGuidanceAngularVelocity = 对接引导：角速度
-        #MechJeb_DockingGuidancePosition = 对接引导：位置
+        #MechJeb_AntennasEXTENDED = 开关天线(当前已展开)
+        #MechJeb_AntennasRETRACTED = 开关天线(当前已收回)
+        #MechJeb_AntennasToggle = 开关天线
+        #MechJeb_StageStatsAll = 分级状态(全部)
+        #MechJeb_DockingGuidance_velocity = 对接制导：速度
+        #MechJeb_DockingGuidanceAngularVelocity = 对接制导：角速度
+        #MechJeb_DockingGuidancePosition = 对接制导：位置
         #MechJeb_AllPlanetPhaseAngles = 全部行星相位角
-        #MechJeb_AllMoonPhaseAngles = 全部卫星相位角
-        #MechJeb_LatLonClipbardCopy = 复制纬度、经度和海拔至剪贴板
-        #MechJeb_PoolsStatus = 池状态
+        #MechJeb_AllMoonPhaseAngles = 全卫星相位角
+        #MechJeb_LatLonClipbardCopy = 复制纬度/经度/高度到剪贴板
+        #MechJeb_PoolsStatus = 线程池状态
         #MechJeb_Separator = 分隔符
         #MechJeb_LandingPredictions = 着陆预测
         #MechJeb_HideMenuButton = 隐藏菜单按钮
         #MechJeb_UseAppLauncher = 使用游戏菜单
         #MechJeb_MenuPosition = 菜单位置
-        #MechJeb_RCSBalancerInfo = RCS 平衡器信息
+        #MechJeb_RCSBalancerInfo = RCS平衡器信息
         #MechJeb_RCSBalancerInfo_Label1 = 计算时间
         #MechJeb_RCSBalancerInfo_Label2 = 等待任务
         #MechJeb_RCSBalancerInfo_Label3 = 缓存大小
@@ -1222,84 +1318,84 @@ Localization
         #MechJeb_RCSBalancerInfo_Label7 = 重新计算重心
         #MechJeb_RCSBalancerInfo_Label8 = 最大重心位移
         #MechJeb_RCSBalancerInfo_Label9 = 状态
-        #MechJeb_RCSThrusterStates = RCS 推进器状态
-        #MechJeb_RCSThrusterStates_Label1 = RCS 推力器状态（缩放到 0-9）
-        #MechJeb_RCSPartThrottles = RCS 部件节流阀
+        #MechJeb_RCSThrusterStates = RCS推进状态
+        #MechJeb_RCSThrusterStates_Label1 = RCS推进状态(缩放到0-9)
+        #MechJeb_RCSPartThrottles = RCS部件节流阀
         #MechJeb_ControlVector = 控制向量
-        #MechJeb_RCSPid = RCS PID
+        #MechJeb_RCSPid = RCS Pid
         #MechJeb_DisableSmartACSAutomatically = 自动关闭智能姿态控制
         #MechJeb_DisableSmartRcsAutomatically = 自动关闭智能Rcs
         #MechJeb_ToggleSolarPanels = 开关太阳能电池板
         #MechJeb_SolarPanelDeployButton = 自动展开太阳能电池板
-        #MechJeb_SolarPanelDeploy = 切换太阳能电池板状态（当前已展开）
-        #MechJeb_SolarPanelRetracted = 切换太阳能电池板状态（当前已收起）
-        #MechJeb_SolarPanelToggle = 切换太阳能电池板状态
+        #MechJeb_SolarPanelDeploy = 开关太阳能电池板(当前已展开)
+        #MechJeb_SolarPanelRetracted = 开关太阳能电池板(当前已收回)
+        #MechJeb_SolarPanelToggle = 开关太阳能电池板
         #MechJeb_AutostagingSettings = 自动分级设置
-        #MechJeb_ClampAutostageThrust = 夹具自动分离力度
+        #MechJeb_ClampAutostageThrust = 夹具自动分级推力
         #MechJeb_LimittoMaxQ = 最大动压限制
-        #MechJeb_PreventEngineOverheats = 防止引擎过热
+        #MechJeb_PreventEngineOverheats = 防止发动机过热
         #MechJeb_SmoothThrottle = 平滑节流阀
-        #MechJeb_PreventJetFlameout = 防止喷气引擎熄火
+        #MechJeb_PreventJetFlameout = 防止飞机熄火
         #MechJeb_PreventUnstableIgnition = 防止不稳定状态点火
-        #MechJeb_UseRCStoullage = 使用 RCS 执行沉底操作
-        #MechJeb_ManageAirIntakes = 管理进气
-        #MechJeb_LimitThrottle = 限制节流阀到
-        #MechJeb_LowerThrottleLimit = 保持节流阀不低于
-        #MechJeb_DifferentialThrottle = 差速节流阀
+        #MechJeb_UseRCStoullage = 使用RCS执行沉底操作
+        #MechJeb_ManageAirIntakes = 管理空气摄入量
+        #MechJeb_LimitThrottle = 节流阀限制
+        #MechJeb_LowerThrottleLimit = 节流阀下限
+        #MechJeb_DifferentialThrottle = 差动节流阀
         #MechJeb_ElectricLimit = 电力限制
         #MechJeb_AutostageOnce = 自动分级一次
         #MechJeb_Autostage = 自动分级
-        #MechJeb_MJWarpControl = MJ 加速控制
-        #MechJeb_DebugString = 调试字符串
-        #MechJeb_RCSTranslation = RCS 平动控制
-        #MechJeb_RCSTorque = RCS 扭矩
+        #MechJeb_MJWarpControl = MJ加速控制
+        #MechJeb_DebugString = Debug调试字符串
+        #MechJeb_RCSTranslation = RCS推力控制
+        #MechJeb_RCSTorque = RCS扭矩
         #MechJeb_Torque = 扭矩
-        #MechJeb_hideBrakeOnEject = 在车辆中隐藏 "弹射时刹车" 按钮
-        #MechJeb_useTitlebarDragging = 仅使用标题栏拖动窗口
-        #MechJeb_rssMode = 模块禁用时不会切断节流阀（RSS/RO）
-        #MechJeb_smartTranslation = 智能 RCS 平移
-        #MechJeb_RCSBalancerOverdrive = RCS 平衡器超驱
-        #MechJeb_conserveFuel = 节约 RCS 燃料
-        #MechJeb_conserveThreshold = 节约 RCS 燃料阈值
-        #MechJeb_RCSTf = RCS Tf （时间常数）
-        #MechJeb_RCSThrottle = 0kn 推力时的 RCS 节流阀
-        #MechJeb_rcsForRotation = 使用 RCS 做旋转
+        #MechJeb_hideBrakeOnEject = 在车辆自动驾驶里隐藏 "飞行员弹射时刹车" 按钮
+        #MechJeb_useTitlebarDragging = 只能使用标题栏拖拽窗口
+        #MechJeb_rssMode = 模块禁用时不关闭油节流阀 (RSS/RO)
+        #MechJeb_smartTranslation = 只能RCS平移
+        #MechJeb_RCSBalancerOverdrive = RCS平衡器覆盖
+        #MechJeb_conserveFuel = 节约RCS燃料
+        #MechJeb_conserveThreshold = 节约RCS燃料阈值
+        #MechJeb_RCSTf = RCS Tf
+        #MechJeb_RCSThrottle = 引擎无推力时RCS节流阀
+        #MechJeb_rcsForRotation = 使用RCS进行滚转
         #MechJeb_ControlHeading = 航向控制
         #MechJeb_ControlSpeed = 速度控制
         #MechJeb_BrakeOnEject = 飞行员弹射时刹车
-        #MechJeb_BrakeOnEnergyDepletion = 能量耗尽时刹车
-        #MechJeb_WarpToDaylight = 能量耗尽时加速到白天
-        #MechJeb_StabilityControl = 稳定性控制
-        #MechJeb_LimitAcceleration = 限制加速度
+        #MechJeb_BrakeOnEnergyDepletion = 能量耗尽时制动
+        #MechJeb_WarpToDaylight = 如果能量耗尽，仍然可以加速时间直到白天
+        #MechJeb_StabilityControl = 稳定控制
+        #MechJeb_LimitAcceleration = 加速度限制
         #MechJeb_DockingSpeedLimit = 对接速度限制
-        #MechJeb_RCSBalancerPrecision = RCS 平衡器精度
+        #MechJeb_RCSBalancerPrecision = RCS平衡精度
         #MechJeb_Speed = 速度
-        #MechJeb_SafeTurnspeed = 安全转向速率
+        #MechJeb_SafeTurnspeed = 安全转速
         #MechJeb_TerrainLookAhead = 前方地形
         #MechJeb_BrakeSpeedLimit = 制动限速
-        #MechJeb_HeadingPIDP = 航向 PID P
-        #MechJeb_HeadingPIDI = 航向 PID I
-        #MechJeb_HeadingPIDD = 航向 PID D
-        #MechJeb_SpeedPIDP = 速度 PID P
-        #MechJeb_SpeedPIDI = 速度 PID I
-        #MechJeb_SpeedPIDD = 速度 PID D
-        #MechJeb_TractionBrakeLimit = 抓地力限制的刹车
-        #MechJeb_MohoMapdist = Moho 地图距离
-        #MechJeb_EveMapdist = Eve 地图距离
-        #MechJeb_GillyMapdist = Gilly 地图距离
-        #MechJeb_KerbinMapdist = Kerbin 地图距离
-        #MechJeb_MunMapdist = Mun 地图距离
-        #MechJeb_MinmusMapdist = Minmus 地图距离
-        #MechJeb_DunaMapdist = Duna 地图距离
-        #MechJeb_IkeMapdist = Ike 地图距离
-        #MechJeb_DresMapdist = Dres 地图距离
-        #MechJeb_EelooMapdist = Eeloo 地图距离
-        #MechJeb_JoolMapdist = Jool 地图距离
-        #MechJeb_TyloMapdist = Tylo 地图距离
-        #MechJeb_LaytheMapdist = Laythe 地图距离
-        #MechJeb_PolMapdist = Pol 地图距离
-        #MechJeb_BopMapdist = Bop 地图距离
-        #MechJeb_VallMapdist = Vall 地图距离
+        #MechJeb_HeadingPIDP = 航向PID P
+        #MechJeb_HeadingPIDI = 航向PID I
+        #MechJeb_HeadingPIDD = 航向PID D
+        #MechJeb_SpeedPIDP = 速度PID P
+        #MechJeb_SpeedPIDI = 速度PID I
+        #MechJeb_SpeedPIDD = 速度PID D
+        #MechJeb_TractionBrakeLimit = 牵引制动限制
+        #MechJeb_MohoMapdist = Moho地图区域
+        #MechJeb_EveMapdist = Eve地图区域
+        #MechJeb_GillyMapdist = Gilly地图区域
+        #MechJeb_KerbinMapdist = Kerbin地图区域
+        #MechJeb_MunMapdist = Mun地图区域
+        #MechJeb_MinmusMapdist = Minmus地图区域
+        #MechJeb_DunaMapdist = Duna地图区域
+        #MechJeb_IkeMapdist = Ike地图区域
+        #MechJeb_DresMapdist = Dres地图区域
+        #MechJeb_EelooMapdist = Eeloo地图区域
+        #MechJeb_JoolMapdist = Jool地图区域
+        #MechJeb_TyloMapdist = Tylo地图区域
+        #MechJeb_LaytheMapdist = Laythe地图区域
+        #MechJeb_PolMapdist = Pol地图区域
+        #MechJeb_BopMapdist = Bop地图区域
+        #MechJeb_VallMapdist = Vall地图区域
 
         #MechJeb_Disabled = 禁用
         #MechJeb_Enabled = 启用
@@ -1313,13 +1409,13 @@ Localization
         #MechJeb_DeactivateSmartACS = 禁用智能姿态控制
         #MechJeb_LandSomewhere = 降落在任意地点
         #MechJeb_LandatKSC = 降落在KSC
-        #MechJeb_PANIC = 紧急控制
-        #MechJeb_TranslatronOFF = 关闭速度控制
-        #MechJeb_TranslatronKeepVert = 速度控制 保持垂直速度
-        #MechJeb_TranslatronZerospeed = 速度控制 消除速度
-        #MechJeb_TranslatronPlusspeed = 速度控制 +1 速度
-        #MechJeb_TranslatronMinusspeed = 速度控制 -1 速度
-        #MechJeb_TranslatronToggleHS = 速度控制 切换水平速度控制
+        #MechJeb_PANIC = 恐慌！
+        #MechJeb_TranslatronOFF = 关闭平动控制
+        #MechJeb_TranslatronKeepVert = 平动控制保持垂速
+        #MechJeb_TranslatronZerospeed = 平动控制0速
+        #MechJeb_TranslatronPlusspeed = 平动控制 +1速
+        #MechJeb_TranslatronMinusspeed = 平动控制 -1速
+        #MechJeb_TranslatronToggleHS = 平动控制切换 H/S
         #MechJeb_AscentAPtoggle = 切换上升远拱点
 
     // Parts
@@ -1327,14 +1423,14 @@ Localization
         #MechJeb_AnatidRobotics_Multiversal = Anatid 智能工业 / 多功能机电一体化
         #MechJeb_MechanicalJeb2_Title = 智能型Jeb - 2.0 版本 
         #MechJeb_MechanicalJeb2_Description = 经过多年的研究，关于Jebediah Kerman为什么是一个前无古人后无来者的王牌飞行员的问题，科学家仍然没有答案, 所以我们决定给他的大脑做一个完整的数字备份，用来帮我们辅助控制载具. 这是 MechJeb 的一个无人控制驾驶舱版本, 旨在拯救那些愿意测试我们的新航天器的坎巴拉人的生命.
-        #MechJeb_MechJeb2_Title = MechJeb 2 (AR202 case)
+        #MechJeb_MechJeb2_Title = MechJeb 2（AR202外壳）
         #MechJeb_MechJeb2_Description = MechJeb的神经电路加强版，可径向安装.
         #MechJeb_Future_ManeuverTranslatron_Title = MechJeb 功能 - 机动 & 平动控制
-        #MechJeb_Future_ManeuverTranslatron_Description = 解锁下列 MechJeb 功能: 机动节点规划, 平动控制, 加速助手, 姿态调整, Thrust Window, RCS平衡器. 一旦解锁，所有已安装的包含 MechJeb 模块的部件将自动解锁该功能。
+        #MechJeb_Future_ManeuverTranslatron_Description = 解锁下列 MechJeb 功能: 机动节点规划, 平动控制, 加速助手, 姿态调整, 推力窗口, RCS平衡器. 一旦解锁，所有已安装的包含 MechJeb 模块的部件将自动解锁该功能。
         #MechJeb_Future_RoverAutopilot_Title = MechJeb 功能 - 车辆自动驾驶
         #MechJeb_Future_RoverAutopilot_Description = 解锁下列 MechJeb 功能: 车辆自动驾驶. 一旦解锁，所有已安装的包含 MechJeb 模块的部件将自动解锁该功能
         #MechJeb_Future_RendevousDocking_Title = MechJeb 功能 - 交会 & 对接
-        #MechJeb_Future_RendevousDocking_Description = 解锁下列 MechJeb 功能: Rendezvous Guidance, 自动交会, 自动对接. 一旦解锁，所有已安装的包含 MechJeb 模块的部件将自动解锁该功能
+        #MechJeb_Future_RendevousDocking_Description = 解锁下列 MechJeb 功能: 交会引导, 自动交会, 自动对接. 一旦解锁，所有已安装的包含 MechJeb 模块的部件将自动解锁该功能
         #MechJeb_Future_AscentLandingSpaceplane_Title = MechJeb 功能 - 升空, 着落, 航天飞机
         #MechJeb_Future_AscentLandingSpaceplane_Description = 解锁下列 MechJeb 功能: 自动升空, 自动着陆, 航天飞机引导. 一旦解锁，所有已安装的包含 MechJeb 模块的部件将自动解锁该功能
         

--- a/Localization/zh-cn.cfg
+++ b/Localization/zh-cn.cfg
@@ -5,7 +5,7 @@ Localization
         #MechJeb_ModuleAreLocked = 部分模块功能关闭直到你解锁科技树的关键性节点和升级追踪站.
         #MechJeb_OnlineManualbutton = 在线手册
 
-        #MechJeb_InstallCheckA_title = 错误的Mechjeb2安装方式
+        #MechJeb_InstallCheckA_title = 错误的MechJeb2安装方式
         #MechJeb_InstallCheckA_msg = MechJeb2安装不正确，无法正常工作.\nMechJeb2的所有文件都应该放在如下路径中 \n<KSP>\n\tGameData\n\t\tMechJeb2\n\t\t\tParts\n\t\t\tPlugins\n\n不要从MechJeb2文件夹中移动任何文件.\n\n不正确的路径:\n
 
         #MechJeb_InstallCheckB_title = MechJebMenuToolbar的安装是多余的
@@ -115,10 +115,15 @@ Localization
 
         //Hohmann transfer
         #MechJeb_Hohm_title = 双脉冲 (霍曼)转移到目标
-        #MechJeb_Hohm_intercept_only = 仅拦截, 不计算捕获 (撞击/飞掠)
+        #MechJeb_Hohm_transfer = 转移
+        #MechJeb_Hohm_rendezvous = 交会
+        #MechJeb_Hohm_flyby = 飞掠 / 撞击
+        #MechJeb_Hohm_intercept = 拦截
+        #MechJeb_Hohm_matchOrbit = 匹配轨道
+        #MechJeb_Hohm_arrivalDelay = 到达延迟
+        #MechJeb_Hohm_createArrivalNode = 创建到达节点
         #MechJeb_Hohm_simpleTransfer = 简单共面霍曼转移
-        #MechJeb_Hohm_Label1 = 微调目标周期偏移
-
+        
         #MechJeb_Hohm_Exception1 = 必须为霍曼转移选择目标。
         #MechJeb_Hohm_Exception2 = 进行霍曼转移的目标必须在同一引力范围内
         #MechJeb_Hohm_Exception3 = 与目标的升交点不存在.
@@ -193,6 +198,11 @@ Localization
         #MechJeb_match_v_Exception1 = 必须选择一个目标来进行速度匹配.
         #MechJeb_match_v_Exception2 = 目标必须在同一引力范围内.
 
+        //stationary orbit
+        #MechJeb_stationary_title = 同步轨道
+        #MechJeb_stationary_label1 = 目标经度:
+        #MechJeb_stationary_Exception1 = 环绕<<1>>的同步轨道超出引力范围.
+
         //resonant orbit
         #MechJeb_resonant_title = 共振轨道
         #MechJeb_resonant_label1 = 把你的轨道周期变更当前轨道周期的<<1>>
@@ -204,27 +214,6 @@ Localization
         #MechJeb_return_label2 = 在下一个窗口期返回.
         #MechJeb_return_errormsg = 警告:建议从接近圆形的轨道(离心率<0.2)开始执行.返回计划是从离心率<<1>>的轨道开始的,可能不准确.
         #MechJeb_return_Exception = <<1>>并不在你可以返回的天体的轨道上.
-
-        //transfer to another planet
-        #MechJeb_transfer_title = 转移到另一个星球
-        #MechJeb_transfer_Label1 = 计划变轨:
-        #MechJeb_transfer_Label2 = 在下一个转移窗口.
-        #MechJeb_transfer_Label3 = 尽可能快
-        #MechJeb_transfer_Label4 = 使用此模式将使您的保修无效
-
-        #MechJeb_transfer_Exception1 = 必须为星际转移选择一个目标
-
-        #MechJeb_transfer_Exception2 = 在<<1>>的轨道上绘制星际间转移是没有意义的.
-
-        #MechJeb_transfer_Exception3 = 使用经典霍曼转移来与环绕在<<1>>上的物体交会.
-
-        #MechJeb_transfer_Exception4 =  从<<1>>引力范围内发出的星际间转移必须以<<2>>环绕的母星——<<3>>为目标.
-
-        #MechJeb_transfer_errormsg1 = 警告:目标的轨道平面与<<2>>º的轨道平面成<<1>>º角（建议最多30度角）.计划中的星际间转移可能无法正确到达目标
-
-        #MechJeb_transfer_errormsg2 = 警告: 建议从与<<2>>围绕<<3>>的轨道在同一平面的轨道上的<<1>>开始进行星际间转移. 起始环绕<<4>>的轨道是倾角为 <<5>>º对<<6>>的环绕<<7>>的轨道(建议< 10º). 计划中的星际间转移可能无法正确到达目标.
-
-        #MechJeb_transfer_errormsg3 = 警告:建议从接近圆形的轨道(离心率< 0.2)开始进行星际间转移.转移计划是从离心率为<<1>>的轨道开始的，因此可能无法正确与目标回合.
 
         //Circularize
         #MechJeb_Maneu_circularize_title = 圆化轨道
@@ -240,92 +229,10 @@ Localization
         #MechJeb_Maneu_button5 = 执行所有节点
         #MechJeb_Maneu_button6 = 中止节点执行
 
-
-    //Aircraft Approach & Autoland
-        #MechJeb_ApproAndLand_title = 飞机进场 & 着陆
-        #MechJeb_ApproAndLand_label1 = 着陆
-        #MechJeb_ApproAndLand_label2 = 跑道距离:
-        #MechJeb_ApproAndLand_label3 = 导航球显示降落导航点
-        #MechJeb_ApproAndLand_label4 = 进场速度:
-        #MechJeb_ApproAndLand_label5 = 接地速度:
-        #MechJeb_ApproAndLand_label6 = 接地时的将推力反向
-        #MechJeb_ApproAndLand_label7 = 一落地就刹车
-        #MechJeb_ApproAndLand_label8 = 状态:
-        #MechJeb_ApproAndLand_label9 = 导航点距离: <<1>> m
-        #MechJeb_ApproAndLand_label10 = 设定速度: <<1>> m/s
-        #MechJeb_ApproAndLand_label11 = 设定高度: <<1>> m
-        #MechJeb_ApproAndLand_label12 = 设定垂直速度: <<1>> m/s
-        #MechJeb_ApproAndLand_label13 = 设定航向: <<1>>º
-        #MechJeb_ApproAndLand_label14 = 下滑道:
-        #MechJeb_ApproAndLand_MaxRateOfDescent = 最大下降率:
-
-        #MechJeb_ApproAndLand_approachState1 = 向 起始进近点 进发
-        #MechJeb_ApproAndLand_approachState2 = 向 最后进近点 进发
-        #MechJeb_ApproAndLand_approachState3 = 截获下滑道中
-        #MechJeb_ApproAndLand_approachState4 = 向 接地点 进发
-        #MechJeb_ApproAndLand_approachState5 = 等待抬头
-        #MechJeb_ApproAndLand_approachState6 = 抬头中
-        #MechJeb_ApproAndLand_approachState7 = 滑行
-
-        #MechJeb_ApproAndLan_button1 = 自动着陆
-        #MechJeb_ApproAndLan_button2 = 终止
-
-    //Aircraft Autopilot
-        #MechJeb_Aircraftauto_title = 飞机自动驾驶仪
-        #MechJeb_Aircraftauto_button1 = 关闭自动驾驶
-        #MechJeb_Aircraftauto_button2 = 启用自动驾驶
-        #MechJeb_Aircraftauto_button3 = PID
-        #MechJeb_Aircraftauto_button4 = 隐藏PID
-
-        #MechJeb_Aircraftauto_Label1 = 高度保持
-
-        #MechJeb_Aircraftauto_btnset1 = 设置
-
-        #MechJeb_Aircraftauto_Label2 = 垂直速度保持
-
-        #MechJeb_Aircraftauto_btnset2 = 设置
-
-        #MechJeb_Aircraftauto_VS =    V/S ±
-
-        #MechJeb_Aircraftauto_Label3 = 垂直速度限制
-
-        #MechJeb_Aircraftauto_btnset3 = 设置
-
-        #MechJeb_Aircraftauto_Label4 = 航向保持
-
-        #MechJeb_Aircraftauto_btnset4 = 设置
-
-        #MechJeb_Aircraftauto_Label5 = 角度保持
-
-        #MechJeb_Aircraftauto_btnset5 = 设置
-
-        #MechJeb_Aircraftauto_Label6 =     角度限制 ±
-
-        #MechJeb_Aircraftauto_btnset6 = 设置
-
-        #MechJeb_Aircraftauto_Label7 = 速度保持
-
-        #MechJeb_Aircraftauto_btnset7 = 设置
-
-        #MechJeb_Aircraftauto_Label8 = 加速度
-
-        #MecgJeb_Aircraftauto_error1 = 错误:<<1>> 目标:<<2>> 当前:<<3>>
-        #MecgJeb_Aircraftauto_error2 = 错误:<<1>> 目标:<<2>> 当前:<<3>> PID: <<4>>
-
-        #MechJeb_Aircraftauto_Label10 = 滚转
-        #MechJeb_Aircraftauto_Pitch = 俯仰
-
-        #MechJeb_Aircraftauto_Limits = 限制:
-        #MechJeb_Aircraftauto_RollLimit = 滚转
-        #MechJeb_Aircraftauto_YawLimit = 偏航
-        #MechJeb_Aircraftauto_PitchUpLimit = 抬头
-        #MechJeb_Aircraftauto_PitchDownLimit = 低头
-
     //Ascent Guidance
         #MechJeb_Ascent_title = 自动发射
         #MechJeb_Ascent_ascentPathList1 = 经典的上升配置
-        #MechJeb_Ascent_ascentPathList2 = Stock-style GravityTurn™
-        #MechJeb_Ascent_ascentPathList3 = Primer Vector Guidance (RSS/RO)
+        #MechJeb_Ascent_ascentPathList3 = 初矢量制导 (RSS/RO)
 
         #MechJeb_Ascent_status1 = 准备发射
         #MechJeb_Ascent_status2 = 关闭
@@ -406,7 +313,7 @@ Localization
         #MechJeb_Ascent_attachAlt = 燃尽高度:
         #MechJeb_Ascent_warnAttachAltLow = 燃尽点低于Pe：近拱点入轨
         #MechJeb_Ascent_warnAttachAltHigh = 燃尽点高于Ap：远拱点入轨
-
+        #MechJeb_Ascent_warnInvalidTarget = 目标必须在同一引力范围内.
 
         #MechJeb_Ascent_checkbox1 = 忽略滑行
         #MechJeb_Ascent_checkbox2 = 角度调整
@@ -474,6 +381,7 @@ Localization
         #MechJeb_WindowEd_Presetname10 = 地表导航
         #MechJeb_WindowEd_Presetname11 = 大气信息
         #MechJeb_WindowEd_Presetname12 = 机动节点信息
+        #MechJeb_WindowEd_Presetname13 = 极限点火信息
 
         #MechJeb_WindowEd_button1 = 新建窗口
         #MechJeb_WindowEd_button2 = 删除窗口
@@ -1132,8 +1040,45 @@ Localization
         #MechJeb_PotentialEnergy_desc = 比位能
         #MechJeb_KineticEnergy = 动能
         #MechJeb_KineticEnergy_desc = 比动能
-        #MechJeb_TimeToImpact = 撞击时间
-        #MechJeb_SuicideBurnCountdown = 极限点火倒计时
+        #MechJeb_HoverslamCoordinates = 坐标
+        #MechJeb_HoverslamCoordinates_tooltip = 预计着陆点的纬度和经度.
+        #MechJeb_HoverslamImpact = 撞击
+        #MechJeb_HoverslamImpact_tooltip = 不执行制动点火时，飞行器撞击地面的剩余时间.
+        #MechJeb_HoverslamIgnition = 点火
+        #MechJeb_HoverslamIgnition_tooltip = 在满推力下，将飞行器带入垂直下降阶段的最晚可能点火时间.
+        #MechJeb_HoverslamTouchdown = 触地
+        #MechJeb_HoverslamTouchdown_tooltip = 飞行器到达垂直下降阶段起点的剩余时间.
+        #MechJeb_HoverslamDeltaV = 极限点火 Δv
+        #MechJeb_HoverslamDeltaV_tooltip = 预计着陆点火所需的 Δv.
+        #MechJeb_HoverslamBiome = 生物群落
+        #MechJeb_HoverslamBiome_tooltip = 预计着陆点的生物群落类型.
+        #MechJeb_HoverslamSlope = 坡度
+        #MechJeb_HoverslamSlope_tooltip = 预计着陆点的地形坡度.
+        #MechJeb_HoverslamTerrainAltitude = 地形高度
+        #MechJeb_HoverslamTerrainAltitude_tooltip = 预计着陆点的地表海拔（ASL）.
+        #MechJeb_HoverslamMapLandingPrediction = 地图着陆预测
+        #MechJeb_HoverslamMapLandingPrediction_tooltip = 在地图视图中标记预计着陆点.
+        #MechJeb_HoverslamVerticalAltitude = 垂直阶段高度
+        #MechJeb_HoverslamVerticalAltitude_tooltip = 制动点火结束、自动驾驶切换至垂直下降阶段时距地面的高度。数值越高，对地形和偏差的余量越大，但消耗的 Δv 也越多.
+        #MechJeb_HoverslamVerticalAuthority = 垂直阶段控制余量
+        #MechJeb_HoverslamVerticalAuthority_tooltip = 制动点火计划使用的推力占悬停推力之上可用推力的比例。50% 为过度与不足留有同等余量；数值越高，Δv 效率越高，但对偏差的容忍度越低.
+        #MechJeb_HoverslamTouchdownSpeed = 触地速度
+        #MechJeb_HoverslamTouchdownSpeed_tooltip = 触地时的目标下降速度.
+        #MechJeb_HoverslamPWMPulseWidth = PWM 脉冲幅度
+        #MechJeb_HoverslamPWMPulseWidth_tooltip = 当引擎节流阀无法降到足够低以悬停时（真实大修 / 真实燃料），自动驾驶将脉冲式调整节流阀。此参数设置最小脉冲持续时间.
+        #MechJeb_HoverslamIgnitionLead = 点火提前量
+        #MechJeb_HoverslamIgnitionLead_tooltip = 用于补偿分级或引擎启动延迟。不建议用作通用控制余量——应改为增加垂直阶段高度.
+        #MechJeb_HoverslamSimRecalcInterval = 模拟重算间隔
+        #MechJeb_HoverslamSimRecalcInterval_tooltip = 模拟重新计算的间隔秒数。数值越低，预测越实时，但 CPU 开销越大.
+        #MechJeb_HoverslamAutoWarp = 极限点火时刻自动跳转
+        #MechJeb_HoverslamAutoWarp_tooltip = 启用后，自动时间加速至点火时刻.
+        #MechJeb_HoverslamHoldUpright = 触地后保持直立
+        #MechJeb_HoverslamHoldUpright_tooltip = 着陆后，交由 SmartASS 的 SURF-UP 模式维持飞行器直立。可能消耗 RCS.
+        #MechJeb_HoverslamEngage = 启动极限点火
+        #MechJeb_HoverslamDisengage = 关闭极限点火
+        #MechJeb_HoverslamEngage_tooltip = 启动（或关闭）极限点火自动驾驶.
+        #MechJeb_HoverslamState = 极限点火状态
+        #MechJeb_HoverslamState_tooltip = 自动驾驶的当前阶段。依次经历：对齐 → 滑行 → 点火 → 垂直。未启动时显示"禁用".
         #MechJeb_RCSthrust = RCS推力
         #MechJeb_RCSTranslationEfficiency = RCS转换效率
         #MechJeb_RCSdV = RCS ΔV
@@ -1184,6 +1129,7 @@ Localization
         #MechJeb_TargetMeanAnomaly = 目标平近点角
         #MechJeb_TargetTrueLongitude = 目标真经度
         #MechJeb_TargetLAN = 目标升交点经度
+        #MechJeb_TargetLDN = 目标降交点经度
         #MechJeb_TargetAoP = 目标近点幅角
         #MechJeb_TargetEccentricity = 目标离心率
         #MechJeb_TargetSMA = 目标轨道半长轴


### PR DESCRIPTION
Update of zh-cn Localization
- Added 5 missing translation keys (TargetTimeToAN, TargetTimeToDN, TargetMeanAnomaly, TargetTrueLongitude, TargetLDN)
- Translated 33 previously untranslated entries
- Fixed 1 mistranslation (SmartASS_button36)
- Fixed key name mismatch (Scrmsg → Scrmsg1)
- Translated 11 additional partially/fully untranslated entries