### PR TITLE
Restore engine thrust limits after differential throttle

### DIFF
--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -163,6 +163,12 @@ namespace MuMech
 
         public DifferentialThrottleStatus DifferentialThrottleSuccess = DifferentialThrottleStatus.SUCCESS;
 
+        // Differential throttle temporarily writes ModuleEngines.thrustPercentage.  Keep the
+        // user's value so disabling the controller does not leave a vessel with the last
+        // solver output as its permanent thrust limit.
+        private readonly Dictionary<ModuleEngines, float> _thrustLimitsBeforeDifferentialThrottle =
+            new Dictionary<ModuleEngines, float>();
+
         [Persistent(pass = (int)Pass.LOCAL)]
         public bool ElectricThrottle;
 
@@ -567,9 +573,18 @@ namespace MuMech
             }
         }
 
-        public override void OnFixedUpdate() =>
-            DifferentialThrottleSuccess =
-                DifferentialThrottle ? ComputeDifferentialThrottle(DifferentialThrottleDemandedTorque) : DifferentialThrottleStatus.SUCCESS;
+        public override void OnFixedUpdate()
+        {
+            if (DifferentialThrottle)
+            {
+                DifferentialThrottleSuccess = ComputeDifferentialThrottle(DifferentialThrottleDemandedTorque);
+            }
+            else
+            {
+                DisableDifferentialThrottle();
+                DifferentialThrottleSuccess = DifferentialThrottleStatus.SUCCESS;
+            }
+        }
 
         //A throttle setting that throttles down when the dynamic pressure exceed a set value
         private float MaximumDynamicPressureThrottle()
@@ -936,6 +951,9 @@ namespace MuMech
 
             for (int i = 0; i < n; i++)
             {
+                if (!_thrustLimitsBeforeDifferentialThrottle.ContainsKey(engines[i].Engine))
+                    _thrustLimitsBeforeDifferentialThrottle.Add(engines[i].Engine, engines[i].Engine.thrustPercentage);
+
                 engines[i].ThrustRatio = (float)(x[i] / mainThrottle);
             }
 
@@ -944,14 +962,13 @@ namespace MuMech
 
         private void DisableDifferentialThrottle()
         {
-            foreach (Part p in Vessel.parts)
+            foreach (var entry in _thrustLimitsBeforeDifferentialThrottle)
             {
-                foreach (PartModule pm in p.Modules)
-                {
-                    if (pm is ModuleEngines engine)
-                        engine.thrustPercentage = 100;
-                }
+                if (entry.Key != null)
+                    entry.Key.thrustPercentage = entry.Value;
             }
+
+            _thrustLimitsBeforeDifferentialThrottle.Clear();
         }
     }
 }

--- a/MechJeb2/MechJebModuleThrustController.cs
+++ b/MechJeb2/MechJebModuleThrustController.cs
@@ -586,6 +586,16 @@ namespace MuMech
             }
         }
 
+        // Docking and undocking move engines between vessels.  Restore their original
+        // limits before the next differential-throttle solve sees the new topology.
+        public override void OnVesselWasModified(Vessel v) => DisableDifferentialThrottle();
+
+        public override void OnDestroy()
+        {
+            DisableDifferentialThrottle();
+            base.OnDestroy();
+        }
+
         //A throttle setting that throttles down when the dynamic pressure exceed a set value
         private float MaximumDynamicPressureThrottle()
         {


### PR DESCRIPTION
Differential throttle writes each `ModuleEngines.thrustPercentage` while solving for torque. Its previous cleanup ran only when the GUI toggle changed from enabled to disabled, and reset every engine to 100% rather than restoring the value that existed before differential throttle was used.

This change records an engine's limiter before the first solver write and restores that value whenever Differential Throttle becomes inactive, a vessel is docked or undocked, or the controller is destroyed. It therefore prevents the controller from leaving asymmetric solver output as a vessel's persistent thrust limit, while preserving intentional non-100% engine limits.

A vessel already saved with stranded limits still needs those limits restored once; this does not try to guess whether an existing saved limiter was intentional.

Validation: `dotnet build MechJeb2.sln -c Release --no-restore` succeeded in the configured KSP checkout.