### PR TITLE
fix(build): run platform-specific copy command

### DIFF
--- a/MechJeb2/MechJeb2.csproj
+++ b/MechJeb2/MechJeb2.csproj
@@ -102,12 +102,11 @@
         <ProjectReference Include="..\MechJebLib\MechJebLib.csproj"/>
     </ItemGroup>
 
-    <Target Name="MechJebCopyBuild" AfterTargets="Build" Condition=" '$(OS)' == 'Windows_NT' ">
-        <Exec Command="call &quot;$(ProjectDir)copy_build.bat&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)&quot; &quot;$(TargetName)&quot; &quot;$(ProjectDir)&quot;"/>
-    </Target>
-
-    <Target Name="MechJebCopyBuild" AfterTargets="Build" Condition=" '$(OS)' != 'Windows_NT' ">
-        <Exec Command="'$(ProjectDir)/copy_build.sh' '$(TargetPath)' '$(TargetDir)' '$(TargetName)' '$(ProjectDir)' '$(KspDir)'"/>
+    <Target Name="MechJebCopyBuild" AfterTargets="Build">
+        <Exec Condition=" '$(OS)' == 'Windows_NT' "
+              Command="call &quot;$(ProjectDir)copy_build.bat&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)&quot; &quot;$(TargetName)&quot; &quot;$(ProjectDir)&quot;"/>
+        <Exec Condition=" '$(OS)' != 'Windows_NT' "
+              Command="'$(ProjectDir)/copy_build.sh' '$(TargetPath)' '$(TargetDir)' '$(TargetName)' '$(ProjectDir)' '$(KspDir)'"/>
     </Target>
 
 </Project>

--- a/MechJeb2/copy_build.bat
+++ b/MechJeb2/copy_build.bat
@@ -29,34 +29,34 @@ IF NOT EXIST "%KSPDIR%\*" (
 echo:
 echo Copying to "%KSPDIR%"
 echo:
-IF EXIST %TargetPath% xcopy /Y /I %TargetPath% "%KSPDIR%\GameData\MechJeb2\Plugins\"
+IF EXIST "%TargetPath%" xcopy /Y /I "%TargetPath%" "%KSPDIR%\GameData\MechJeb2\Plugins\"
 echo:
 
-IF EXIST %TargetDir%%TargetName%.pdb xcopy /Y /I "%TargetDir%%TargetName%.pdb" "%KSPDIR%\GameData\MechJeb2\Plugins\"
+IF EXIST "%TargetDir%%TargetName%.pdb" xcopy /Y /I "%TargetDir%%TargetName%.pdb" "%KSPDIR%\GameData\MechJeb2\Plugins\"
 echo:
 
-IF EXIST %TargetDir%JetBrains.Annotations.dll xcopy /Y /I "%TargetDir%JetBrains.Annotations.dll "%KSPDIR%\GameData\MechJeb2\Plugins\"
+IF EXIST "%TargetDir%JetBrains.Annotations.dll" xcopy /Y /I "%TargetDir%JetBrains.Annotations.dll" "%KSPDIR%\GameData\MechJeb2\Plugins\"
 echo:
 
-IF EXIST %TargetDir%JetBrains.Annotations.xml xcopy /Y /I "%TargetDir%JetBrains.Annotations.xml "%KSPDIR%\GameData\MechJeb2\Plugins\"
+IF EXIST "%TargetDir%JetBrains.Annotations.xml" xcopy /Y /I "%TargetDir%JetBrains.Annotations.xml" "%KSPDIR%\GameData\MechJeb2\Plugins\"
 echo:
 
-IF EXIST %TargetDir%MechJebLib.dll xcopy /Y /I "%TargetDir%MechJebLib.dll "%KSPDIR%\GameData\MechJeb2\Plugins\"
+IF EXIST "%TargetDir%MechJebLib.dll" xcopy /Y /I "%TargetDir%MechJebLib.dll" "%KSPDIR%\GameData\MechJeb2\Plugins\"
 echo:
 
-IF EXIST %TargetDir%MechJebLib.pdb xcopy /Y /I "%TargetDir%MechJebLib.pdb "%KSPDIR%\GameData\MechJeb2\Plugins\"
+IF EXIST "%TargetDir%MechJebLib.pdb" xcopy /Y /I "%TargetDir%MechJebLib.pdb" "%KSPDIR%\GameData\MechJeb2\Plugins\"
 echo:
 
-IF EXIST %TargetDir%MechJebLibBindings.dll xcopy /Y /I "%TargetDir%MechJebLibBindings.dll "%KSPDIR%\GameData\MechJeb2\Plugins\"
+IF EXIST "%TargetDir%MechJebLibBindings.dll" xcopy /Y /I "%TargetDir%MechJebLibBindings.dll" "%KSPDIR%\GameData\MechJeb2\Plugins\"
 echo:
 
-IF EXIST %TargetDir%MechJebLibBindings.pdb xcopy /Y /I "%TargetDir%MechJebLibBindings.pdb "%KSPDIR%\GameData\MechJeb2\Plugins\"
+IF EXIST "%TargetDir%MechJebLibBindings.pdb" xcopy /Y /I "%TargetDir%MechJebLibBindings.pdb" "%KSPDIR%\GameData\MechJeb2\Plugins\"
 echo:
 
-IF EXIST %TargetDir%alglib.dll xcopy /Y /I "%TargetDir%alglib.dll "%KSPDIR%\GameData\MechJeb2\Plugins\"
+IF EXIST "%TargetDir%alglib.dll" xcopy /Y /I "%TargetDir%alglib.dll" "%KSPDIR%\GameData\MechJeb2\Plugins\"
 echo:
 
-IF EXIST %TargetDir%alglib.pdb xcopy /Y /I "%TargetDir%alglib.pdb "%KSPDIR%\GameData\MechJeb2\Plugins\"
+IF EXIST "%TargetDir%alglib.pdb" xcopy /Y /I "%TargetDir%alglib.pdb" "%KSPDIR%\GameData\MechJeb2\Plugins\"
 echo:
 
 IF EXIST %ProjectDir%..\Bundles xcopy /S /Y /I "%ProjectDir%..\Bundles" "%KSPDIR%\GameData\MechJeb2\Bundles"


### PR DESCRIPTION
MechJeb2.csproj defined MechJebCopyBuild twice under mutually exclusive OS conditions. MSBuild kept the latter definition, so the copy target was skipped on Windows. Consolidate the target and apply the OS conditions to its commands.