### PR TITLE
Allow 10,000 steps in the delta V sim

### DIFF
--- a/MechJeb2/MechJebModuleStageStats.cs
+++ b/MechJeb2/MechJebModuleStageStats.cs
@@ -76,6 +76,8 @@ namespace MuMech
                 else
                 {
                     Debug.Log("[MechJebModuleStageStats] atmo stats failed");
+                    if (_vesselManagerAtmo.FuelFlowSimulation.Exception != null)
+                        Debug.Log(_vesselManagerAtmo.FuelFlowSimulation.Exception);
                 }
 
                 if (!_vesselManagerAtmo.FuelFlowSimulation.TryMarkReady())
@@ -98,10 +100,12 @@ namespace MuMech
                 else
                 {
                     Debug.Log("[MechJebModuleStageStats] vac stats failed");
+                    if (_vesselManagerVac.FuelFlowSimulation.Exception != null)
+                        Debug.Log(_vesselManagerVac.FuelFlowSimulation.Exception);
                 }
 
                 if (!_vesselManagerVac.FuelFlowSimulation.TryMarkReady())
-                    throw new Exception("[MechJebModuleStageStats] Tried to mark a running vcc stage stats as ready.");
+                    throw new Exception("[MechJebModuleStageStats] Tried to mark a running vac stage stats as ready.");
             }
         }
 

--- a/MechJebLib/FuelFlowSimulation/FuelFlowSimulation.cs
+++ b/MechJebLib/FuelFlowSimulation/FuelFlowSimulation.cs
@@ -15,7 +15,7 @@ namespace MechJebLib.FuelFlowSimulation
 {
     public class FuelFlowSimulation : AsyncJob
     {
-        private const int MAXSTEPS = 100;
+        private const int MAXSTEPS = 10_000;
 
         public readonly List<FuelStats> Segments = new List<FuelStats>();
         private FuelStats _currentSegment;


### PR DESCRIPTION
Apparently tanks * engines = steps when you have cryo fuels boiling off or something like that.

10,000 might be excessive, but it was hitting 100 in under 100ms for me so that should still be under 10sec.